### PR TITLE
ACE-5924: disable access logging

### DIFF
--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -164,7 +164,7 @@ services:
             BASEPATH: ./
 
     proxy:
-        image: quay.io/alfresco/alfresco-acs-nginx:2.0.0
+        image: quay.io/alfresco/alfresco-acs-nginx:2.2.0
         mem_limit: 128m
         depends_on:
             - alfresco


### PR DESCRIPTION
- update proxy image to the latest version 2.2.0 that has access logs for nginx switched off
- the underlying ADW image has been updated to have access logs switched off too