### PR TITLE
REPO-3721: Admin console link

### DIFF
--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -78,7 +78,7 @@ services:
             - 8099:8099
 
     share:
-        image: alfresco-share-test
+        image: alfresco/alfresco-share:6.0
         mem_limit: 1g
         environment:
             REPO_HOST: "alfresco"

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -29,6 +29,8 @@ services:
                 -Dtika.url=http://tika:8090/
                 -Dsfs.url=http://shared-file-store:8099/
                 -Dshare.host=localhost
+                -Dalfresco.host=localhost
+                -Dalfresco.port=8082
                 -Ddeployment.method=DOCKER_COMPOSE
                 -Dcsrf.filter.enabled=false
                 -Xms1g -Xmx1g
@@ -76,12 +78,19 @@ services:
             - 8099:8099
 
     share:
-        image: alfresco/alfresco-share:6.0
+        image: alfresco-share-test
         mem_limit: 1g
         environment:
-            - REPO_HOST=alfresco
-            - REPO_PORT=8080
-            - "CATALINA_OPTS= -Xms500m -Xmx500m"
+            REPO_HOST: "alfresco"
+            REPO_PORT: "8080"
+            JAVA_OPTS: "
+                -Xms500m
+                -Xmx500m
+                -Dalfresco.host=localhost
+                -Dalfresco.port=8082
+                -Dalfresco.context=alfresco
+                -Dalfresco.protocol=http
+                "
         ports:
             - 8080:8080
 

--- a/helm/alfresco-content-services/templates/config-share.yaml
+++ b/helm/alfresco-content-services/templates/config-share.yaml
@@ -21,3 +21,4 @@ data:
   REPO_PORT: "{{ .Values.repository.service.externalPort }}"
   CSRF_FILTER_REFERER: "{{ $alfprotocol }}://{{ $alfhost }}/.*"
   CSRF_FILTER_ORIGIN: "{{ $alfprotocol }}://{{ $alfhost }}"
+  CATALINA_OPTS: "-Dalfresco.proxy={{ .Values.externalProtocol | default "http" }}://{{ .Values.externalHost }}:{{ .Values.externalPort | default .Values.repository.service.externalPort }}"

--- a/helm/alfresco-content-services/templates/config-share.yaml
+++ b/helm/alfresco-content-services/templates/config-share.yaml
@@ -21,4 +21,4 @@ data:
   REPO_PORT: "{{ .Values.repository.service.externalPort }}"
   CSRF_FILTER_REFERER: "{{ $alfprotocol }}://{{ $alfhost }}/.*"
   CSRF_FILTER_ORIGIN: "{{ $alfprotocol }}://{{ $alfhost }}"
-  CATALINA_OPTS: "-Dalfresco.proxy={{ .Values.externalProtocol | default "http" }}://{{ .Values.externalHost }}:{{ .Values.externalPort | default .Values.repository.service.externalPort }}"
+  JAVA_OPTS: "-Dalfresco.proxy={{ .Values.externalProtocol | default "http" }}://{{ .Values.externalHost }}:{{ .Values.externalPort | default .Values.repository.service.externalPort }}"


### PR DESCRIPTION
   docker-compose : Add external alfresco.host and alfresco.port to JAVA_OPTS for repository image in order to fix AOS
   docker-compose : Add external aflresco.host alfresco.port alfresco.context and alfresco.protocol to JAVA_OPTS for share image in order to fix broken admin console link
   helm : Add CATALINA_OPTS to config-share. Add alfresco.proxy value to fix broken admin console link