### PR TITLE
multiple instances support

### DIFF
--- a/helm/alfresco-content-services/requirements.yaml
+++ b/helm/alfresco-content-services/requirements.yaml
@@ -10,8 +10,8 @@ dependencies:
   repository: https://kubernetes-charts.storage.googleapis.com/
   condition: postgresql.enabled
 - name: alfresco-search
-  version: 0.0.11
-  repository: https://kubernetes-charts.alfresco.com/stable
+  version: 0.0.12
+  repository: https://kubernetes-charts.alfresco.com/incubator
   condition: alfresco-search.enabled
 - name: alfresco-infrastructure
   version: 4.1.0

--- a/helm/alfresco-content-services/templates/Rule_04-network-policy-repository.yaml
+++ b/helm/alfresco-content-services/templates/Rule_04-network-policy-repository.yaml
@@ -22,7 +22,7 @@ spec:
       # Allow traffic from search
       - podSelector:
           matchLabels:
-            app:  {{ template "alfresco-search.host" . }}
+            app:  {{ template "alfresco-content-services.alfresco-search.host" . }}
       {{- end }}
 
       # Allow traffic from share
@@ -77,7 +77,7 @@ spec:
       # Search (solr)
       - podSelector:
           matchLabels:
-             app:  {{ template "alfresco-search.host" . }}
+             app:  {{ template "alfresco-content-services.alfresco-search.host" . }}
       {{- end }}
 
       # Share

--- a/helm/alfresco-content-services/templates/Rule_05-network-policy-search.yaml
+++ b/helm/alfresco-content-services/templates/Rule_05-network-policy-search.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      app: {{ template "alfresco-search.host" . }}
+      app: {{ template "alfresco-content-services.alfresco-search.host" . }}
   policyTypes:
   - Ingress
   - Egress
@@ -27,7 +27,7 @@ spec:
       # Allow Search to access itself
       - podSelector:
           matchLabels:
-            app: {{ template "alfresco-search.host" . }}
+            app: {{ template "alfresco-content-services.alfresco-search.host" . }}
 
       ports:
         - protocol: TCP
@@ -48,7 +48,7 @@ spec:
       # Allow Search to access itself
       - podSelector:
           matchLabels:
-            app: {{ template "alfresco-search.host" . }}
+            app: {{ template "alfresco-content-services.alfresco-search.host" . }}
 
     # Allow DB to communicate with EFS
     - to:

--- a/helm/alfresco-content-services/templates/_helpers.tpl
+++ b/helm/alfresco-content-services/templates/_helpers.tpl
@@ -22,3 +22,13 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- $name := include "activemq.fullname" $context -}}
 {{- printf "nio://%s-broker:61616" $name }}
 {{- end -}}
+
+{{- define "alfresco-content-services.alfresco-search.host" -}}
+{{- $context := dict "Chart" (dict "Name" "alfresco-search") "Release" .Release "Values" (index .Values "alfresco-search") -}}
+{{- include "alfresco-search.host" $context -}}
+{{- end -}}
+
+{{- define "alfresco-content-services.alfresco-search.port" -}}
+{{- $context := dict "Chart" (dict "Name" "alfresco-search") "Release" .Release "Values" (index .Values "alfresco-search") -}}
+{{- index $context "service" "externalPort" -}}
+{{- end -}}

--- a/helm/alfresco-content-services/templates/_helpers.tpl
+++ b/helm/alfresco-content-services/templates/_helpers.tpl
@@ -16,3 +16,9 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- $name := (.Values.nameOverride | default (printf "%s" "alfresco-")) -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{- define "alfresco-content-services.activemq.url" -}}
+{{- $context := dict "Chart" (dict "Name" "activemq") "Release" .Release "Values" (index .Values "alfresco-infrastructure" "activemq") -}}
+{{- $name := include "activemq.fullname" $context -}}
+{{- printf "nio://%s-broker:61616" $name }}
+{{- end -}}

--- a/helm/alfresco-content-services/templates/config-ai-transformer.yaml
+++ b/helm/alfresco-content-services/templates/config-ai-transformer.yaml
@@ -17,11 +17,11 @@ data:
   {{- end }}
   {{- end }}
   {{- if index .Values "alfresco-infrastructure" "activemq" "enabled" }}
-  ACTIVEMQ_URL: nio://{{ .Release.Name }}-activemq-broker:61616
+  ACTIVEMQ_URL: {{ template "alfresco-content-services.activemq.url" . }}
   ACTIVEMQ_USER: {{ index .Values "alfresco-infrastructure" "activemq" "adminUser" "username" }}
   ACTIVEMQ_PASSWORD: {{ index .Values "alfresco-infrastructure" "activemq" "adminUser" "password" }}
   {{- else }}
-  ACTIVEMQ_URL: {{ .Values.messageBroker.url | default (printf "nio://%s-activemq-broker:61616" .Release.Name ) }}
+  ACTIVEMQ_URL: {{ .Values.messageBroker.url | default (include "alfresco-content-services.activemq.url" .) }}
   ACTIVEMQ_USER: {{ .Values.messageBroker.user }}
   ACTIVEMQ_PASSWORD: {{ .Values.messageBroker.password }}
   {{- end }}

--- a/helm/alfresco-content-services/templates/config-imagemagick.yaml
+++ b/helm/alfresco-content-services/templates/config-imagemagick.yaml
@@ -16,11 +16,11 @@ data:
   {{- end }}
   {{- end }}
   {{- if index .Values "alfresco-infrastructure" "activemq" "enabled" }}
-  ACTIVEMQ_URL: nio://{{ .Release.Name }}-activemq-broker:61616
+  ACTIVEMQ_URL: {{ template "alfresco-content-services.activemq.url" . }}
   ACTIVEMQ_USER: {{ index .Values "alfresco-infrastructure" "activemq" "adminUser" "username" }}
   ACTIVEMQ_PASSWORD: {{ index .Values "alfresco-infrastructure" "activemq" "adminUser" "password" }}
   {{- else }}
-  ACTIVEMQ_URL: {{ .Values.messageBroker.url | default (printf "nio://%s-activemq-broker:61616" .Release.Name ) }}
+  ACTIVEMQ_URL: {{ .Values.messageBroker.url | default (include "alfresco-content-services.activemq.url" .) }}
   ACTIVEMQ_USER: {{ .Values.messageBroker.user }}
   ACTIVEMQ_PASSWORD: {{ .Values.messageBroker.password }}
   {{- end }}

--- a/helm/alfresco-content-services/templates/config-libreoffice.yaml
+++ b/helm/alfresco-content-services/templates/config-libreoffice.yaml
@@ -16,11 +16,11 @@ data:
   {{- end }}
   {{- end }}
   {{- if index .Values "alfresco-infrastructure" "activemq" "enabled" }}
-  ACTIVEMQ_URL: nio://{{ .Release.Name }}-activemq-broker:61616
+  ACTIVEMQ_URL: {{ template "alfresco-content-services.activemq.url" . }}
   ACTIVEMQ_USER: {{ index .Values "alfresco-infrastructure" "activemq" "adminUser" "username" }}
   ACTIVEMQ_PASSWORD: {{ index .Values "alfresco-infrastructure" "activemq" "adminUser" "password" }}
   {{- else }}
-  ACTIVEMQ_URL: {{ .Values.messageBroker.url | default (printf "nio://%s-activemq-broker:61616" .Release.Name ) }}
+  ACTIVEMQ_URL: {{ .Values.messageBroker.url | default (include "alfresco-content-services.activemq.url" .) }}
   ACTIVEMQ_USER: {{ .Values.messageBroker.user }}
   ACTIVEMQ_PASSWORD: {{ .Values.messageBroker.password }}
   {{- end }}

--- a/helm/alfresco-content-services/templates/config-pdfrenderer.yaml
+++ b/helm/alfresco-content-services/templates/config-pdfrenderer.yaml
@@ -16,11 +16,11 @@ data:
   {{- end }}
   {{- end }}
   {{- if index .Values "alfresco-infrastructure" "activemq" "enabled" }}
-  ACTIVEMQ_URL: nio://{{ .Release.Name }}-activemq-broker:61616
+  ACTIVEMQ_URL: {{ template "alfresco-content-services.activemq.url" . }}
   ACTIVEMQ_USER: {{ index .Values "alfresco-infrastructure" "activemq" "adminUser" "username" }}
   ACTIVEMQ_PASSWORD: {{ index .Values "alfresco-infrastructure" "activemq" "adminUser" "password" }}
   {{- else }}
-  ACTIVEMQ_URL: {{ .Values.messageBroker.url | default (printf "nio://%s-activemq-broker:61616" .Release.Name ) }}
+  ACTIVEMQ_URL: {{ .Values.messageBroker.url | default (include "alfresco-content-services.activemq.url" .) }}
   ACTIVEMQ_USER: {{ .Values.messageBroker.user }}
   ACTIVEMQ_PASSWORD: {{ .Values.messageBroker.password }}
   {{- end }}

--- a/helm/alfresco-content-services/templates/config-repository.yaml
+++ b/helm/alfresco-content-services/templates/config-repository.yaml
@@ -56,11 +56,11 @@ data:
       {{- end }}
       -Dsfs.url=http://{{ template "alfresco.shortname" . }}-filestore:80
       {{- if index .Values "alfresco-infrastructure" "activemq" "enabled" }}
-      -Dmessaging.broker.url=failover:(nio://{{ .Release.Name }}-activemq-broker:61616)?timeout=3000&jms.useCompression=true
+      -Dmessaging.broker.url=failover:({{ template "alfresco-content-services.activemq.url" . }})?timeout=3000&jms.useCompression=true
       -Dmessaging.broker.username={{ index .Values "alfresco-infrastructure" "activemq" "adminUser" "username" }}
       -Dmessaging.broker.password={{ index .Values "alfresco-infrastructure" "activemq" "adminUser" "password" }}
       {{- else }}
-      -Dmessaging.broker.url={{ .Values.messageBroker.url | default (printf "failover:(nio://%s-activemq-broker:61616)?timeout=3000&jms.useCompression=true" .Release.Name)}}
+      -Dmessaging.broker.url={{ .Values.messageBroker.url | default (printf "failover:(%s)?timeout=3000&jms.useCompression=true" (include "alfresco-content-services.activemq.url" .))}}
       -Dmessaging.broker.username={{ .Values.messageBroker.user }}
       -Dmessaging.broker.password={{ .Values.messageBroker.password }}
       {{- end }}"

--- a/helm/alfresco-content-services/templates/config-repository.yaml
+++ b/helm/alfresco-content-services/templates/config-repository.yaml
@@ -37,7 +37,7 @@ data:
       -Dshare.port={{ .Values.externalPort | default .Values.share.service.externalPort }}
       -Dalfresco_user_store.adminpassword={{ .Values.repository.adminPassword | default "209c6174da490caeb422f3fa5a7ae634" }}
       {{- if index .Values "alfresco-search" "enabled" }}
-      -Dsolr.host={{ template "alfresco-search.host" . }}
+      -Dsolr.host={{ template "alfresco-content-services.alfresco-search.host" . }}
       -Dsolr.port={{ template "alfresco-search.port" . }}
       {{- else }}
       {{- if index .Values "alfresco-search" "external" }}

--- a/helm/alfresco-content-services/templates/config-tika.yaml
+++ b/helm/alfresco-content-services/templates/config-tika.yaml
@@ -16,11 +16,11 @@ data:
   {{- end }}
   {{- end }}
   {{- if index .Values "alfresco-infrastructure" "activemq" "enabled" }}
-  ACTIVEMQ_URL: nio://{{ .Release.Name }}-activemq-broker:61616
+  ACTIVEMQ_URL: {{ template "alfresco-content-services.activemq.url" . }}
   ACTIVEMQ_USER: {{ index .Values "alfresco-infrastructure" "activemq" "adminUser" "username" }}
   ACTIVEMQ_PASSWORD: {{ index .Values "alfresco-infrastructure" "activemq" "adminUser" "password" }}
   {{- else }}
-  ACTIVEMQ_URL: {{ .Values.messageBroker.url | default (printf "nio://%s-activemq-broker:61616" .Release.Name ) }}
+  ACTIVEMQ_URL: {{ .Values.messageBroker.url | default (include "alfresco-content-services.activemq.url" .) }}
   ACTIVEMQ_USER: {{ .Values.messageBroker.user }}
   ACTIVEMQ_PASSWORD: {{ .Values.messageBroker.password }}
   {{- end }}

--- a/helm/alfresco-content-services/templates/config-transform-router.yaml
+++ b/helm/alfresco-content-services/templates/config-transform-router.yaml
@@ -16,11 +16,11 @@ data:
   {{- end }}
   {{- end }}
   {{- if index .Values "alfresco-infrastructure" "activemq" "enabled" }}
-  ACTIVEMQ_URL: nio://{{ .Release.Name }}-activemq-broker:61616
+  ACTIVEMQ_URL: {{ template "alfresco-content-services.activemq.url" . }}
   ACTIVEMQ_USER: {{ index .Values "alfresco-infrastructure" "activemq" "adminUser" "username" }}
   ACTIVEMQ_PASSWORD: {{ index .Values "alfresco-infrastructure" "activemq" "adminUser" "password" }}
   {{- else }}
-  ACTIVEMQ_URL: {{ .Values.messageBroker.url | default (printf "nio://%s-activemq-broker:61616" .Release.Name ) }}
+  ACTIVEMQ_URL: {{ .Values.messageBroker.url | default (include "alfresco-content-services.activemq.url" .) }}
   ACTIVEMQ_USER: {{ .Values.messageBroker.user }}
   ACTIVEMQ_PASSWORD: {{ .Values.messageBroker.password }}
   {{- end }}

--- a/helm/alfresco-content-services/values.yaml
+++ b/helm/alfresco-content-services/values.yaml
@@ -336,7 +336,6 @@ alfresco-infrastructure:
     enabled: true
   alfresco-identity-service:
     enabled: false
-
 alfresco-search:
   enabled: true
 # If enabled is set to false, then external host and port need to point to the external instance of SOLR6, and in this case:
@@ -433,3 +432,7 @@ s3connector:
 # or uncomment the following line if you don't want/need to pass it as a parameter on every install command :
 # registryPullSecrets: private-repo-registry-secret
 # for more information: https://github.com/Alfresco/alfresco-anaxes-shipyard/blob/master/SECRETS.md
+messageBroker:
+  url:
+  user:
+  password:


### PR DESCRIPTION
allows having an umbrella chart that installs two instances of ACS with different aliases by using nameOverride on the required components in order to avoid a clash on service DNS names for activemq and search (solr)