### PR TITLE
ATS-380 : Update AWS image tags for the AI 1.0.0 amps

### DIFF
--- a/helm/alfresco-content-services/ai-reference-values.yaml
+++ b/helm/alfresco-content-services/ai-reference-values.yaml
@@ -1,12 +1,12 @@
 repository:
   image:
     repository: quay.io/alfresco/alfresco-content-repository-aws
-    tag: "6.1.0-AI-0.4.0"
+    tag: "6.1.0.2"
 
 share:
   image:
     repository: quay.io/alfresco/alfresco-share-aws
-    tag: "6.1.0-AI-0.4.0"
+    tag: "6.1.0.1"
 
 ai:
   enabled: true


### PR DESCRIPTION
Update the AI reference values (image tags) with:
- **alfresco-content-repository-aws:6.1.0.2**
_and_
- **alfresco-share-aws:6.1.0.1**