### PR TITLE
ATS-473 / ATS-474: Update ACS deployment for ATS (targeting 6.2.0-A2 or higher)

### DIFF
--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -59,7 +59,7 @@ services:
 
     transform-router:
         mem_limit: 512m
-        image: quay.io/alfresco/alfresco-transform-router:1.1.0-EA1
+        image: quay.io/alfresco/alfresco-transform-router:1.1.0-EA2
         environment:
           JAVA_OPTS: " -Xms256m -Xmx512m"
           ACTIVEMQ_URL: "nio://activemq:61616"
@@ -74,7 +74,7 @@ services:
           - activemq
 
     alfresco-pdf-renderer:
-        image: alfresco/alfresco-pdf-renderer:2.1.0-EA3
+        image: alfresco/alfresco-pdf-renderer:2.1.0-EA4
         mem_limit: 1g
         environment:
             JAVA_OPTS: " -Xms256m -Xmx512m"
@@ -86,7 +86,7 @@ services:
         - activemq
 
     imagemagick:
-        image: alfresco/alfresco-imagemagick:2.1.0-EA3
+        image: alfresco/alfresco-imagemagick:2.1.0-EA4
         mem_limit: 1g
         environment:
             JAVA_OPTS: " -Xms256m -Xmx512m"
@@ -98,7 +98,7 @@ services:
         - activemq
 
     libreoffice:
-        image: alfresco/alfresco-libreoffice:2.1.0-EA3
+        image: alfresco/alfresco-libreoffice:2.1.0-EA4
         mem_limit: 1g
         environment:
             JAVA_OPTS: " -Xms256m -Xmx512m"
@@ -110,7 +110,7 @@ services:
         - activemq
 
     tika:
-        image: alfresco/alfresco-tika:2.1.0-EA3
+        image: alfresco/alfresco-tika:2.1.0-EA4
         mem_limit: 1g
         environment:
             JAVA_OPTS: " -Xms256m -Xmx512m"
@@ -122,7 +122,7 @@ services:
             - activemq
 
     transform-misc:
-        image: alfresco/alfresco-transform-misc:2.1.0-EA3
+        image: alfresco/alfresco-transform-misc:2.1.0-EA4
         mem_limit: 1g
         environment:
             JAVA_OPTS: " -Xms256m -Xmx512m"

--- a/helm/alfresco-content-services/values.yaml
+++ b/helm/alfresco-content-services/values.yaml
@@ -78,7 +78,7 @@ transformrouter:
   replicaCount: 2
   image:
     repository: quay.io/alfresco/alfresco-transform-router
-    tag: "1.1.0-EA1"
+    tag: "1.1.0-EA2"
     pullPolicy: Always
     internalPort: 8095
   service:
@@ -102,7 +102,7 @@ pdfrenderer:
   replicaCount: 2
   image:
     repository: alfresco/alfresco-pdf-renderer
-    tag: "2.1.0-EA3"
+    tag: "2.1.0-EA4"
     pullPolicy: Always
     internalPort: 8090
   service:
@@ -135,7 +135,7 @@ imagemagick:
   replicaCount: 2
   image:
     repository: alfresco/alfresco-imagemagick
-    tag: "2.1.0-EA3"
+    tag: "2.1.0-EA4"
     pullPolicy: Always
     internalPort: 8090
   service:
@@ -168,7 +168,7 @@ libreoffice:
   replicaCount: 2
   image:
     repository: alfresco/alfresco-libreoffice
-    tag: "2.1.0-EA3"
+    tag: "2.1.0-EA4"
     pullPolicy: Always
     internalPort: 8090
   service:
@@ -201,7 +201,7 @@ tika:
   replicaCount: 2
   image:
     repository: alfresco/alfresco-tika
-    tag: "2.1.0-EA3"
+    tag: "2.1.0-EA4"
     pullPolicy: Always
     internalPort: 8090
   service:
@@ -234,7 +234,7 @@ transformmisc:
   replicaCount: 2
   image:
     repository: alfresco/alfresco-transform-misc
-    tag: "2.1.0-EA3"
+    tag: "2.1.0-EA4"
     pullPolicy: Always
     internalPort: 8090
   service:


### PR DESCRIPTION
- to use new T-Engines 2.1.0-EA4 / T-Router 1.1.0-EA2