### PR TITLE
Global ACS Ingress configuration Helm values

### DIFF
--- a/helm/alfresco-content-services/templates/ingress-repository.yaml
+++ b/helm/alfresco-content-services/templates/ingress-repository.yaml
@@ -15,16 +15,33 @@ metadata:
       location ~ ^(/.*/s/api/solr/.*)$ {return 403;}
       location ~ ^(/.*/wcservice/api/solr/.*)$ {return 403;}
       location ~ ^(/.*/wcs/api/solr/.*)$ {return 403;}
+    # Global ingress annotations to be combined with specific ingress annotations 
+    {{- range $key, $value := .Values.global.acs.ingress.annotations }}
+    {{ $key }}: {{ tpl $value $ | quote }}
+    {{- end }}
 
 spec:
   rules:
-  - http:
-      paths:
-      - path: {{ .Values.repository.ingress.path }}
-        backend:
-          serviceName: {{ template "content-services.shortname" . }}-repository
-          servicePort: {{ .Values.repository.service.externalPort }}
-      - path: {{ .Values.apiexplorer.ingress.path }}
-        backend:
-          serviceName: {{ template "content-services.shortname" . }}-repository
-          servicePort: {{ .Values.repository.service.externalPort }}
+    {{- if .Values.global.acs.ingress.hostName }}
+    - host: {{ tpl .Values.global.acs.ingress.hostName $ | quote }}
+      http:
+    {{- else }}
+    - http:
+    {{- end }} 
+        paths:
+        - path: {{ .Values.repository.ingress.path }}
+          backend:
+            serviceName: {{ template "content-services.shortname" . }}-repository
+            servicePort: {{ .Values.repository.service.externalPort }}
+        - path: {{ .Values.apiexplorer.ingress.path }}
+          backend:
+            serviceName: {{ template "content-services.shortname" . }}-repository
+            servicePort: {{ .Values.repository.service.externalPort }}
+  {{- if .Values.global.acs.ingress.tls }}
+  tls:
+    - secretName: {{ tpl .Values.global.acs.ingress.tlsSecretName $ }}
+      {{- if .Values.global.acs.ingress.hostName }}
+      hosts:
+        - {{ tpl .Values.global.acs.ingress.hostName $ | quote }}
+      {{- end }}
+  {{- end }}

--- a/helm/alfresco-content-services/templates/ingress-share.yaml
+++ b/helm/alfresco-content-services/templates/ingress-share.yaml
@@ -10,12 +10,29 @@ metadata:
     nginx.ingress.kubernetes.io/configuration-snippet: |
       location ~ ^(/.*/proxy/alfresco/api/solr/.*)$ {return 403 ;}
                   location ~ ^(/.*/-default-/proxy/alfresco/api/.*)$ {return 403;}
-    
+    # Global ingress annotations to be combined with specific ingress annotations 
+    {{- range $key, $value := .Values.global.acs.ingress.annotations }}
+    {{ $key }}: {{ tpl $value $ | quote }}
+    {{- end }}
+
 spec:
   rules:
-  - http:
-      paths:
-      - path: {{ .Values.share.ingress.path }}
-        backend:
-          serviceName: {{ template "content-services.shortname" . }}-share
-          servicePort: {{ .Values.share.service.externalPort }}
+    {{- if .Values.global.acs.ingress.hostName }}
+    - host: {{ tpl .Values.global.acs.ingress.hostName $ | quote }}
+      http:
+    {{- else }}
+    - http:
+    {{- end }} 
+        paths:
+        - path: {{ .Values.share.ingress.path }}
+          backend:
+            serviceName: {{ template "content-services.shortname" . }}-share
+            servicePort: {{ .Values.share.service.externalPort }}
+  {{- if .Values.global.acs.ingress.tls }}
+  tls:
+    - secretName: {{ tpl .Values.global.acs.ingress.tlsSecretName $ }}
+      {{- if .Values.global.acs.ingress.hostName }}
+      hosts:
+        - {{ tpl .Values.global.acs.ingress.hostName $ | quote }}
+      {{- end }}
+  {{- end }}

--- a/helm/alfresco-content-services/values.yaml
+++ b/helm/alfresco-content-services/values.yaml
@@ -9,6 +9,14 @@
 # If container memory is not explicitly set, then the above flags will default max heap to 1/4th of container's memory which may not be ideal.
 # Hence, setting up explicit Container memory and then assigning a percentage of it to the JVM for performance tuning.
 
+global:
+  acs: 
+    ingress:
+      hostName: # configure host name for all acs ingresses, i.e. {{ .Release.Name }}.domain.com
+      tls: # true | false 
+      tlsSecretName: # specify tls secret name, .i.e. "tls-{{ .Release.Name }}-acs"
+      annotations: [] # customize global ingress annotations, i.e. certmanager.k8s.io/issuer: letsencrypt-prod, kubernetes.io/tls-acme: "true" 
+
 repository:
   replicaCount: 2
   image:

--- a/helm/alfresco-content-services/values.yaml
+++ b/helm/alfresco-content-services/values.yaml
@@ -31,7 +31,7 @@ repository:
     externalPort: &repositoryExternalPort 80
   ingress:
     path: /
-    maxUploadSize: "5g"
+    maxUploadSize: "5000m"
   environment:
     JAVA_OPTS: " -Dsolr.base.url=/solr
       -Dsolr.secureComms=none


### PR DESCRIPTION
This PR provides support for global ACS ingress configuration via Helm values and includes:

* fix: configure global values for ingress hostName, tls, secret, annotations 
* fix: replace maxUploadSize with 5000m (5g does not work in EKS)
