### PR TITLE
add support for extra ingress annotations

### DIFF
--- a/helm/alfresco-content-services/templates/ingress-repository.yaml
+++ b/helm/alfresco-content-services/templates/ingress-repository.yaml
@@ -3,6 +3,12 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ template "content-services.shortname" . }}-repository
+  labels:
+    app: {{ template "content-services.shortname" . }}-repository
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    component: repository
   annotations:
     kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/affinity: "cookie"
@@ -17,6 +23,9 @@ metadata:
       location ~ ^(/.*/wcservice/api/solr/.*)$ {return 403;}
       location ~ ^(/.*/wcs/api/solr/.*)$ {return 403;}
     {{- end }}
+{{- if .Values.repository.ingress.annotations }}
+{{ toYaml .Values.repository.ingress.annotations | indent 4 }}
+{{- end }}
 
 spec:
   rules:

--- a/helm/alfresco-content-services/templates/ingress-share.yaml
+++ b/helm/alfresco-content-services/templates/ingress-share.yaml
@@ -3,6 +3,12 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ template "content-services.shortname" . }}-share
+  labels:
+    app: {{ template "content-services.shortname" . }}-share
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    component: share
   annotations:
     kubernetes.io/ingress.class: "nginx"
     # Default limit is 1m, document(s) above this size will throw 413 (Request Entity Too Large) error
@@ -10,7 +16,10 @@ metadata:
     nginx.ingress.kubernetes.io/configuration-snippet: |
       location ~ ^(/.*/proxy/alfresco/api/solr/.*)$ {return 403 ;}
                   location ~ ^(/.*/-default-/proxy/alfresco/api/.*)$ {return 403;}
-    
+{{- if .Values.share.ingress.annotations }}
+{{ toYaml .Values.share.ingress.annotations | indent 4 }}
+{{- end }}
+
 spec:
   rules:
   {{- if .Values.share.ingress.hostName }}

--- a/helm/alfresco-content-services/values.yaml
+++ b/helm/alfresco-content-services/values.yaml
@@ -24,6 +24,8 @@ repository:
   ingress:
     path: /
     maxUploadSize: "5g"
+    annotations: {}
+      # nginx.ingress.kubernetes.io/enable-cors: "true"
   environment:
     JAVA_OPTS: " -Dsolr.base.url=/solr
       -Dsolr.secureComms=none
@@ -288,6 +290,7 @@ share:
     externalPort: 80
   ingress:
     path: /share
+    annotations: {}
   resources:
     requests:
       memory: "2000Mi"


### PR DESCRIPTION
allows customising the annotations on the ingress of repository and share if required, for example to enable cors