### PR TITLE
ACA-1847: integrate ADW image and app proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Alfresco Content Services deployed via `docker-compose` or Kubernetes contains t
 3. A Postgres DB  
 4. Alfresco Search Services (Solr6)
 5. Alfresco Transform Service
+6. Alfresco Digital Workspace
 
 ## Deployment options
 * [Deploying with Helm charts on AWS using Kops](docs/helm-deployment-aws_cloud.md)

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -113,7 +113,7 @@ services:
                 -Dalfresco.protocol=http
                 "
         ports:
-            - 8084:8080
+            - 8080:8080
 
     postgres:
         image: postgres:10.1
@@ -165,7 +165,7 @@ services:
         volumes:
             - ./nginx.conf:/etc/nginx/conf.d/default.conf
         ports:
-            - 8080:80
+            - 8084:80
 
 volumes:
     shared-file-store-volume:

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -113,7 +113,7 @@ services:
                 -Dalfresco.protocol=http
                 "
         ports:
-            - 8080:8080
+            - 8084:8080
 
     postgres:
         image: postgres:10.1
@@ -150,6 +150,22 @@ services:
             - 5672:5672 # AMQP
             - 61616:61616 # OpenWire
             - 61613:61613 # STOMP
+
+    digital-workspace:
+        image: quay.io/alfresco/alfresco-digital-workspace:1.0.0
+        depends_on:
+            - alfresco
+        ports:
+            - 8085:80
+
+    proxy:
+        image: nginx:stable-alpine
+        depends_on:
+            - digital-workspace
+        volumes:
+            - ./nginx.conf:/etc/nginx/conf.d/default.conf
+        ports:
+            - 8080:80
 
 volumes:
     shared-file-store-volume:

--- a/docker-compose/nginx.conf
+++ b/docker-compose/nginx.conf
@@ -1,0 +1,31 @@
+server {
+    listen *:80;
+
+    set  $allowOriginSite *;
+    proxy_pass_request_headers on;
+    proxy_pass_header Set-Cookie;
+
+    location / {
+        proxy_pass http://digital-workspace;
+
+        proxy_next_upstream error timeout invalid_header http_500 http_502 http_503 http_504;
+        proxy_redirect off;
+        proxy_buffering off;
+        proxy_set_header Host            $host;
+        proxy_set_header X-Real-IP       $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_pass_header Set-Cookie;
+    }
+
+    location /alfresco/ {
+        proxy_pass http://alfresco:8080;
+
+        proxy_next_upstream error timeout invalid_header http_500 http_502 http_503 http_504;
+        proxy_redirect off;
+        proxy_buffering off;
+        proxy_set_header Host            $host;
+        proxy_set_header X-Real-IP       $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_pass_header Set-Cookie;
+    }
+}


### PR DESCRIPTION
## Details

The PR adds extra Alfresco Digital Workspace 1.0.0 from quay.io.
The resulting application is served at port 8085.

In order to solve the problems with the CORS the application comes with the proxy container at port 8084 that allows redirecting requests to the underlying repository.

See also: https://issues.alfresco.com/jira/browse/ACA-1847

## Result
`http://localhost:8084` points to the ADW instance
`http://localhost:8084/alfresco` proxies the calls from the app to Repository without CORS issues

## Testing

```sh
docker-compose up
open http://localhost:8084
```

Use default `admin:admin` to log into the app.

