### PR TITLE
Enable SSL Redirect on Repo Ingress Controller for http -> https redirection

### DIFF
--- a/helm/alfresco-content-services/templates/ingress-repository.yaml
+++ b/helm/alfresco-content-services/templates/ingress-repository.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ template "content-services.shortname" . }}-repository
   annotations:
     kubernetes.io/ingress.class: "nginx"
-    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/affinity: "cookie"
     nginx.ingress.kubernetes.io/session-cookie-name: "alf_affinity_route"
     nginx.ingress.kubernetes.io/session-cookie-hash: "sha1"


### PR DESCRIPTION
- Repo Ingress controller to follow HTTP -> HTTPS redirection (by default)