### PR TITLE
DEPLOY-563: Stable Infrastructure Chart for ACS 6.1 (with ActiveMQ)

### DIFF
--- a/helm/alfresco-content-services/templates/config-repository.yaml
+++ b/helm/alfresco-content-services/templates/config-repository.yaml
@@ -46,7 +46,7 @@ data:
       -Dmessaging.broker.username={{ index .Values "alfresco-infrastructure" "activemq" "adminUser" "username" }}
       -Dmessaging.broker.password={{ index .Values "alfresco-infrastructure" "activemq" "adminUser" "password" }}
       {{- else }}
-      -Dmessaging.broker.url={{ .Values.messageBroker.url }}
+      -Dmessaging.broker.url={{ .Values.messageBroker.url | default (printf "failover:(nio://%s-activemq-broker:61616)?timeout=3000&jms.useCompression=true" .Release.Name)}}
       -Dmessaging.broker.username={{ .Values.messageBroker.user }}
       -Dmessaging.broker.password={{ .Values.messageBroker.password }}
       {{- end }}"

--- a/helm/alfresco-content-services/templates/config-transform-router.yaml
+++ b/helm/alfresco-content-services/templates/config-transform-router.yaml
@@ -14,7 +14,7 @@ data:
   ACTIVEMQ_USER: {{ index .Values "alfresco-infrastructure" "activemq" "adminUser" "username" }}
   ACTIVEMQ_PASSWORD: {{ index .Values "alfresco-infrastructure" "activemq" "adminUser" "password" }}
   {{- else }}
-  ACTIVEMQ_URL: {{ .Values.messageBroker.url }}
+  ACTIVEMQ_URL: {{ .Values.messageBroker.url | default (printf "nio://%s-activemq-broker:61616" .Release.Name ) }}
   ACTIVEMQ_USER: {{ .Values.messageBroker.user }}
   ACTIVEMQ_PASSWORD: {{ .Values.messageBroker.password }}
   {{- end }}


### PR DESCRIPTION
DBP chart brings its own Alfresco Infrastructure. So when we bring in the ACS chart we disable the requirement to bring another Infrastructure Chart. 
We need a default for message broker URL property to pick up the ActiveMq service that comes with DBP's Alfresco Infrastructure. 