### PR TITLE
REPO-3934: ACS 6.1: Release RC1

### DIFF
--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -14,7 +14,7 @@ version: "2"
 
 services:
     alfresco:
-        image: alfresco/alfresco-content-repository:6.1.0-EA3
+        image: alfresco/alfresco-content-repository:6.1.0-RC1
         mem_limit: 1200m
         environment:
             JAVA_OPTS: "
@@ -106,7 +106,7 @@ services:
             - shared-file-store-volume:/tmp/Alfresco/sfs
 
     share:
-        image: alfresco/alfresco-share:6.0
+        image: alfresco/alfresco-share:6.1.0-RC1
         mem_limit: 1g
         environment:
             REPO_HOST: "alfresco"

--- a/helm/alfresco-content-services/Chart.yaml
+++ b/helm/alfresco-content-services/Chart.yaml
@@ -3,7 +3,7 @@
 # Request an extended 30-day trial at https://www.alfresco.com/platform/content-services-ecm/trial/docker
 name: alfresco-content-services
 version: 1.1.5
-appVersion: 6.1.0-EA3
+appVersion: 6.1.0-RC1
 description: A Helm chart for deploying Alfresco Content Services
 keywords:
 - content

--- a/helm/alfresco-content-services/values.yaml
+++ b/helm/alfresco-content-services/values.yaml
@@ -13,7 +13,7 @@ repository:
   replicaCount: 2
   image:
     repository: alfresco/alfresco-content-repository
-    tag: "6.1.0-EA3"
+    tag: "6.1.0-RC1"
     pullPolicy: Always
     internalPort: 8080
     hazelcastPort: 5701
@@ -246,7 +246,7 @@ share:
   replicaCount: 1
   image:
     repository: alfresco/alfresco-share
-    tag: "6.0"
+    tag: "6.1.0-RC1"
     pullPolicy: Always
     internalPort: 8080
   service:


### PR DESCRIPTION
- update alfresco-content-repository and alfresco-share image for 6.1.0-RC1 release