### PR TITLE
fix: use templated external* values for repository and share configs

### DIFF
--- a/helm/alfresco-content-services/templates/NOTES.txt
+++ b/helm/alfresco-content-services/templates/NOTES.txt
@@ -1,12 +1,16 @@
 
 {{ if .Values.externalHost }}
-You can access all components of Alfresco Content Services using the same root address, but different paths as follows:
+{{ $alfhost := tpl .Values.externalHost $ }}
+{{ $alfprotocol := tpl (.Values.externalProtocol | default "http") $ }}
+{{ $alfport := tpl (.Values.externalPort | default .Values.repository.service.externalPort | toString ) $ }}
+{{ $alfurl := printf "%s://%s:%s" $alfprotocol $alfhost $alfport }}
+You can access all components of Alfresco Content Services Community using the same root address, but different paths as follows:
 
-  Share: {{ .Values.externalProtocol | default "http" }}://{{ .Values.externalHost }}:{{ .Values.externalPort | default .Values.repository.service.externalPort }}/share
-  Content: {{ .Values.externalProtocol | default "http" }}://{{ .Values.externalHost }}:{{ .Values.externalPort | default .Values.repository.service.externalPort }}/alfresco
-  Api-Explorer: {{ .Values.externalProtocol | default "http" }}://{{ .Values.externalHost }}:{{ .Values.externalPort | default .Values.repository.service.externalPort }}/api-explorer
-{{ if index .Values "alfresco-search" "ingress" "enabled" }}  Solr: {{ .Values.externalProtocol | default "http" }}://{{ .Values.externalHost }}:{{ .Values.externalPort | default .Values.repository.service.externalPort }}/solr {{ end }}
-{{ if (index .Values "alfresco-insight-zeppelin") }}{{ if (index .Values "alfresco-insight-zeppelin" "enabled") }}  Zeppelin: {{ .Values.externalProtocol | default "http" }}://{{ .Values.externalHost }}:{{ .Values.externalPort | default .Values.repository.service.externalPort }}/zeppelin {{ end }}{{ end }}  
+  Content: {{ $alfurl }}/alfresco
+  Share: {{ $alfurl }}/share
+  Api-Explorer: {{ $alfurl }}/api-explorer
+{{ if index .Values "alfresco-search" "ingress" "enabled" }}  Solr: {{ $alfurl }}/solr {{ end }}
+{{ if (index .Values "alfresco-insight-zeppelin") }}{{ if (index .Values "alfresco-insight-zeppelin" "enabled") }}  Zeppelin: {{ $alfurl }}/zeppelin {{ end }}{{ end }}  
 {{ else }}
 If you have a specific DNS address for the cluster please run the following commands to get the application paths and configure ACS:
 

--- a/helm/alfresco-content-services/templates/config-repository.yaml
+++ b/helm/alfresco-content-services/templates/config-repository.yaml
@@ -32,9 +32,9 @@ data:
       -Dcsrf.filter.origin={{ $alfprotocol }}://{{ $alfhost }}:{{ $alfport }}
       -Dcsrf.filter.referer={{ $alfprotocol }}://{{ $alfhost }}:{{ $alfport }}/.*
       {{ end }}
-      -Dshare.protocol={{ .Values.externalProtocol | default "http"}}
-      -Dshare.host={{ .Values.externalHost | default (printf "%s-share" (include "content-services.shortname" .)) }}
-      -Dshare.port={{ .Values.externalPort | default .Values.share.service.externalPort }}
+      -Dshare.protocol={{ tpl (.Values.externalProtocol | default "http") $ }}
+      -Dshare.host={{ tpl (.Values.externalHost | default (printf "%s-share" (include "content-services.shortname" .))) $ }}
+      -Dshare.port={{ tpl (.Values.externalPort | default .Values.share.service.externalPort | toString) $ }}
       -Dalfresco_user_store.adminpassword={{ .Values.repository.adminPassword | default "209c6174da490caeb422f3fa5a7ae634" }}
       {{- if index .Values "alfresco-search" "enabled" }}
       -Dsolr.host={{ template "alfresco-search.host" . }}

--- a/helm/alfresco-content-services/templates/config-share.yaml
+++ b/helm/alfresco-content-services/templates/config-share.yaml
@@ -11,6 +11,7 @@ metadata:
 data:
   {{ $alfhost := tpl (.Values.externalHost | default (printf "%s-share" (include "content-services.shortname" .))) $ }}
   {{ $alfprotocol := tpl (.Values.externalProtocol | default "http") $ }}
+  {{ $alfport := tpl (.Values.externalPort | default .Values.repository.service.externalPort | toString) $ }}
   # The CATALINA_OPTS defined in the values.yaml file for the "share" are set here using proper quotes
   {{- if .Values.share.environment }}
   {{- range $key, $val := .Values.share.environment }}
@@ -21,4 +22,4 @@ data:
   REPO_PORT: "{{ .Values.repository.service.externalPort }}"
   CSRF_FILTER_REFERER: "{{ $alfprotocol }}://{{ $alfhost }}/.*"
   CSRF_FILTER_ORIGIN: "{{ $alfprotocol }}://{{ $alfhost }}"
-  JAVA_OPTS: "-Dalfresco.proxy={{ .Values.externalProtocol | default "http" }}://{{ .Values.externalHost }}:{{ .Values.externalPort | default .Values.repository.service.externalPort }}"
+  JAVA_OPTS: "-Dalfresco.proxy={{ $alfprotocol }}://{{ $alfhost }}:{{ $alfport }}"


### PR DESCRIPTION
This PR fixes repository and share configs to support templated `externalHost`, `externalPort`, `externalProtocol` custom values required for AAE 7.1 deployment