### PR TITLE
ATS-216: Update helm chart reference deployment (on k8s) with 2 replicas

### DIFF
--- a/helm/alfresco-content-services/templates/deployment-filestore.yaml
+++ b/helm/alfresco-content-services/templates/deployment-filestore.yaml
@@ -24,6 +24,27 @@ spec:
       imagePullSecrets:
         - name: {{ .Values.registryPullSecrets }}
       {{- end }}
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 10
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - {{ template "alfresco.shortname" . }}-filestore
+              topologyKey: failure-domain.beta.kubernetes.io/zone
+          - weight: 5
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - {{ template "alfresco.shortname" . }}-filestore
+              topologyKey: kubernetes.io/hostname
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.filestore.image.repository }}:{{ .Values.filestore.image.tag }}"

--- a/helm/alfresco-content-services/templates/deployment-imagemagick.yaml
+++ b/helm/alfresco-content-services/templates/deployment-imagemagick.yaml
@@ -24,6 +24,27 @@ spec:
       imagePullSecrets:
         - name: {{ .Values.registryPullSecrets }}
       {{- end }}
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 10
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - {{ template "content-services.shortname" . }}-imagemagick
+              topologyKey: failure-domain.beta.kubernetes.io/zone
+          - weight: 5
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - {{ template "content-services.shortname" . }}-imagemagick
+              topologyKey: kubernetes.io/hostname
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.imagemagick.image.repository }}:{{ .Values.imagemagick.image.tag }}"

--- a/helm/alfresco-content-services/templates/deployment-libreoffice.yaml
+++ b/helm/alfresco-content-services/templates/deployment-libreoffice.yaml
@@ -24,6 +24,27 @@ spec:
       imagePullSecrets:
         - name: {{ .Values.registryPullSecrets }}
       {{- end }}
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 10
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - {{ template "content-services.shortname" . }}-libreoffice
+              topologyKey: failure-domain.beta.kubernetes.io/zone
+          - weight: 5
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - {{ template "content-services.shortname" . }}-libreoffice
+              topologyKey: kubernetes.io/hostname
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.libreoffice.image.repository }}:{{ .Values.libreoffice.image.tag }}"

--- a/helm/alfresco-content-services/templates/deployment-pdfrenderer.yaml
+++ b/helm/alfresco-content-services/templates/deployment-pdfrenderer.yaml
@@ -24,6 +24,27 @@ spec:
       imagePullSecrets:
         - name: {{ .Values.registryPullSecrets }}
       {{- end }}
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 10
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - {{ template "content-services.shortname" . }}-pdfrenderer
+              topologyKey: failure-domain.beta.kubernetes.io/zone
+          - weight: 5
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - {{ template "content-services.shortname" . }}-pdfrenderer
+              topologyKey: kubernetes.io/hostname
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.pdfrenderer.image.repository }}:{{ .Values.pdfrenderer.image.tag }}"

--- a/helm/alfresco-content-services/templates/deployment-tika.yaml
+++ b/helm/alfresco-content-services/templates/deployment-tika.yaml
@@ -24,6 +24,27 @@ spec:
       imagePullSecrets:
         - name: {{ .Values.registryPullSecrets }}
       {{- end }}
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 10
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - {{ template "content-services.shortname" . }}-tika
+              topologyKey: failure-domain.beta.kubernetes.io/zone
+          - weight: 5
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - {{ template "content-services.shortname" . }}-tika
+              topologyKey: kubernetes.io/hostname
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.tika.image.repository }}:{{ .Values.tika.image.tag }}"

--- a/helm/alfresco-content-services/templates/deployment-transform-router.yaml
+++ b/helm/alfresco-content-services/templates/deployment-transform-router.yaml
@@ -20,6 +20,27 @@ spec:
       # only set this secret if a private docker registry variable is defined
       imagePullSecrets:
         - name: {{ .Values.registryPullSecrets }}
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 10
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - {{ template "alfresco.shortname" . }}-router
+              topologyKey: failure-domain.beta.kubernetes.io/zone
+          - weight: 5
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - {{ template "alfresco.shortname" . }}-router
+              topologyKey: kubernetes.io/hostname
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.transformrouter.image.repository }}:{{ .Values.transformrouter.image.tag }}"

--- a/helm/alfresco-content-services/values.yaml
+++ b/helm/alfresco-content-services/values.yaml
@@ -56,7 +56,7 @@ apiexplorer:
     path: /api-explorer
 
 transformrouter:
-  replicaCount: 1
+  replicaCount: 2
   image:
     repository: quay.io/alfresco/alfresco-transform-router
     tag: "0.4.0-RC"
@@ -80,7 +80,7 @@ transformrouter:
 # Declares the alfresco-pdf-renderer service used by the content repository
 # to transform pdf files
 pdfrenderer:
-  replicaCount: 1
+  replicaCount: 2
   image:
     repository: quay.io/alfresco/alfresco-pdf-renderer
     tag: "2.0.7"
@@ -113,7 +113,7 @@ pdfrenderer:
 # Declares the alfresco-imagemagick service used by the content repository
 # to transform image files
 imagemagick:
-  replicaCount: 1
+  replicaCount: 2
   image:
     repository: quay.io/alfresco/alfresco-imagemagick
     tag: "2.0.7"
@@ -146,7 +146,7 @@ imagemagick:
 # Declares the alfresco-libreoffice service used by the content repository
 # to transform office files
 libreoffice:
-  replicaCount: 1
+  replicaCount: 2
   image:
     repository: quay.io/alfresco/alfresco-libreoffice
     tag: "2.0.7"
@@ -179,7 +179,7 @@ libreoffice:
 # Declares the alfresco-tika service used by the content repository
 # to transform office files
 tika:
-  replicaCount: 1
+  replicaCount: 2
   image:
     repository: quay.io/alfresco/alfresco-tika
     tag: "2.0.7"


### PR DESCRIPTION
- update replicaCount from 1 to 2 for T-Router and T-Engines
- keep only 1 replica for Shared File Store (in case EFS is not enabled)
- update pod scheduling for different Availability Zones and K8s nodes