### PR TITLE
REPO-3747 update trial license usage info (#70)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,7 @@ Alfresco Content Services deployed via `docker-compose` or Kubernetes contains t
 ## Other information
 * See alternative commands and start up [tutorial with AWS support](https://github.com/Alfresco/alfresco-anaxes-shipyard/blob/master/docs/running-a-cluster.md)
 * [Tips and tricks](https://github.com/Alfresco/alfresco-anaxes-shipyard/blob/master/docs/tips-and-tricks.md) for working with Kubernetes and Alfresco Content Services.
+* The Docker Compose and Helm charts downloaded directly from here (github.com) are for
+ a limited trial of the Enterprise version of Alfresco Content Services that goes into read-only mode after 2-days. 
+ Request an extended 30-day trial at 
+ https://www.alfresco.com/platform/content-services-ecm/trial/docker

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -5,7 +5,7 @@
 # If container memory is not explicitly set, then the above flags will default max heap to 1/4th of container's memory which may not be ideal. 
 # Hence, setting up explicit Container memory and then assigning a percentage of it to the JVM for performance tuning.
 
-# Note: the docker-compose file from github.com is a limited trial that goes into read-only mode after 2-days.
+# Note: The docker-compose file from github.com is a limited trial that goes into read-only mode after 2-days.
 # Get the latest docker-compose.yml file with a 30-day trial license by accessing the Alfresco Content Services trial download page at:
 # https://www.alfresco.com/platform/content-services-ecm/trial/download
 

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -5,7 +5,11 @@
 # If container memory is not explicitly set, then the above flags will default max heap to 1/4th of container's memory which may not be ideal. 
 # Hence, setting up explicit Container memory and then assigning a percentage of it to the JVM for performance tuning.
 
-# Using version 2 as 3 does not support resource constraint options (cpu_*, mem_* limits) for non swarm mode in Compose  
+# Note: the docker-compose file from github.com is a limited trial that goes into read-only mode after 2-days.
+# Get the latest docker-compose.yml file with a 30-day trial license by accessing the Alfresco Content Services trial download page at:
+# https://www.alfresco.com/platform/content-services-ecm/trial/download
+
+# Using version 2 as 3 does not support resource constraint options (cpu_*, mem_* limits) for non swarm mode in Compose
 version: "2"
 
 services:

--- a/docs/docker-compose-deployment.md
+++ b/docs/docker-compose-deployment.md
@@ -8,7 +8,7 @@ To deploy Alfresco Content Services using _docker-compose_, you'll need to insta
 
 | Component      | Installation Guide |
 | ---------------| ------------------ |
-| License        | [30 day trial license](https://www.alfresco.com/platform/content-services-ecm/trial/download) for Enterprise |
+| License        | [30-day trial license](https://www.alfresco.com/platform/content-services-ecm/trial/download) for Enterprise |
 | Docker         | https://docs.docker.com/ |
 | Docker Compose | https://docs.docker.com/compose/install/ |
 
@@ -20,14 +20,14 @@ To deploy Alfresco Content Services using _docker-compose_, you'll need to insta
 1. Clone this repository or download a single file - [docker-compose](../docker-compose/docker-compose.yml).
 2. Navigate to the folder where the _docker-compose.yml_ file is located.
 3. Run ```docker-compose up```
-4. Navigate to the admin console and apply your trial license:
+4. Navigate to the Admin Console and apply your trial license:
 * [http://<machine_ip>:8082/alfresco/service/enterprise/admin/admin-license](http://localhost:8082/alfresco/service/enterprise/admin/admin-license) (```<machine_ip>``` will usually just be ```localhost```)
 * Default username and password is ```admin```
-* More instructions here: http://docs.alfresco.com/6.0/tasks/at-adminconsole-license.html
+* See [Uploading a new license](http://docs.alfresco.com/6.0/tasks/at-adminconsole-license.html) for more details
 5. Open the following URLs in your browser to check that everything starts up:
 * Share: [http://<machine_ip>:8080/share](http://localhost:8080/share)
-* REST APIs and administration: http://<machine_ip>:8082/alfresco
-* Search administration: http://<machine_ip>:8083/solr
+* REST APIs and administration: [http://<machine_ip>:8082/alfresco](http://<machine_ip>:8082/alfresco)
+* Search administration: [http://<machine_ip>:8083/solr](http://<machine_ip>:8083/solr)
 
 **Note:**
 * Make sure ports 5432, 8080, 8082, and 8083 are open. These are defined in the _docker-compose.yml_ file.

--- a/docs/docker-compose-deployment.md
+++ b/docs/docker-compose-deployment.md
@@ -8,6 +8,7 @@ To deploy Alfresco Content Services using _docker-compose_, you'll need to insta
 
 | Component      | Installation Guide |
 | ---------------| ------------------ |
+| License        | [30 day trial license](https://www.alfresco.com/platform/content-services-ecm/trial/download) for Enterprise |
 | Docker         | https://docs.docker.com/ |
 | Docker Compose | https://docs.docker.com/compose/install/ |
 
@@ -19,10 +20,14 @@ To deploy Alfresco Content Services using _docker-compose_, you'll need to insta
 1. Clone this repository or download a single file - [docker-compose](../docker-compose/docker-compose.yml).
 2. Navigate to the folder where the _docker-compose.yml_ file is located.
 3. Run ```docker-compose up```
-4. Open the following URLs in your browser to check that everything starts up:
-* http://<machine_ip>:8082/alfresco
-* http://<machine_ip>:8080/share
-* http://<machine_ip>:8083/solr
+4. Navigate to the admin console and apply your trial license:
+* [http://<machine_ip>:8082/alfresco/service/enterprise/admin/admin-license](http://localhost:8082/alfresco/service/enterprise/admin/admin-license) (```<machine_ip>``` will usually just be ```localhost```)
+* Default username and password is ```admin```
+* More instructions here: http://docs.alfresco.com/6.0/tasks/at-adminconsole-license.html
+5. Open the following URLs in your browser to check that everything starts up:
+* Share: [http://<machine_ip>:8080/share](http://localhost:8080/share)
+* REST APIs and administration: http://<machine_ip>:8082/alfresco
+* Search administration: http://<machine_ip>:8083/solr
 
 **Note:**
 * Make sure ports 5432, 8080, 8082, and 8083 are open. These are defined in the _docker-compose.yml_ file.

--- a/helm/alfresco-content-services/Chart.yaml
+++ b/helm/alfresco-content-services/Chart.yaml
@@ -1,3 +1,6 @@
+# Note: the Helm chart from github.com is a limited trial of the Enterprise version of Alfresco Content Services
+# that goes into read-only mode after 2-days.
+# Request an extended 30-day trial at https://www.alfresco.com/platform/content-services-ecm/trial/docker
 name: alfresco-content-services
 version: 1.0.4
 appVersion: 6.0.0

--- a/helm/alfresco-content-services/Chart.yaml
+++ b/helm/alfresco-content-services/Chart.yaml
@@ -1,4 +1,4 @@
-# Note: the Helm chart from github.com is a limited trial of the Enterprise version of Alfresco Content Services
+# Note: The Helm chart from github.com is a limited trial of the Enterprise version of Alfresco Content Services
 # that goes into read-only mode after 2-days.
 # Request an extended 30-day trial at https://www.alfresco.com/platform/content-services-ecm/trial/docker
 name: alfresco-content-services

--- a/helm/alfresco-content-services/README.md
+++ b/helm/alfresco-content-services/README.md
@@ -24,6 +24,7 @@ $ helm install alfresco-incubator/alfresco-content-services
 This chart bootstraps an ACS deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
 ## Prerequisites
+  - [30 day trial license](https://www.alfresco.com/platform/content-services-ecm/trial/download) for Enterprise
   - Kubernetes 1.4+ with Beta APIs enabled
   - Minimum of 16GB Memory to distribute among ACS Cluster nodes
 

--- a/helm/alfresco-content-services/README.md
+++ b/helm/alfresco-content-services/README.md
@@ -24,7 +24,7 @@ $ helm install alfresco-incubator/alfresco-content-services
 This chart bootstraps an ACS deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
 ## Prerequisites
-  - [30 day trial license](https://www.alfresco.com/platform/content-services-ecm/trial/download) for Enterprise
+  - [30-day trial license](https://www.alfresco.com/platform/content-services-ecm/trial/download) for Enterprise
   - Kubernetes 1.4+ with Beta APIs enabled
   - Minimum of 16GB Memory to distribute among ACS Cluster nodes
 


### PR DESCRIPTION
* REPO-3747: Update comments with instructions on getting an extended trial

* REPO-3747: Update README.md

* REPO-3747: Added Enterprise license prerequisite

Enterprise license is a prerequisite for any serious trial.
Added details on how to apply the license.
Added links for license upload and Share.

* REPO-3747: Trial license prerequisite

(cherry picked from commit f63f31d526e06a40e08f1b02543fb747ce7e5e78)