### PR TITLE
REPO-3747 update trial license usage info (#70) (#71)

### DIFF
--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -5,7 +5,7 @@
 # If container memory is not explicitly set, then the above flags will default max heap to 1/4th of container's memory which may not be ideal.
 # Hence, setting up explicit Container memory and then assigning a percentage of it to the JVM for performance tuning.
 
-# Note: the docker-compose file from github.com is a limited trial that goes into read-only mode after 2-days.
+# Note: The docker-compose file from github.com is a limited trial that goes into read-only mode after 2-days.
 # Get the latest docker-compose.yml file with a 30-day trial license by accessing the Alfresco Content Services trial download page at:
 # https://www.alfresco.com/platform/content-services-ecm/trial/download
 

--- a/docs/docker-compose-deployment.md
+++ b/docs/docker-compose-deployment.md
@@ -8,7 +8,7 @@ To deploy Alfresco Content Services using _docker-compose_, you'll need to insta
 
 | Component      | Installation Guide |
 | ---------------| ------------------ |
-| License        | [30 day trial license](https://www.alfresco.com/platform/content-services-ecm/trial/download) for Enterprise |
+| License        | [30-day trial license](https://www.alfresco.com/platform/content-services-ecm/trial/download) for Enterprise |
 | Docker         | https://docs.docker.com/ |
 | Docker Compose | https://docs.docker.com/compose/install/ |
 
@@ -20,14 +20,14 @@ To deploy Alfresco Content Services using _docker-compose_, you'll need to insta
 1. Clone this repository or download a single file - [docker-compose](../docker-compose/docker-compose.yml).
 2. Navigate to the folder where the _docker-compose.yml_ file is located.
 3. Run ```docker-compose up```
-4. Navigate to the admin console and apply your trial license:
+4. Navigate to the Admin Console and apply your trial license:
 * [http://<machine_ip>:8082/alfresco/service/enterprise/admin/admin-license](http://localhost:8082/alfresco/service/enterprise/admin/admin-license) (```<machine_ip>``` will usually just be ```localhost```)
 * Default username and password is ```admin```
-* More instructions here: http://docs.alfresco.com/6.0/tasks/at-adminconsole-license.html
-4. Open the following URLs in your browser to check that everything starts up:
+* See [Uploading a new license](http://docs.alfresco.com/6.0/tasks/at-adminconsole-license.html) for more details
+5. Open the following URLs in your browser to check that everything starts up:
 * Share: [http://<machine_ip>:8080/share](http://localhost:8080/share)
-* REST APIs and administration: http://<machine_ip>:8082/alfresco
-* Search administration: http://<machine_ip>:8083/solr
+* REST APIs and administration: [http://<machine_ip>:8082/alfresco](http://<machine_ip>:8082/alfresco)
+* Search administration: [http://<machine_ip>:8083/solr](http://<machine_ip>:8083/solr)
 
 **Note:**
 * Make sure ports 5432, 8080, 8082, and 8083 are open. These are defined in the _docker-compose.yml_ file.

--- a/docs/docker-compose-deployment.md
+++ b/docs/docker-compose-deployment.md
@@ -26,8 +26,8 @@ To deploy Alfresco Content Services using _docker-compose_, you'll need to insta
 * See [Uploading a new license](http://docs.alfresco.com/6.0/tasks/at-adminconsole-license.html) for more details
 5. Open the following URLs in your browser to check that everything starts up:
 * Share: [http://<machine_ip>:8080/share](http://localhost:8080/share)
-* REST APIs and administration: [http://<machine_ip>:8082/alfresco](http://<machine_ip>:8082/alfresco)
-* Search administration: [http://<machine_ip>:8083/solr](http://<machine_ip>:8083/solr)
+* REST APIs and administration: [http://<machine_ip>:8082/alfresco](http://localhost:8082/alfresco)
+* Search administration: [http://<machine_ip>:8083/solr](http://localhost:8083/solr)
 
 **Note:**
 * Make sure ports 5432, 8080, 8082, and 8083 are open. These are defined in the _docker-compose.yml_ file.

--- a/helm/alfresco-content-services/Chart.yaml
+++ b/helm/alfresco-content-services/Chart.yaml
@@ -1,4 +1,4 @@
-# Note: the Helm chart from github.com is a limited trial of the Enterprise version of Alfresco Content Services
+# Note: The Helm chart from github.com is a limited trial of the Enterprise version of Alfresco Content Services
 # that goes into read-only mode after 2-days.
 # Request an extended 30-day trial at https://www.alfresco.com/platform/content-services-ecm/trial/docker
 name: alfresco-content-services

--- a/helm/alfresco-content-services/README.md
+++ b/helm/alfresco-content-services/README.md
@@ -24,7 +24,7 @@ $ helm install alfresco-incubator/alfresco-content-services
 This chart bootstraps an ACS deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
 ## Prerequisites
-  - [30 day trial license](https://www.alfresco.com/platform/content-services-ecm/trial/download) for Enterprise
+  - [30-day trial license](https://www.alfresco.com/platform/content-services-ecm/trial/download) for Enterprise
   - Kubernetes 1.4+ with Beta APIs enabled
   - Minimum of 16GB Memory to distribute among ACS Cluster nodes
 


### PR DESCRIPTION
* The written instructions made in the original commit have been updated on the support/HF/1.0 branch, this cherry-pick brings those updates to the master branch

(cherry picked from commit 71320ba5d93a9064d0359a3572b0ed08fc97aa3a)