### PR TITLE
REPO-4145 : Helm Chart does not start if alfresco-search is disabled

### DIFF
--- a/helm/alfresco-content-services/templates/Rule_04-network-policy-repository.yaml
+++ b/helm/alfresco-content-services/templates/Rule_04-network-policy-repository.yaml
@@ -18,10 +18,12 @@ spec:
           matchLabels:
             app: nginx-ingress
 
+      {{- if index .Values "alfresco-search" "enabled" }}
       # Allow traffic from search
       - podSelector:
           matchLabels:
-            app: {{ template "alfresco-search.host" . }}
+            app:  {{ template "alfresco-search.host" . }}
+      {{ end }}
 
       # Allow traffic from share
       - podSelector:
@@ -70,11 +72,13 @@ spec:
       - podSelector:
           matchLabels:
              app: {{ template "content-services.shortname" . }}-repository
-      
+
+      {{ if index .Values "alfresco-search" "enabled" }}
       # Search (solr)
       - podSelector:
           matchLabels:
-             app: {{ template "alfresco-search.host" . }}
+             app:  {{ template "alfresco-search.host" . }}
+      {{ end }}
 
       # Share
       - podSelector:

--- a/helm/alfresco-content-services/templates/Rule_04-network-policy-repository.yaml
+++ b/helm/alfresco-content-services/templates/Rule_04-network-policy-repository.yaml
@@ -23,7 +23,7 @@ spec:
       - podSelector:
           matchLabels:
             app:  {{ template "alfresco-search.host" . }}
-      {{ end }}
+      {{- end }}
 
       # Allow traffic from share
       - podSelector:
@@ -73,12 +73,12 @@ spec:
           matchLabels:
              app: {{ template "content-services.shortname" . }}-repository
 
-      {{ if index .Values "alfresco-search" "enabled" }}
+      {{- if index .Values "alfresco-search" "enabled" }}
       # Search (solr)
       - podSelector:
           matchLabels:
              app:  {{ template "alfresco-search.host" . }}
-      {{ end }}
+      {{- end }}
 
       # Share
       - podSelector:

--- a/helm/alfresco-content-services/templates/Rule_05-network-policy-search.yaml
+++ b/helm/alfresco-content-services/templates/Rule_05-network-policy-search.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.networkpolicysetting.enabled }}
+{{- if index .Values "alfresco-search" "enabled" }}
 # Allow search communication with other components
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -56,4 +57,5 @@ spec:
       ports:
       - protocol: TCP
         port: 2049
+{{- end }}
 {{- end }}

--- a/helm/alfresco-content-services/templates/config-repository.yaml
+++ b/helm/alfresco-content-services/templates/config-repository.yaml
@@ -39,10 +39,11 @@ data:
       {{- if index .Values "alfresco-search" "enabled" }}
       -Dsolr.host={{ template "alfresco-search.host" . }}
       -Dsolr.port={{ template "alfresco-search.port" . }}
-      {{- end }}
+      {{- else }}
       {{- if index .Values "alfresco-search" "external" }}
       -Dsolr.host={{ index .Values "alfresco-search" "external" "host" }}
       -Dsolr.port={{ index .Values "alfresco-search" "external" "port" }}
+      {{- end }}
       {{- end }}
       -Dalfresco-pdf-renderer.url=http://{{ template "content-services.shortname" . }}-pdfrenderer
       -Dimg.url=http://{{ template "content-services.shortname" . }}-imagemagick

--- a/helm/alfresco-content-services/templates/config-repository.yaml
+++ b/helm/alfresco-content-services/templates/config-repository.yaml
@@ -35,9 +35,13 @@ data:
       -Dshare.protocol={{ .Values.externalProtocol | default "http"}}
       -Dshare.host={{ .Values.externalHost | default (printf "%s-share" (include "content-services.shortname" .)) }}
       -Dshare.port={{ .Values.externalPort | default .Values.share.service.externalPort }}
-      -Dalfresco_user_store.adminpassword={{ .Values.repository.adminPassword | default "209c6174da490caeb422f3fa5a7ae634" }}
+      -Dalfresco_user_store.adminpassword={{ .Values.repository.adminPassword | default "209c6174da490caeb422f3fa5a7ae634" }} {{ if index .Values "alfresco-search" "enabled" }}
       -Dsolr.host={{ template "alfresco-search.host" . }}
       -Dsolr.port={{ template "alfresco-search.port" . }}
+      {{ end }} {{ if index .Values "alfresco-search" "external" }}
+      -Dsolr.host={{ index .Values "alfresco-search" "external" "host" }}
+      -Dsolr.port={{ index .Values "alfresco-search" "external" "port" }}
+      {{ end }}
       -Dalfresco-pdf-renderer.url=http://{{ template "content-services.shortname" . }}-pdfrenderer
       -Dimg.url=http://{{ template "content-services.shortname" . }}-imagemagick
       -Djodconverter.url=http://{{ template "content-services.shortname" . }}-libreoffice

--- a/helm/alfresco-content-services/templates/config-repository.yaml
+++ b/helm/alfresco-content-services/templates/config-repository.yaml
@@ -35,13 +35,15 @@ data:
       -Dshare.protocol={{ .Values.externalProtocol | default "http"}}
       -Dshare.host={{ .Values.externalHost | default (printf "%s-share" (include "content-services.shortname" .)) }}
       -Dshare.port={{ .Values.externalPort | default .Values.share.service.externalPort }}
-      -Dalfresco_user_store.adminpassword={{ .Values.repository.adminPassword | default "209c6174da490caeb422f3fa5a7ae634" }} {{ if index .Values "alfresco-search" "enabled" }}
+      -Dalfresco_user_store.adminpassword={{ .Values.repository.adminPassword | default "209c6174da490caeb422f3fa5a7ae634" }}
+      {{- if index .Values "alfresco-search" "enabled" }}
       -Dsolr.host={{ template "alfresco-search.host" . }}
       -Dsolr.port={{ template "alfresco-search.port" . }}
-      {{ end }} {{ if index .Values "alfresco-search" "external" }}
+      {{- end }}
+      {{- if index .Values "alfresco-search" "external" }}
       -Dsolr.host={{ index .Values "alfresco-search" "external" "host" }}
       -Dsolr.port={{ index .Values "alfresco-search" "external" "port" }}
-      {{ end }}
+      {{- end }}
       -Dalfresco-pdf-renderer.url=http://{{ template "content-services.shortname" . }}-pdfrenderer
       -Dimg.url=http://{{ template "content-services.shortname" . }}-imagemagick
       -Djodconverter.url=http://{{ template "content-services.shortname" . }}-libreoffice

--- a/helm/alfresco-content-services/templates/ingress-repository.yaml
+++ b/helm/alfresco-content-services/templates/ingress-repository.yaml
@@ -10,11 +10,13 @@ metadata:
     nginx.ingress.kubernetes.io/session-cookie-hash: "sha1"
     # Default file limit (1m) check, document(s) above this size will throw 413 (Request Entity Too Large) error
     nginx.ingress.kubernetes.io/proxy-body-size: {{ .Values.repository.ingress.maxUploadSize }}
+    {{- if index .Values "alfresco-search" "enabled" }}
     nginx.ingress.kubernetes.io/configuration-snippet: |
       location ~ ^(/.*/service/api/solr/.*)$ {return 403;}
       location ~ ^(/.*/s/api/solr/.*)$ {return 403;}
       location ~ ^(/.*/wcservice/api/solr/.*)$ {return 403;}
       location ~ ^(/.*/wcs/api/solr/.*)$ {return 403;}
+    {{ end }}
 
 spec:
   rules:

--- a/helm/alfresco-content-services/templates/ingress-repository.yaml
+++ b/helm/alfresco-content-services/templates/ingress-repository.yaml
@@ -16,7 +16,7 @@ metadata:
       location ~ ^(/.*/s/api/solr/.*)$ {return 403;}
       location ~ ^(/.*/wcservice/api/solr/.*)$ {return 403;}
       location ~ ^(/.*/wcs/api/solr/.*)$ {return 403;}
-    {{ end }}
+    {{- end }}
 
 spec:
   rules:

--- a/helm/alfresco-content-services/values.yaml
+++ b/helm/alfresco-content-services/values.yaml
@@ -307,7 +307,7 @@ alfresco-infrastructure:
     enabled: false
 
 alfresco-search:
-  enabled: false
+  enabled: true
 # If enabled is set to false, then external host and port need to point to the external instance of SOLR6, and in this case:
 # Note: Rule_05-network-policy-search will be disable.
 # Note: Rule_04-network-policy-repository internal trafic to SOLR6 instance will be disabled.

--- a/helm/alfresco-content-services/values.yaml
+++ b/helm/alfresco-content-services/values.yaml
@@ -307,7 +307,16 @@ alfresco-infrastructure:
     enabled: false
 
 alfresco-search:
-  enabled: true
+  enabled: false
+# If enabled is set to false, then external host and port need to point to the external instance of SOLR6, and in this case:
+# Note: Rule_05-network-policy-search will be disable.
+# Note: Rule_04-network-policy-repository internal trafic to SOLR6 instance will be disabled.
+# Note: ingress-repository will not block external trafic to */solr/*
+#  external: 
+    # Host dns/ip of the external solr6 instance.
+#    host: "127.0.0.1"
+    # Port of the external solr6 instance.
+#    port: "8983"
   repository: &repositoryHostPort 
     # The value for "host" is the name of this chart
     host: alfresco-cs


### PR DESCRIPTION
   Add external host and port for search in values.yaml
   If alfresco-search chart is not enabled, add if-else-end clause to config-repository.yaml to skip adding solr.host and solr.port from alfresco-search charts (null value)
   If alfresco-search chart is not enabled, add if-else-end clause to config-repository.yaml to add external values (if uncommented)
   If alfresco-search chart is not enabled, disable ingress trafic restriction to */solr/*
   If alfresco-search chart is not enabled, disable search network policy
   If alfresco-search chart is not enabled, disable trafic from in-cluster search pod.