### PR TITLE
Fix repository short name in values.yaml for search alfresco-host

### DIFF
--- a/helm/alfresco-content-services/values.yaml
+++ b/helm/alfresco-content-services/values.yaml
@@ -214,7 +214,7 @@ alfresco-search:
   enabled: true
   repository:
     # The value for "host" is the name of this chart
-    host: alfresco-content-services
+    host: alfresco-cs
     port: *repositoryExternalPort
 
 # choose if you want network policy enabled


### PR DESCRIPTION
- Use alfresco-cs short name in search host