### PR TITLE
REPO-3720, MNT-19825 ImageMagick docker transformer does not take arb…

### DIFF
--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -35,7 +35,7 @@ services:
             - 8082:8080 #Browser port
 
     alfresco-pdf-renderer:
-        image: alfresco/alfresco-pdf-renderer:1.2
+        image: alfresco/alfresco-pdf-renderer:1.3
         mem_limit: 1g
         environment:
             JAVA_OPTS: " -Xms256m -Xmx256m"
@@ -43,7 +43,7 @@ services:
             - 8090:8090
 
     imagemagick:
-        image: alfresco/alfresco-imagemagick:1.2
+        image: alfresco/alfresco-imagemagick:1.3
         mem_limit: 1g
         environment:
             JAVA_OPTS: " -Xms256m -Xmx256m"
@@ -51,7 +51,7 @@ services:
             - 8091:8090
 
     libreoffice:
-        image: alfresco/alfresco-libreoffice:1.2
+        image: alfresco/alfresco-libreoffice:1.3
         mem_limit: 1g
         environment:
             JAVA_OPTS: " -Xms256m -Xmx256m"


### PR DESCRIPTION
REPO-3720, MNT-19825 ImageMagick docker transformer does not take arbtrary command line options. (#54)

Cherry picked from master 8dd2eff187047d7c7c60b6199ed9b31a12324fa5 (ACS 6.1.0) to 1.0 (ACS 6.0.N)