### PR TITLE
fix: externalize initContainer Docker image repository and tag

### DIFF
--- a/helm/alfresco-content-services/templates/deployment-filestore.yaml
+++ b/helm/alfresco-content-services/templates/deployment-filestore.yaml
@@ -81,7 +81,7 @@ spec:
       {{- if .Values.persistence.filestore.enabled }}
       initContainers:
         - name: init-fs
-          image: busybox
+          image: "{{ .Values.filestore.initContainer.image.repository }}:{{ .Values.filestore.initContainer.image.tag }}"
           # command to allow sfs to write to EFS volume.
           command: ["sh", "-c", "chown -R 33030:1000 {{ .Values.persistence.filestore.data.mountPath }}"]
           volumeMounts:

--- a/helm/alfresco-content-services/templates/deployment-repository.yaml
+++ b/helm/alfresco-content-services/templates/deployment-repository.yaml
@@ -71,12 +71,12 @@ spec:
       {{- if eq .Values.database.external false }}
         # wait for the DB to startup before this deployment can start
         - name: init-db
-          image: busybox
+          image: "{{ .Values.repository.initContainer.image.repository }}:{{ .Values.repository.initContainer.image.tag }}"
           command: ['sh', '-c', 'until nc -w1 {{ printf "%s-%s" .Release.Name .Values.postgresql.nameOverride }} {{ .Values.postgresql.service.port }}; do echo "waiting for {{ printf "%s-%s" .Release.Name .Values.postgresql.nameOverride }}"; sleep 2; done;']
       {{- end }}
       {{- if .Values.persistence.repository.enabled }}
         - name: init-fs
-          image: busybox
+          image: "{{ .Values.repository.initContainer.image.repository }}:{{ .Values.repository.initContainer.image.tag }}"
           # command to allow repository to write to EFS volume.
           command: ["sh", "-c", "chown -R 33000:1000 {{ .Values.persistence.repository.data.mountPath }}"]
           volumeMounts:

--- a/helm/alfresco-content-services/values.yaml
+++ b/helm/alfresco-content-services/values.yaml
@@ -17,6 +17,10 @@ repository:
     pullPolicy: Always
     internalPort: 8080
     hazelcastPort: 5701
+  initContainer:
+    image:
+      repository: busybox
+      tag: latest
   service:
     name: alfresco
     type: ClusterIP
@@ -251,6 +255,10 @@ filestore:
     tag: "0.5.3"
     pullPolicy: Always
     internalPort: 8099
+  initContainer:
+    image:
+      repository: busybox
+      tag: latest
   service:
     name: filestore
     type: ClusterIP


### PR DESCRIPTION
This PR enables to externalize init containers Docker image repository and tag values for repository and filestore deployments. This is needed to be able to override values for ACS deployments that use organization's private Docker registry instead of public Docker Hub or Quay.io.

Related PRs:  https://github.com/Alfresco/alfresco-activemq-deployment/pull/9 and https://github.com/Alfresco/alfresco-search-deployment/pull/42