### PR TITLE
ACE-5900: move ADW to the "/workspace" route

### DIFF
--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -160,9 +160,11 @@ services:
     digital-workspace:
         image: quay.io/alfresco/alfresco-digital-workspace:1.0.0
         mem_limit: 128m
+        environment:
+            BASEPATH: ./
 
     proxy:
-        image: quay.io/alfresco/alfresco-acs-nginx:1.0.0
+        image: quay.io/alfresco/alfresco-acs-nginx:2.0.0
         mem_limit: 128m
         depends_on:
             - alfresco
@@ -173,10 +175,6 @@ services:
             - digital-workspace
             - alfresco
             - share
-        # environment:
-        #     ADW_URL: "http://digital-workspace"
-        #     REPO_URL: "http://alfresco:8080"
-        #     SHARE_URL: "http://share:8080"
 
 volumes:
     shared-file-store-volume:


### PR DESCRIPTION
As per requests:

* move ADW to the "/workspace" root (see https://issues.alfresco.com/jira/browse/ACE-5900)
* expose ACS via the "/"
* remove old comments from the docker-compose