### PR TITLE
WIP: Experiment: SEARCH-1305: speedup packaging of Helm chart on dev environment

### DIFF
--- a/helm/alfresco-content-services/.cmd/new-version.sh
+++ b/helm/alfresco-content-services/.cmd/new-version.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+if [ $# -lt 1 ]; then
+   echo "Please pass the current version as first parameter so I can generate the new version!" 
+   echo "Example: $ $0 0.0.2 #will generate 0.0.3" 
+   exit 1 
+fi
+set -e
+echo $1 | awk -F. -v OFS=. 'NF==1{print ++$NF}; NF>1{if(length($NF+1)>length($NF))$(NF-1)++; $NF=sprintf("%0*d", length($NF), ($NF+1)%(10^length($NF))); print}'

--- a/helm/alfresco-content-services/.cmd/serve-helm.sh
+++ b/helm/alfresco-content-services/.cmd/serve-helm.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# this will serve the charts created locally
+kill $(pgrep helm) # kill the helm repo if is opened
+helm serve &
+HELM_PID=$!
+echo "Serving local charts using helm, on PID:$HELM_PID"

--- a/helm/alfresco-content-services/Makefile
+++ b/helm/alfresco-content-services/Makefile
@@ -20,7 +20,7 @@ package: build
 	helm init --client-only
 	helm package .	
 	helm search local/$(NAME) -l
-	rm -rf ${NAME}*.tgz%	
+	rm -rf ${NAME}*.tgz	
 
 tag:
 ifeq ($(OS),Darwin)

--- a/helm/alfresco-content-services/Makefile
+++ b/helm/alfresco-content-services/Makefile
@@ -1,0 +1,44 @@
+OS := $(shell uname)
+
+NAME := $(shell sed -n 's/^name: //p' Chart.yaml)
+CURRENT_VERSION := $(shell sed -n 's/^version: //p' Chart.yaml)
+RELEASE_VERSION := $(shell .cmd/new-version.sh $(CURRENT_VERSION))
+
+build: clean
+	rm -rf requirements.lock
+	helm dependency build
+	helm lint
+
+clean:
+	rm -rf charts
+	rm -rf ${NAME}*.tgz
+
+# this will clean build and package your helm chart
+# it will also save it to your local helm repository
+# you can serve it using: $ helm serve (or calling: $ make local-repo)
+package: build	
+	helm init --client-only
+	helm package .	
+	helm search local/$(NAME) -l
+	rm -rf ${NAME}*.tgz%
+
+tag:
+ifeq ($(OS),Darwin)
+	sed -i "" -e "s/version:.*/version: $(RELEASE_VERSION)/" Chart.yaml
+	sed -i "" -e "s/tag: .*/tag: $(RELEASE_VERSION)/" values.yaml
+else ifeq ($(OS),Linux)
+	sed -i -e "s/version:.*/version: $(RELEASE_VERSION)/" Chart.yaml	
+	sed -i -e "s/tag: .*/tag: $(RELEASE_VERSION)/" values.yaml
+else
+	echo "platfrom $(OS) not supported to release from"
+	exit -1
+endif
+
+release-tag:	
+	git add --all
+	git commit -m "release $(NAME) v.$(RELEASE_VERSION) chart" --allow-empty # if first release then no verion update is performed
+	git tag -fa v$(RELEASE_VERSION) -m "Release version $(RELEASE_VERSION)"
+	git push origin v$(RELEASE_VERSION)
+
+local-repo:
+	.cmd/serve-helm.sh

--- a/helm/alfresco-content-services/Makefile
+++ b/helm/alfresco-content-services/Makefile
@@ -20,15 +20,13 @@ package: build
 	helm init --client-only
 	helm package .	
 	helm search local/$(NAME) -l
-	rm -rf ${NAME}*.tgz%
+	rm -rf ${NAME}*.tgz%	
 
 tag:
 ifeq ($(OS),Darwin)
-	sed -i "" -e "s/version:.*/version: $(RELEASE_VERSION)/" Chart.yaml
-	sed -i "" -e "s/tag: .*/tag: $(RELEASE_VERSION)/" values.yaml
+	sed -i "" -e "s/version:.*/version: $(RELEASE_VERSION)/" Chart.yaml	
 else ifeq ($(OS),Linux)
-	sed -i -e "s/version:.*/version: $(RELEASE_VERSION)/" Chart.yaml	
-	sed -i -e "s/tag: .*/tag: $(RELEASE_VERSION)/" values.yaml
+	sed -i -e "s/version:.*/version: $(RELEASE_VERSION)/" Chart.yaml		
 else
 	echo "platfrom $(OS) not supported to release from"
 	exit -1


### PR DESCRIPTION
**Features:**
within "_helm/alfresco-content-services_" folder:
* ability to bump up the new release version automatically: `make tag` (and also push it to repository if we want `make release-tag`)
* ability to build or package the chart: `make package`
* ability to build or package the chart, not skipping the local helm repository: `make local-repo package`

**Note:**
You can mix the commands if you like: `make tag release-tag package` (this should auto-increment the version, commit the tag and push the updated Chart.yaml to repo
