### PR TITLE
WIP: REPO-3867: AWS Load Tests: Integrate yourkit profiling agent into the docker images for ACS Repository

### DIFF
--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -9,6 +9,9 @@
 # Get the latest docker-compose.yml file with a 30-day trial license by accessing the Alfresco Content Services trial download page at:
 # https://www.alfresco.com/platform/content-services-ecm/trial/download
 
+# Add the following environment variable to CATALINA_OPTS on alfresco service to activate YourKit profiling agent on tomcat
+#-agentpath:/usr/local/YourKit-JavaProfiler-2018.04/bin/linux-x86-64/libyjpagent.so=delay=200000,listen=all,sessionname=$$HOSTNAME,dir=/tmp/Alfresco/yourkit,onexit=snapshot,periodicperf=600,periodicmem=600
+
 # Using version 2 as 3 does not support resource constraint options (cpu_*, mem_* limits) for non swarm mode in Compose
 version: "2"
 
@@ -41,6 +44,8 @@ services:
                 "
         ports:
             - 8082:8080 #Browser port
+        volumes:
+            - yourkit-snapshots-volume:/tmp/Alfresco/yourkit
 
     transform-router:
         image: quay.io/alfresco/alfresco-transform-router:0.1.1-EA
@@ -153,6 +158,10 @@ services:
 
 volumes:
     shared-file-store-volume:
+        driver_opts:
+            type: tmpfs
+            device: tmpfs
+    yourkit-snapshots-volume:
         driver_opts:
             type: tmpfs
             device: tmpfs

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -43,7 +43,7 @@ services:
             - 8082:8080 #Browser port
 
     transform-router:
-        image: quay.io/alfresco/alfresco-transform-router:0.1.0-EA
+        image: quay.io/alfresco/alfresco-transform-router:0.1.1-EA
         environment:
           ACTIVEMQ_URL: "nio://activemq:61616"
           IMAGEMAGICK_URL: "http://imagemagick:8090"
@@ -54,7 +54,7 @@ services:
           - activemq
 
     alfresco-pdf-renderer:
-        image: quay.io/alfresco/alfresco-pdf-renderer:2.0.0-EA
+        image: quay.io/alfresco/alfresco-pdf-renderer:2.0.1-EA
         mem_limit: 1g
         environment:
             JAVA_OPTS: " -Xms256m -Xmx256m"
@@ -63,7 +63,7 @@ services:
             - 8090:8090
 
     imagemagick:
-        image: quay.io/alfresco/alfresco-imagemagick:2.0.0-EA
+        image: quay.io/alfresco/alfresco-imagemagick:2.0.1-EA
         mem_limit: 1g
         environment:
             JAVA_OPTS: " -Xms256m -Xmx256m"
@@ -72,7 +72,7 @@ services:
             - 8091:8090
 
     libreoffice:
-        image: quay.io/alfresco/alfresco-libreoffice:2.0.0-EA
+        image: quay.io/alfresco/alfresco-libreoffice:2.0.1-EA
         mem_limit: 1g
         environment:
             JAVA_OPTS: " -Xms256m -Xmx256m"
@@ -81,7 +81,7 @@ services:
             - 8092:8090
 
     tika:
-        image: quay.io/alfresco/alfresco-tika:2.0.0-EA
+        image: quay.io/alfresco/alfresco-tika:2.0.1-EA
         mem_limit: 1g
         environment:
             JAVA_OPTS: " -Xms256m -Xmx256m"

--- a/helm/alfresco-content-services/templates/Rule_14-network-policy-yourkit.yaml
+++ b/helm/alfresco-content-services/templates/Rule_14-network-policy-yourkit.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.networkpolicysetting.enabled }}
+# Allow yourkit communication with ingress
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: yourkit
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ template "alfresco.shortname" . }}-yourkit
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+    - from:
+      # Allow traffic from nginx-ingress
+      - podSelector:
+          matchLabels:
+            app: nginx-ingress
+
+      ports:
+        - protocol: TCP
+          port: 80
+        - protocol: TCP
+          port: 80
+
+  egress:
+    # Allow repo to communicate back with other components
+    - to:
+      # nginx-ingress
+      - podSelector:
+          matchLabels:
+             app: nginx-ingress
+
+{{- end }}

--- a/helm/alfresco-content-services/templates/config-yourkit.yaml
+++ b/helm/alfresco-content-services/templates/config-yourkit.yaml
@@ -15,5 +15,3 @@ data:
   {{ $key }}: {{ $val | quote }}
   {{- end }}
   {{- end }}
-  livenessPercent: "{{ .Values.yourkit.livenessProbe.livenessPercent }}"
-  livenessSavePeriodSeconds: "{{ .Values.yourkit.livenessProbe.livenessSavePeriodSeconds }}"

--- a/helm/alfresco-content-services/templates/config-yourkit.yaml
+++ b/helm/alfresco-content-services/templates/config-yourkit.yaml
@@ -9,9 +9,10 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     component: yourkit
 data:
-  # The JAVA_OPTS defined in the values.yaml file for "yourkit" are set here using proper quotes
+  # The ENVs defined in the values.yaml file for "yourkit" are set here using proper quotes
   {{- if .Values.yourkit.environment }}
   {{- range $key, $val := .Values.yourkit.environment }}
   {{ $key }}: {{ $val | quote }}
   {{- end }}
   {{- end }}
+  default.conf: {{ .Values.yourkit.nginx_conf | quote }}

--- a/helm/alfresco-content-services/templates/config-yourkit.yaml
+++ b/helm/alfresco-content-services/templates/config-yourkit.yaml
@@ -1,0 +1,19 @@
+# Defines the properties required by the yourkit container
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "alfresco.shortname" . }}-yourkit-configmap
+  labels:
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    component: yourkit
+data:
+  # The JAVA_OPTS defined in the values.yaml file for "yourkit" are set here using proper quotes
+  {{- if .Values.yourkit.environment }}
+  {{- range $key, $val := .Values.yourkit.environment }}
+  {{ $key }}: {{ $val | quote }}
+  {{- end }}
+  {{- end }}
+  livenessPercent: "{{ .Values.yourkit.livenessProbe.livenessPercent }}"
+  livenessSavePeriodSeconds: "{{ .Values.yourkit.livenessProbe.livenessSavePeriodSeconds }}"

--- a/helm/alfresco-content-services/templates/deployment-yourkit.yaml
+++ b/helm/alfresco-content-services/templates/deployment-yourkit.yaml
@@ -1,0 +1,64 @@
+# Defines the deployment for the yourkit
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ template "alfresco.shortname" . }}-yourkit
+  labels:
+    app: {{ template "alfresco.shortname" . }}-yourkit
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    component: yourkit
+spec:
+  replicas: {{ .Values.yourkit.replicaCount }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "alfresco.shortname" . }}-yourkit
+        release: {{ .Release.Name }}
+        component: transformers
+    spec:
+      {{- if .Values.registryPullSecrets }}
+      # only set this secret if a private docker registry variable is defined
+      imagePullSecrets:
+        - name: {{ .Values.registryPullSecrets }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.yourkit.image.repository }}:{{ .Values.yourkit.image.tag }}"
+          imagePullPolicy: {{ .Values.yourkit.image.pullPolicy }}
+          envFrom:
+          - configMapRef:
+              # config map to use, defined in config-yourkit.yaml
+              name: {{ template "alfresco.shortname" . }}-yourkit-configmap
+          ports:
+            - containerPort: {{ .Values.yourkit.image.internalPort }}
+          resources:
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: {{ .Values.yourkit.image.internalPort }}
+            initialDelaySeconds: {{ .Values.yourkit.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.yourkit.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.yourkit.readinessProbe.timeoutSeconds }}
+          livenessProbe:
+            httpGet:
+              path: /live
+              port: {{ .Values.yourkit.image.internalPort }}
+            initialDelaySeconds: {{ .Values.yourkit.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.yourkit.livenessProbe.periodSeconds }}
+            failureThreshold: 1
+            timeoutSeconds: {{ .Values.yourkit.livenessProbe.timeoutSeconds }}
+{{ toYaml .Values.yourkit.resources | indent 12 }}
+          {{- if .Values.persistence.yourkit.enabled }}
+          volumeMounts:
+          - name: data
+            mountPath: {{ .Values.persistence.yourkit.data.mountPath }}
+            subPath: {{ .Values.persistence.yourkit.data.subPath }}
+          {{- end }}
+      {{- if .Values.persistence.yourkit.enabled }}
+      volumes:
+      - name: data
+        persistentVolumeClaim:
+          claimName: {{ .Values.persistence.existingClaim }}
+      {{- end }}

--- a/helm/alfresco-content-services/templates/deployment-yourkit.yaml
+++ b/helm/alfresco-content-services/templates/deployment-yourkit.yaml
@@ -33,17 +33,19 @@ spec:
               name: {{ template "alfresco.shortname" . }}-yourkit-configmap
           ports:
             - containerPort: {{ .Values.yourkit.image.internalPort }}
+              name: http
+              protocol: TCP
           resources:
           readinessProbe:
             httpGet:
-              path: /ready
+              path: /
               port: {{ .Values.yourkit.image.internalPort }}
             initialDelaySeconds: {{ .Values.yourkit.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.yourkit.readinessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.yourkit.readinessProbe.timeoutSeconds }}
           livenessProbe:
             httpGet:
-              path: /live
+              path: /
               port: {{ .Values.yourkit.image.internalPort }}
             initialDelaySeconds: {{ .Values.yourkit.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.yourkit.livenessProbe.periodSeconds }}

--- a/helm/alfresco-content-services/templates/deployment-yourkit.yaml
+++ b/helm/alfresco-content-services/templates/deployment-yourkit.yaml
@@ -16,7 +16,7 @@ spec:
       labels:
         app: {{ template "alfresco.shortname" . }}-yourkit
         release: {{ .Release.Name }}
-        component: transformers
+        component: yourkit
     spec:
       {{- if .Values.registryPullSecrets }}
       # only set this secret if a private docker registry variable is defined

--- a/helm/alfresco-content-services/templates/deployment-yourkit.yaml
+++ b/helm/alfresco-content-services/templates/deployment-yourkit.yaml
@@ -57,10 +57,15 @@ spec:
           - name: data
             mountPath: {{ .Values.persistence.yourkit.data.mountPath }}
             subPath: {{ .Values.persistence.yourkit.data.subPath }}
+          - mountPath: /etc/nginx/conf.d/
+            name: nginxconf
           {{- end }}
       {{- if .Values.persistence.yourkit.enabled }}
       volumes:
       - name: data
         persistentVolumeClaim:
           claimName: {{ .Values.persistence.existingClaim }}
+      - name: nginxconf
+        configMap:
+          name: {{ template "alfresco.shortname" . }}-yourkit-configmap
       {{- end }}

--- a/helm/alfresco-content-services/templates/ingress-yourkit.yaml
+++ b/helm/alfresco-content-services/templates/ingress-yourkit.yaml
@@ -6,6 +6,8 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: "nginx"
     # nginx.ingress.kubernetes.io/auth-type: basic
+    # nginx.ingress.kubernetes.io/auth-secret: {{ template "alfresco-search.fullName" . }}-solr
+    # nginx.ingress.kubernetes.io/auth-realm: "Authentication Required - Alfresco Search Services"
 
 spec:
   rules:

--- a/helm/alfresco-content-services/templates/ingress-yourkit.yaml
+++ b/helm/alfresco-content-services/templates/ingress-yourkit.yaml
@@ -2,10 +2,10 @@
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: {{ template "content-services.shortname" . }}-yourkit
+  name: {{ template "alfresco.shortname" . }}-yourkit
   annotations:
     kubernetes.io/ingress.class: "nginx"
-    nginx.ingress.kubernetes.io/auth-type: basic
+    # nginx.ingress.kubernetes.io/auth-type: basic
 
 spec:
   rules:
@@ -13,5 +13,5 @@ spec:
       paths:
       - path: {{ .Values.yourkit.ingress.path }}
         backend:
-          serviceName: {{ template "content-services.shortname" . }}-yourkit
+          serviceName: {{ template "alfresco.shortname" . }}-yourkit
           servicePort: {{ .Values.yourkit.service.externalPort }}

--- a/helm/alfresco-content-services/templates/ingress-yourkit.yaml
+++ b/helm/alfresco-content-services/templates/ingress-yourkit.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.ingress.enabled }}
+# Defines the ingress for the Yourkit snapshots directory on alfresco content repository
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ template "content-services.shortname" . }}-yourkit
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/auth-type: basic
+
+spec:
+  rules:
+  - http:
+      paths:
+      - path: {{ .Values.yourkit.ingress.path }}
+        backend:
+          serviceName: {{ template "content-services.shortname" . }}-yourkit
+          servicePort: {{ .Values.yourkit.service.externalPort }}
+{{- end }}

--- a/helm/alfresco-content-services/templates/ingress-yourkit.yaml
+++ b/helm/alfresco-content-services/templates/ingress-yourkit.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.ingress.enabled }}
 # Defines the ingress for the Yourkit snapshots directory on alfresco content repository
 apiVersion: extensions/v1beta1
 kind: Ingress
@@ -16,4 +15,3 @@ spec:
         backend:
           serviceName: {{ template "content-services.shortname" . }}-yourkit
           servicePort: {{ .Values.yourkit.service.externalPort }}
-{{- end }}

--- a/helm/alfresco-content-services/templates/svc-yourkit.yaml
+++ b/helm/alfresco-content-services/templates/svc-yourkit.yaml
@@ -1,0 +1,20 @@
+# Defines the service for the YourKit service
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "alfresco.shortname" . }}-yourkit
+  labels:
+    app: {{ template "alfresco.shortname" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    component: yourkit
+spec:
+  type: {{ .Values.yourkit.service.type }}
+  ports:
+    - port: {{ .Values.yourkit.service.externalPort }}
+      targetPort: {{ .Values.yourkit.image.internalPort }}
+      name: {{ .Values.yourkit.service.name }}
+  selector:
+    app: {{ template "alfresco.shortname" . }}-yourkit
+    release: {{ .Release.Name }}

--- a/helm/alfresco-content-services/values.yaml
+++ b/helm/alfresco-content-services/values.yaml
@@ -57,7 +57,7 @@ transformrouter:
   replicaCount: 1
   image:
     repository: quay.io/alfresco/alfresco-transform-router
-    tag: "0.1.0-EA"
+    tag: "0.1.1-EA"
     pullPolicy: Always
     internalPort: 8095
   service:
@@ -79,7 +79,7 @@ pdfrenderer:
   replicaCount: 1
   image:
     repository: quay.io/alfresco/alfresco-pdf-renderer
-    tag: "2.0.0-EA"
+    tag: "2.0.1-EA"
     pullPolicy: Always
     internalPort: 8090
   service:
@@ -112,7 +112,7 @@ imagemagick:
   replicaCount: 1
   image:
     repository: quay.io/alfresco/alfresco-imagemagick
-    tag: "2.0.0-EA"
+    tag: "2.0.1-EA"
     pullPolicy: Always
     internalPort: 8090
   service:
@@ -145,7 +145,7 @@ libreoffice:
   replicaCount: 1
   image:
     repository: quay.io/alfresco/alfresco-libreoffice
-    tag: "2.0.0-EA"
+    tag: "2.0.1-EA"
     pullPolicy: Always
     internalPort: 8090
   service:
@@ -178,7 +178,7 @@ tika:
   replicaCount: 1
   image:
     repository: quay.io/alfresco/alfresco-tika
-    tag: "2.0.0-EA"
+    tag: "2.0.1-EA"
     pullPolicy: Always
     internalPort: 8090
   service:

--- a/helm/alfresco-content-services/values.yaml
+++ b/helm/alfresco-content-services/values.yaml
@@ -267,6 +267,35 @@ share:
     periodSeconds: 20
     timeoutSeconds: 10
 
+yourkit:
+  replicaCount: 1
+  image:
+    repository: nginx
+    tag: 1.11.0
+    pullPolicy: IfNotPresent
+    internalPort: 8080
+  service:
+    name: yourkit
+    type: ClusterIP
+    externalPort: 80
+  ingress:
+    path: /yourkit
+  resources:
+    requests:
+      memory: "2000Mi"
+    limits:
+      memory: "2000Mi"
+  environment:
+    CATALINA_OPTS: " -Xms1000M -Xmx1000M"
+  readinessProbe:
+    initialDelaySeconds: 60
+    periodSeconds: 20
+    timeoutSeconds: 10
+  livenessProbe:
+    initialDelaySeconds: 130
+    periodSeconds: 20
+    timeoutSeconds: 10
+
 # Defines the mounting points for the persistence required by the apps in the
 # cluster the alf_data folder from alfresco-content-repository app is mapped to
 # alfresco-content-services/repository-data
@@ -277,6 +306,11 @@ persistence:
     data:
       mountPath: "/usr/local/tomcat/alf_data"
       subPath: "alfresco-content-services/repository-data"
+  yourkit:
+    enabled: true
+    data:
+      mountPath: "/tmp/Alfresco-YourKit"
+      subPath: "alfresco-content-services/filestore-yourkit"
   filestore:
     enabled: true
     data:

--- a/helm/alfresco-content-services/values.yaml
+++ b/helm/alfresco-content-services/values.yaml
@@ -269,9 +269,15 @@ share:
 
 yourkit:
   replicaCount: 1
-  # index: >-
-  #   <h1>Hello</h1>
-  #   <p>This is a test</p>
+  nginx_conf: >-
+    server {
+        listen       80;
+        server_name  localhost;
+        root   /usr/share/nginx/html;
+        location /yourkit/ {
+            autoindex on;
+        }
+    }
   image:
     repository: nginx
     tag: 1.11.0
@@ -288,8 +294,8 @@ yourkit:
       memory: "2000Mi"
     limits:
       memory: "2000Mi"
-  # environment:
-  #   CATALINA_OPTS: " -Xms1000M -Xmx1000M"
+  environment:
+  #   SOME_KEY: "ITS_VALUE"
   readinessProbe:
     initialDelaySeconds: 60
     periodSeconds: 20
@@ -312,7 +318,7 @@ persistence:
   yourkit:
     enabled: true
     data:
-      mountPath: "/tmp/Alfresco-YourKit"
+      mountPath: "/usr/share/nginx/html/yourkit"
       subPath: "alfresco-content-services/filestore-yourkit"
   filestore:
     enabled: true

--- a/helm/alfresco-content-services/values.yaml
+++ b/helm/alfresco-content-services/values.yaml
@@ -12,8 +12,8 @@
 repository:
   replicaCount: 2
   image:
-    repository: alfresco/alfresco-content-repository
-    tag: "6.1.0-EA2"
+    repository: quay.io/alfresco/alfresco-content-repository
+    tag: "feature-REPO-3867-yourkit-6.1.0-SNAPSHOT"
     pullPolicy: Always
     internalPort: 8080
     hazelcastPort: 5701

--- a/helm/alfresco-content-services/values.yaml
+++ b/helm/alfresco-content-services/values.yaml
@@ -256,8 +256,8 @@ share:
       memory: "2000Mi"
     limits:
       memory: "2000Mi"
-  # environment:
-  #   CATALINA_OPTS: " -Xms1000M -Xmx1000M"
+  environment:
+    CATALINA_OPTS: " -Xms1000M -Xmx1000M"
   readinessProbe:
     initialDelaySeconds: 60
     periodSeconds: 20
@@ -269,9 +269,9 @@ share:
 
 yourkit:
   replicaCount: 1
-  index: >-
-    <h1>Hello</h1>
-    <p>This is a test</p>
+  # index: >-
+  #   <h1>Hello</h1>
+  #   <p>This is a test</p>
   image:
     repository: nginx
     tag: 1.11.0
@@ -288,8 +288,8 @@ yourkit:
       memory: "2000Mi"
     limits:
       memory: "2000Mi"
-  environment:
-    CATALINA_OPTS: " -Xms1000M -Xmx1000M"
+  # environment:
+  #   CATALINA_OPTS: " -Xms1000M -Xmx1000M"
   readinessProbe:
     initialDelaySeconds: 60
     periodSeconds: 20

--- a/helm/alfresco-content-services/values.yaml
+++ b/helm/alfresco-content-services/values.yaml
@@ -256,8 +256,8 @@ share:
       memory: "2000Mi"
     limits:
       memory: "2000Mi"
-  environment:
-    CATALINA_OPTS: " -Xms1000M -Xmx1000M"
+  # environment:
+  #   CATALINA_OPTS: " -Xms1000M -Xmx1000M"
   readinessProbe:
     initialDelaySeconds: 60
     periodSeconds: 20
@@ -269,11 +269,14 @@ share:
 
 yourkit:
   replicaCount: 1
+  index: >-
+    <h1>Hello</h1>
+    <p>This is a test</p>
   image:
     repository: nginx
     tag: 1.11.0
     pullPolicy: IfNotPresent
-    internalPort: 8080
+    internalPort: 80
   service:
     name: yourkit
     type: ClusterIP


### PR DESCRIPTION
- added a new volume to docker-compose for the YourKit agent snapshots that can be taken on ACS deployment
- the commented YourKit startup parameters can be added as CATALINA_OPTS or JAVA_OPTS on alfresco service
- a new nginx pod has been created expose and allow read access for the user on the ACS Snapshots taken by the agent  