### PR TITLE
Hofix: NetworkPolicy for deny-k8s-dashboard should be global

### DIFF
--- a/helm/alfresco-content-services/templates/Rule_09-network-policy-deny-k8s-dashboard.yaml
+++ b/helm/alfresco-content-services/templates/Rule_09-network-policy-deny-k8s-dashboard.yaml
@@ -4,7 +4,6 @@ kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
 metadata:
   name: deny-dashboard
-  namespace: kube-system
 spec:
   podSelector:
     matchLabels:


### PR DESCRIPTION
- Fixed [Rule_09-network-policy-deny-k8s-dashboard.yaml](helm/alfresco-content-services/templates/Rule_09-network-policy-deny-k8s-dashboard.yaml) to be applied globally.