### PR TITLE
REPO-3534: Security Group Outbound traffic

### DIFF
--- a/docs/helm-deployment-aws_cloud.md
+++ b/docs/helm-deployment-aws_cloud.md
@@ -396,11 +396,12 @@ helm get values -a $ACSRELEASE
 
 ### Network Hardening
 
-* The `kops` utility will setup platform for setting up ACS cluster, but with some extra steps the networking on AWS infrastructure can be hardened.  
+The `kops` utility will setup platform for setting up ACS cluster, but with some extra steps the networking on AWS infrastructure can be hardened.  
 
 See AWS documentation: https://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_SecurityGroups.html
 
 Below are some recommended modifications to Security Groups that manage Inbound and Outbound traffic.
+
 
 #### Lockdown Bastion 
 
@@ -451,9 +452,10 @@ aws ec2 authorize-security-group-egress --group-id $BASTION_HOST_SG --ip-permiss
 </p>
 </details>
 
+
 #### Restrict k8s Master(s) Outbound traffic 
 
-By default, `kops` will allow all Outbound traffic from Master nodes Security Group to everywhere.  This can be restricted too by allowing explicit Outbound to be same as Inbound.
+By default, Outbound traffic is allowed from Master Security Group to everywhere.  This can be restricted too by allowing explicit Outbound to be same as Inbound.
 
 <details><summary>
 Below is an example of how to modify Master SG Outbound traffic with the AWS Cli.</summary>
@@ -490,7 +492,7 @@ aws ec2 revoke-security-group-egress --group-id $MASTERS_HOST_SG --ip-permission
 
 #### Restrict k8s Node(s) Outbound traffic 
 
-By default `kops` will allow all Outbound traffic from Node Security Group to everywhere.  This can be restricted too by allowing explicit Outbound to be same as Inbound.
+By default, Outbound traffic is allowed from Node Security Group to everywhere.  This can be restricted too by allowing explicit Outbound to be same as Inbound.
 
 <details><summary>
 Below is an example of how to modify Node SG Outbound traffic with the AWS Cli.</summary>
@@ -511,6 +513,26 @@ aws ec2 authorize-security-group-egress --group-id $NODES_HOST_SG --ip-permissio
 
 # Once Outbound rules are in place, revoke default Outbound rule which is open for everything
 aws ec2 revoke-security-group-egress --group-id $NODES_HOST_SG --ip-permissions '[{"IpProtocol": "-1", "FromPort": -1, "ToPort": -1, "IpRanges": [{"CidrIp": "0.0.0.0/0"}]}]'
+```
+
+</p>
+</details>
+
+
+#### Restrict API ELB Outbound traffic 
+
+By default, Outbound traffic is allowed from API ELB Security Group to everywhere.  This can be restricted too by allowing explicit Outbound to the ELB Instances.
+
+<details><summary>
+Below is an example of how to modify API ELB SG Outbound traffic with the AWS Cli.</summary>
+<p>
+
+```bash
+# Allow Outbound traffic between API ELB and Instances that it is listening to
+aws ec2 authorize-security-group-egress --group-id $API_ELB_SG --ip-permissions '[{"IpProtocol": "tcp", "FromPort": 443, "ToPort": 443, "UserIdGroupPairs": [{"GroupId": '\"$MASTERS_HOST_SG\"', "Description": "Outbound traffic between API ELB and instances it is listening to"}]}]'
+
+# Once Outbound rules are in place, revoke default Outbound rule which is open for everything
+aws ec2 revoke-security-group-egress --group-id $API_ELB_SG --ip-permissions '[{"IpProtocol": "-1", "FromPort": -1, "ToPort": -1, "IpRanges": [{"CidrIp": "0.0.0.0/0"}]}]'
 ```
 
 </p>

--- a/docs/helm-deployment-aws_cloud.md
+++ b/docs/helm-deployment-aws_cloud.md
@@ -539,6 +539,26 @@ aws ec2 revoke-security-group-egress --group-id $API_ELB_SG --ip-permissions '[{
 </details>
 
 
+#### Restrict K8S ELB Outbound traffic
+
+By default, Outbound traffic is allowed from K8S ELB Security Group to everywhere.  This can be restricted too by allowing explicit Outbound to the ELB Instances.
+
+<details><summary>
+Below is an example of how to modify K8S ELB SG Outbound traffic with the AWS Cli.</summary>
+<p>
+
+```bash
+# Allow Outbound traffic between K8S ELB and Instances that it is listening to
+aws ec2 authorize-security-group-egress --group-id $K8S_ELB_SG --ip-permissions '[{"IpProtocol": "-1", "FromPort": -1, "ToPort": -1, "UserIdGroupPairs": [{"GroupId": '\"$NODES_HOST_SG\"', "Description": "HTTP Outbound traffic between K8S ELB and instances it is listening to"}]}]'
+
+# Once Outbound rules are in place, revoke default Outbound rule which is open for everything
+aws ec2 revoke-security-group-egress --group-id $K8S_ELB_SG --ip-permissions '[{"IpProtocol": "-1", "FromPort": -1, "ToPort": -1, "IpRanges": [{"CidrIp": "0.0.0.0/0"}]}]'
+```
+
+</p>
+</details>
+
+
 ## Cleaning up your deployment
 
 ```bash

--- a/docs/helm-deployment-aws_cloud.md
+++ b/docs/helm-deployment-aws_cloud.md
@@ -511,6 +511,9 @@ aws ec2 authorize-security-group-egress --group-id $NODES_HOST_SG --ip-permissio
 # Allow Outbound traffic between Node(s) and Bastion Host
 aws ec2 authorize-security-group-egress --group-id $NODES_HOST_SG --ip-permissions '[{"IpProtocol": "tcp", "FromPort": 22, "ToPort": 22, "UserIdGroupPairs": [{"GroupId": '\"$BASTION_HOST_SG\"', "Description": "Outbound traffic between Node(s) & Bastion Host"}]}]'
 
+# Allow Outbound traffic between Node(s) and DockerHub to pull images
+aws ec2 authorize-security-group-egress --group-id $NODES_HOST_SG --ip-permissions '[{"IpProtocol": "tcp", "FromPort": 443, "ToPort": 443, "IpRanges": [{"CidrIp": "0.0.0.0/0", "Description": "Allow Nodes to pull images from DockerHub"}]}]'
+
 # Once Outbound rules are in place, revoke default Outbound rule which is open for everything
 aws ec2 revoke-security-group-egress --group-id $NODES_HOST_SG --ip-permissions '[{"IpProtocol": "-1", "FromPort": -1, "ToPort": -1, "IpRanges": [{"CidrIp": "0.0.0.0/0"}]}]'
 ```
@@ -553,6 +556,30 @@ aws ec2 authorize-security-group-egress --group-id $K8S_ELB_SG --ip-permissions 
 
 # Once Outbound rules are in place, revoke default Outbound rule which is open for everything
 aws ec2 revoke-security-group-egress --group-id $K8S_ELB_SG --ip-permissions '[{"IpProtocol": "-1", "FromPort": -1, "ToPort": -1, "IpRanges": [{"CidrIp": "0.0.0.0/0"}]}]'
+```
+
+</p>
+</details>
+
+
+#### Restrict Default SG Outbound traffic
+
+By default, Outbound traffic is allowed from default Security Group to everywhere.  This can be restricted too by allowing explicit Outbound to be same as Inbound.
+
+<details><summary>
+Below is an example of how to modify default SG Outbound traffic with the AWS Cli.</summary>
+<p>
+
+```bash
+# Allow Outbound traffic between default SG
+aws ec2 authorize-security-group-egress --group-id $DEFAULT_SG --ip-permissions '[{"IpProtocol": "-1", "FromPort": -1, "ToPort": -1, "UserIdGroupPairs": [{"GroupId": '\"$DEFAULT_SG\"', "Description": "Outbound traffic among default SG"}]}]'
+
+# Allow Outbound traffic for EFS for IPv4 & IPv6
+aws ec2 authorize-security-group-egress --group-id $DEFAULT_SG --ip-permissions '[{"IpProtocol": "tcp", "FromPort": 2049, "ToPort": 2049, "IpRanges": [{"CidrIp": "0.0.0.0/0", "Description": "IPv4 Outbound traffic for EFS Mount point"}]}]'
+aws ec2 authorize-security-group-egress --group-id $DEFAULT_SG --ip-permissions '[{"IpProtocol": "tcp", "FromPort": 2049, "ToPort": 2049, "Ipv6Ranges": [{"CidrIpv6": "::/0", "Description": "IPv6 Outbound traffic for EFS Mount point"}]}]'
+
+# Once Outbound rules are in place, revoke default Outbound rule which is open for everything
+aws ec2 revoke-security-group-egress --group-id $DEFAULT_SG --ip-permissions '[{"IpProtocol": "-1", "FromPort": -1, "ToPort": -1, "IpRanges": [{"CidrIp": "0.0.0.0/0"}]}]'
 ```
 
 </p>

--- a/docs/helm-deployment-aws_cloud.md
+++ b/docs/helm-deployment-aws_cloud.md
@@ -396,19 +396,19 @@ helm get values -a $ACSRELEASE
 
 ### Network Hardening
 
-The `kops` utility will setup platform for setting up ACS cluster, but with some extra steps the networking on AWS infrastructure can be hardened.  
+The `kops` utility sets up a platform for the ACS cluster, but with some extra steps you can harden the networking on your AWS infrastructure.  
 
 See AWS documentation: https://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_SecurityGroups.html
 
-Below are some recommended modifications to Security Groups that manage Inbound and Outbound traffic.
+Below are some recommended modifications to Security Groups (SG) that manage Inbound and Outbound traffic.
 
 
 #### Lockdown Bastion 
 
-By default, SSH access to bastion host is open from everywhere for Inbound and Outbound traffic.  You may want it to lock down to a specific IP address(es).
+By default, SSH access to the bastion host is open from everywhere for Inbound and Outbound traffic.  You may want to lock it down to a specific IP address(es).
 
 <details><summary>
-Below is an example of how to modify Bastion traffic with the AWS Cli.</summary>
+Below is an example of how to modify the Bastion traffic with the AWS Cli.</summary>
 <p>
 
 ```bash
@@ -455,7 +455,7 @@ aws ec2 authorize-security-group-egress --group-id $BASTION_HOST_SG --ip-permiss
 
 #### Restrict k8s Master(s) Outbound traffic 
 
-By default, Outbound traffic is allowed from Master Security Group to everywhere.  This can be restricted too by allowing explicit Outbound to be same as Inbound.
+By default, Outbound traffic is allowed from Master Security Group to everywhere.  This can be restricted by allowing explicit Outbound to be same as Inbound.
 
 <details><summary>
 Below is an example of how to modify Master SG Outbound traffic with the AWS Cli.</summary>
@@ -492,7 +492,7 @@ aws ec2 revoke-security-group-egress --group-id $MASTERS_HOST_SG --ip-permission
 
 #### Restrict k8s Node(s) Outbound traffic 
 
-By default, Outbound traffic is allowed from Node Security Group to everywhere.  This can be restricted too by allowing explicit Outbound to be same as Inbound.
+By default, Outbound traffic is allowed from Node Security Group to everywhere.  This can be restricted by allowing explicit Outbound to be same as Inbound.
 
 <details><summary>
 Below is an example of how to modify Node SG Outbound traffic with the AWS Cli.</summary>
@@ -524,7 +524,7 @@ aws ec2 revoke-security-group-egress --group-id $NODES_HOST_SG --ip-permissions 
 
 #### Restrict API ELB Outbound traffic 
 
-By default, Outbound traffic is allowed from API ELB Security Group to everywhere.  This can be restricted too by allowing explicit Outbound to the ELB Instances.
+By default, Outbound traffic is allowed from API ELB Security Group to everywhere.  This can be restricted by allowing explicit Outbound to the ELB Instances.
 
 <details><summary>
 Below is an example of how to modify API ELB SG Outbound traffic with the AWS Cli.</summary>
@@ -544,7 +544,7 @@ aws ec2 revoke-security-group-egress --group-id $API_ELB_SG --ip-permissions '[{
 
 #### Restrict K8S ELB Outbound traffic
 
-By default, Outbound traffic is allowed from K8S ELB Security Group to everywhere.  This can be restricted too by allowing explicit Outbound to the ELB Instances.
+By default, Outbound traffic is allowed from K8S ELB Security Group to everywhere.  This can be restricted by allowing explicit Outbound to the ELB Instances.
 
 <details><summary>
 Below is an example of how to modify K8S ELB SG Outbound traffic with the AWS Cli.</summary>
@@ -564,7 +564,7 @@ aws ec2 revoke-security-group-egress --group-id $K8S_ELB_SG --ip-permissions '[{
 
 #### Restrict Default SG Outbound traffic
 
-By default, Outbound traffic is allowed from default Security Group to everywhere.  This can be restricted too by allowing explicit Outbound to be same as Inbound.
+By default, Outbound traffic is allowed from default Security Group to everywhere.  This can be restricted by allowing explicit Outbound to be same as Inbound.
 
 <details><summary>
 Below is an example of how to modify default SG Outbound traffic with the AWS Cli.</summary>


### PR DESCRIPTION
**Limit ACS Bastion access**
- Bastion ELB Inbound to be a CIDR (user provided) for SSH connection from, and Outbound to be Bastion Host SG
- Bastion Host Inbound to be only from Bastion ELB and Outbound to: Bastion ELB, K8s Master(s) & Node(s)
- Revoke default outbound traffic which is open to everything

**Limit ACS k8s Master Outbound traffic**
- Add Master node outbound traffic same as inbound traffic 
- Revoke default outbound traffic which is open to everything

**Limit ACS k8s Node Outbound traffic**
- Add Node outbound traffic same as inbound traffic
- Add Node outbound to pull images from DockerHub
- Revoke default outbound traffic which is open to everything

**Limit API ELB SG Outbound traffic**
- Add API ELB outbound traffic only to instances it listen (Master SG)
- Revoke default outbound traffic which is open to everything

**Limit K8S ELB SG Outbound traffic**
- Add K8S ELB outbound traffic only to instances it listen (Node SG)
- Revoke default outbound traffic which is open to everything

**Limit Default SG Outbound traffic**
- Add Default SG outbound traffic same as inbound traffic
- Revoke default outbound traffic which is open to everything