### PR TITLE
REPO-3479: ACS configuration values can be passed with helm command

### DIFF
--- a/helm/alfresco-content-services/README.md
+++ b/helm/alfresco-content-services/README.md
@@ -7,7 +7,7 @@ To use, add the `http://kubernetes-charts.alfresco.com/incubator` to your helm r
 helm repo add alfresco-incubator http://kubernetes-charts.alfresco.com/incubator
 ```
 
-## To install ACS;
+## To install the ACS cluster
 
 ```console
 $ helm install alfresco-incubator/alfresco-content-services

--- a/helm/alfresco-content-services/README.md
+++ b/helm/alfresco-content-services/README.md
@@ -7,7 +7,7 @@ To use, add the `http://kubernetes-charts.alfresco.com/incubator` to your helm r
 helm repo add alfresco-incubator http://kubernetes-charts.alfresco.com/incubator
 ```
 
-## TL;DR;
+## To install ACS;
 
 ```console
 $ helm install alfresco-incubator/alfresco-content-services
@@ -22,7 +22,7 @@ This chart bootstraps an ACS deployment on a [Kubernetes](http://kubernetes.io) 
 
 ## Installing the Chart
 
-To install the chart with the release name `my-release`:
+To install the chart with the release name `my-acs`:
 
 ```console
 # Alfresco Admin password should be encoded in MD5 Hash
@@ -31,7 +31,7 @@ export ALF_ADMIN_PWD=$(printf %s 'MyAdminPwd' | iconv -t UTF-16LE | openssl md4 
 # Alfresco Database (Postgresql) password
 export ALF_DB_PWD='MyDbPwd'
 
-$ helm install --name my-release alfresco-incubator/alfresco-content-services \
+$ helm install --name my-acs alfresco-incubator/alfresco-content-services \
                --set repository.adminPassword="$ALF_ADMIN_PWD" \
                --set postgresql.postgresPassword="$ALF_DB_PWD"
 ```
@@ -42,10 +42,10 @@ The command deploys ACS Cluster on the Kubernetes cluster in the default configu
 
 ## Uninstalling the Chart
 
-To uninstall/delete the `my-release` deployment:
+To uninstall/delete the `my-acs` deployment:
 
 ```console
-$ helm delete my-release
+$ helm delete my-acs
 ```
 
 The command removes all the Kubernetes components associated with the chart and deletes the release.

--- a/helm/alfresco-content-services/README.md
+++ b/helm/alfresco-content-services/README.md
@@ -56,7 +56,7 @@ The following table lists the configurable parameters of the ACS chart and their
 
 Parameter | Description | Default
 --- | --- | ---
-`repository.adminPassword` | Administrator password for ACS in md5 hash format | md5: `209c6174da490caeb422f3fa5a7ae634` (or) `admin`
+`repository.adminPassword` | Administrator password for ACS in md5 hash format | md5: `209c6174da490caeb422f3fa5a7ae634` (of string `admin`)
 `postgresql.postgresUser` | postgresql database user | `alfresco`
 `postgresql.postgresPassword` | postgresql database password | `alfresco`
 `postgresql.postgresDatabase` | postgresql database name | `alfresco`

--- a/helm/alfresco-content-services/README.md
+++ b/helm/alfresco-content-services/README.md
@@ -45,7 +45,7 @@ The command deploys ACS Cluster on the Kubernetes cluster in the default configu
 To uninstall/delete the `my-acs` deployment:
 
 ```console
-$ helm delete my-acs
+$ helm delete my-acs --purge
 ```
 
 The command removes all the Kubernetes components associated with the chart and deletes the release.

--- a/helm/alfresco-content-services/README.md
+++ b/helm/alfresco-content-services/README.md
@@ -2,7 +2,7 @@
 
 Alfresco Content Services is an Enterprise Content Management (ECM) system that is used for document and case management, project collaboration, web content publishing, and compliant records management.  The flexible compute, storage, and database services that Kubernetes offers make it an ideal platform for Alfresco Content Services. This helm chart presents an enterprise-grade Alfresco Content Services configuration that you can adapt to virtually any scenario, and scale up, down, or out, depending on your use case.
 
-To use, add the `http://kubernetes-charts.alfresco.com/incubator` annotation to your helm repository.
+To use, add the `http://kubernetes-charts.alfresco.com/incubator` to your helm repository.
 ```console
 helm repo add alfresco-incubator http://kubernetes-charts.alfresco.com/incubator
 ```

--- a/helm/alfresco-content-services/README.md
+++ b/helm/alfresco-content-services/README.md
@@ -1,0 +1,62 @@
+# Alfresco Content Services (ACS) Helm Chart
+
+Alfresco Content Services is an Enterprise Content Management (ECM) system that is used for document and case management, project collaboration, web content publishing, and compliant records management.  The flexible compute, storage, and database services that Kubernetes offers make it an ideal platform for Alfresco Content Services. This helm chart presents an enterprise-grade Alfresco Content Services configuration that you can adapt to virtually any scenario, and scale up, down, or out, depending on your use case.
+
+To use, add the `http://kubernetes-charts.alfresco.com/incubator` annotation to your helm repository.
+```console
+helm repo add alfresco-incubator http://kubernetes-charts.alfresco.com/incubator
+```
+
+## TL;DR;
+
+```console
+$ helm install alfresco-incubator/alfresco-content-services
+```
+
+## Introduction
+
+This chart bootstraps an ACS deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+
+## Prerequisites
+  - Kubernetes 1.4+ with Beta APIs enabled
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```console
+# Alfresco Admin password should be encoded in MD5 Hash
+export ALF_ADMIN_PWD=$(printf %s 'MyAdminPwd' | iconv -t UTF-16LE | openssl md4 | awk '{ print $1}')
+
+# Alfresco Database (Postgresql) password
+export ALF_DB_PWD='MyDbPwd'
+
+$ helm install --name my-release alfresco-incubator/alfresco-content-services \
+               --set repository.adminPassword="$ALF_ADMIN_PWD" \
+               --set postgresql.postgresPassword="$ALF_DB_PWD"
+```
+
+The command deploys ACS Cluster on the Kubernetes cluster in the default configuration (but with your chosen Alfresco administrator & database passwords). The [configuration](#configuration) section lists the parameters that can be configured during installation.
+
+> **Tip**: List all releases using `helm list`
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```console
+$ helm delete my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+
+The following table lists the configurable parameters of the ACS chart and their default values.
+
+Parameter | Description | Default
+--- | --- | ---
+`repository.adminPassword` | Administrator password for ACS in md5 hash format | md5: `209c6174da490caeb422f3fa5a7ae634` (or) `admin`
+`postgresql.postgresUser` | postgresql database user | `alfresco`
+`postgresql.postgresPassword` | postgresql database password | `alfresco`
+`postgresql.postgresDatabase` | postgresql database name | `alfresco`

--- a/helm/alfresco-content-services/templates/config-repository.yaml
+++ b/helm/alfresco-content-services/templates/config-repository.yaml
@@ -25,6 +25,7 @@ data:
       -Dshare.protocol={{ .Values.externalProtocol | default "http"}}
       -Dshare.host={{ .Values.externalHost | default (printf "%s-share" (include "content-services.fullname" .)) }}
       -Dshare.port={{ .Values.externalPort | default .Values.share.service.externalPort }}
+      -Dalfresco_user_store.adminpassword={{ .Values.repository.adminPassword | default "209c6174da490caeb422f3fa5a7ae634" }}
       -Dcsrf.filter.origin={{ $alfprotocol }}://{{ $alfhost }}:{{ $alfport }}/.*
       -Dcsrf.filter.referer={{ $alfprotocol }}://{{ $alfhost }}:{{ $alfport }}/.*
       -Ddb.driver={{ template "database.driver" . }}


### PR DESCRIPTION
- Alfresco admin password can be configurable with `helm`
- Added a `README.md` for ACS Helm charts
- Started adding ACS configuration parameters to support `helm` installation