### PR TITLE
fix resource definitions in various deployment manifests

### DIFF
--- a/helm/alfresco-content-services/templates/deployment-ai-transformer.yaml
+++ b/helm/alfresco-content-services/templates/deployment-ai-transformer.yaml
@@ -57,6 +57,7 @@ spec:
           ports:
               - containerPort: {{ .Values.aiTransformer.image.internalPort }}
           resources:
+{{ toYaml .Values.aiTransformer.resources | indent 12 }}
           readinessProbe:
             httpGet:
               path: /ready
@@ -72,5 +73,4 @@ spec:
             periodSeconds: {{ .Values.aiTransformer.livenessProbe.periodSeconds }}
             failureThreshold: 1
             timeoutSeconds: {{ .Values.aiTransformer.livenessProbe.timeoutSeconds }}
-{{ toYaml .Values.aiTransformer.resources | indent 12 }}
 {{- end }}

--- a/helm/alfresco-content-services/templates/deployment-filestore.yaml
+++ b/helm/alfresco-content-services/templates/deployment-filestore.yaml
@@ -56,6 +56,7 @@ spec:
           ports:
             - containerPort: {{ .Values.filestore.image.internalPort }}
           resources:
+{{ toYaml .Values.filestore.resources | indent 12 }}
           readinessProbe:
             httpGet:
               path: /ready
@@ -71,7 +72,6 @@ spec:
             periodSeconds: {{ .Values.filestore.livenessProbe.periodSeconds }}
             failureThreshold: 1
             timeoutSeconds: {{ .Values.filestore.livenessProbe.timeoutSeconds }}
-{{ toYaml .Values.filestore.resources | indent 12 }}
           {{- if .Values.persistence.filestore.enabled }}
           volumeMounts:
           - name: data

--- a/helm/alfresco-content-services/templates/deployment-imagemagick.yaml
+++ b/helm/alfresco-content-services/templates/deployment-imagemagick.yaml
@@ -56,6 +56,7 @@ spec:
           ports:
             - containerPort: {{ .Values.imagemagick.image.internalPort }}
           resources:
+{{ toYaml .Values.imagemagick.resources | indent 12 }}
           readinessProbe:
             httpGet:
               path: /ready
@@ -71,4 +72,3 @@ spec:
             periodSeconds: {{ .Values.imagemagick.livenessProbe.periodSeconds }}
             failureThreshold: 1
             timeoutSeconds: {{ .Values.imagemagick.livenessProbe.timeoutSeconds }}
-{{ toYaml .Values.imagemagick.resources | indent 12 }}

--- a/helm/alfresco-content-services/templates/deployment-libreoffice.yaml
+++ b/helm/alfresco-content-services/templates/deployment-libreoffice.yaml
@@ -56,6 +56,7 @@ spec:
           ports:
             - containerPort: {{ .Values.libreoffice.image.internalPort }}
           resources:
+{{ toYaml .Values.libreoffice.resources | indent 12 }}
           readinessProbe:
             httpGet:
               path: /ready
@@ -71,4 +72,3 @@ spec:
             periodSeconds: {{ .Values.libreoffice.livenessProbe.periodSeconds }}
             failureThreshold: 1
             timeoutSeconds: {{ .Values.libreoffice.livenessProbe.timeoutSeconds }}
-{{ toYaml .Values.libreoffice.resources | indent 12 }}

--- a/helm/alfresco-content-services/templates/deployment-pdfrenderer.yaml
+++ b/helm/alfresco-content-services/templates/deployment-pdfrenderer.yaml
@@ -56,6 +56,7 @@ spec:
           ports:
             - containerPort: {{ .Values.pdfrenderer.image.internalPort }}
           resources:
+{{ toYaml .Values.pdfrenderer.resources | indent 12 }}
           readinessProbe:
             httpGet:
               path: /ready
@@ -71,4 +72,3 @@ spec:
             periodSeconds: {{ .Values.pdfrenderer.livenessProbe.periodSeconds }}
             failureThreshold: 1
             timeoutSeconds: {{ .Values.pdfrenderer.livenessProbe.timeoutSeconds }}
-{{ toYaml .Values.pdfrenderer.resources | indent 12 }}

--- a/helm/alfresco-content-services/templates/deployment-tika.yaml
+++ b/helm/alfresco-content-services/templates/deployment-tika.yaml
@@ -56,6 +56,7 @@ spec:
           ports:
             - containerPort: {{ .Values.tika.image.internalPort }}
           resources:
+{{ toYaml .Values.tika.resources | indent 12 }}
           readinessProbe:
             httpGet:
               path: /ready
@@ -71,4 +72,3 @@ spec:
             periodSeconds: {{ .Values.tika.livenessProbe.periodSeconds }}
             failureThreshold: 1
             timeoutSeconds: {{ .Values.tika.livenessProbe.timeoutSeconds }}
-{{ toYaml .Values.tika.resources | indent 12 }}


### PR DESCRIPTION
Hi, the resource definitions are place in the wrong lines in some deployment templates.