### PR TITLE
APPSREPO-656 : ACS Deployment includes Sync service

### DIFF
--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -1,9 +1,7 @@
-# This docker-compose file will spin up an ACS cluster on a local host or on a server and it requires a minimum of 16GB Memory to distribute among containers.
-# Limit container memory and assign X percentage to JVM.  There are couple of ways to allocate JVM Memory for ACS Containers
-# For example: 'JAVA_OPTS: "$JAVA_OPTS -XX:+PrintFlagsFinal -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap"'
-# See Oracle docs (https://docs.oracle.com/javase/9/gctuning/parallel-collector1.htm#JSGCT-GUID-CAB83393-3438-44ED-98F0-D15641B43C7D).
-# If the container memory is not explicitly set then the flags above will set the max heap default to 1/4 of the container's memory, which may not be ideal.
+# This docker-compose file will spin up an ACS cluster on a local host or on a server and it requires a minimum of 13GB Memory to distribute among containers.
+# 
 # For performance tuning, assign the container memory and give a percentage of it to the JVM.
+# Use either the -Xms,-Xmx flags or the newly added flags in java 10+: -XX:MaxRAMPercentage and -XX:MinRAMPercentage. More details here: https://www.oracle.com/technetwork/java/javase/10-relnote-issues-4108729.html
 
 # Note: The docker-compose file from github.com is a limited trial that goes into read-only mode after 2 days.
 # Get the latest docker-compose.yml file with a 30-day trial license by accessing the Alfresco Content Services trial download page at:
@@ -14,7 +12,7 @@ version: "2"
 
 services:
     alfresco:
-        image: alfresco/alfresco-content-repository:6.2.0-A3
+        image: alfresco/alfresco-content-repository:6.2.0-A5
         mem_limit: 1700m
         environment:
             JAVA_OPTS: "
@@ -54,6 +52,7 @@ services:
                 -Dtransform.misc.url=http://transform-misc:8090/
 
                 -Dcsrf.filter.enabled=false
+                -Ddsync.service.uris=http://localhost:8080/syncservice
                 -Xms1500m -Xmx1500m
                 "
 
@@ -214,6 +213,25 @@ services:
             - digital-workspace
             - alfresco
             - share
+            
+    sync-service:
+        image: quay.io/alfresco/service-sync:3.1.2-RC2
+        mem_limit: 1g
+        environment:
+            JAVA_OPTS : "
+            -Dsql.db.driver=org.postgresql.Driver
+            -Dsql.db.url=jdbc:postgresql://postgres:5432/alfresco
+            -Dsql.db.username=alfresco
+            -Dsql.db.password=alfresco
+            -Dmessaging.broker.host=activemq
+            -Drepo.hostname=alfresco
+            -Drepo.port=8080
+            -Ddw.server.applicationConnectors[0].type=http
+            -Xms1000m -Xmx1000m
+            "
+
+        ports:
+            - 9090:9090
 
 volumes:
     shared-file-store-volume:

--- a/helm/alfresco-content-services/requirements.yaml
+++ b/helm/alfresco-content-services/requirements.yaml
@@ -21,3 +21,10 @@ dependencies:
   version: 1.2.0
   condition: alfresco-digital-workspace.enabled
   repository: https://kubernetes-charts.alfresco.com/stable
+- name: alfresco-sync-service
+  version: 1.0.0-RC1
+  condition: alfresco-sync-service.enabled
+  repository: https://kubernetes-charts.alfresco.com/stable
+  import-values:
+    - child: syncservice
+      parent: syncservice

--- a/helm/alfresco-content-services/templates/NOTES.txt
+++ b/helm/alfresco-content-services/templates/NOTES.txt
@@ -4,6 +4,10 @@
 {{ $alfprotocol := tpl (.Values.externalProtocol | default "http") $ }}
 {{ $alfport := tpl (.Values.externalPort | default .Values.repository.service.externalPort | toString ) $ }}
 {{ $alfurl := printf "%s://%s:%s" $alfprotocol $alfhost $alfport }}
+
+{{ $alfportdsync := tpl (.Values.externalPort | default .Values.syncservice.service.externalPort | toString ) $ }}
+{{ $alfurldsync := printf "%s://%s:%s" $alfprotocol $alfhost $alfportdsync }}
+
 You can access all components of Alfresco Content Services Community using the same root address, but different paths as follows:
 
   Content: {{ $alfurl }}/alfresco
@@ -11,6 +15,7 @@ You can access all components of Alfresco Content Services Community using the s
   Api-Explorer: {{ $alfurl }}/api-explorer
 {{ if index .Values "alfresco-search" "ingress" "enabled" }}  Solr: {{ $alfurl }}/solr {{ end }}
 {{ if (index .Values "alfresco-insight-zeppelin") }}{{ if (index .Values "alfresco-insight-zeppelin" "enabled") }}  Zeppelin: {{ $alfurl }}/zeppelin {{ end }}{{ end }}
+{{- if index .Values "alfresco-sync-service" "enabled" }}  Sync service: {{ $alfurldsync }}/syncservice/healthcheck {{ end }}
 {{ else }}
 If you have a specific DNS address for the cluster please run the following commands to get the application paths and configure ACS:
 

--- a/helm/alfresco-content-services/templates/config-repository.yaml
+++ b/helm/alfresco-content-services/templates/config-repository.yaml
@@ -64,6 +64,11 @@ data:
       -Dmessaging.broker.url={{ .Values.messageBroker.url | default (printf "failover:(nio://%s-activemq-broker:61616)?timeout=3000&jms.useCompression=true" .Release.Name)}}
       -Dmessaging.broker.username={{ .Values.messageBroker.user }}
       -Dmessaging.broker.password={{ .Values.messageBroker.password }}
+      {{- end }}
+      {{- if index .Values "alfresco-sync-service" "enabled" }}
+      -Ddsync.service.uris={{ .Values.externalProtocol | default "http" }}://{{ .Values.externalHost }}:{{ .Values.externalPort | default .Values.syncservice.service.externalPort }}/syncservice
+      {{- else }}
+      -Devents.subsystem.autoStart=false
       {{- end }}"
   CATALINA_OPTS: " $ALFRESCO_OPTS  
       -Ddb.driver={{ .Values.database.driver | default "org.postgresql.Driver" }}

--- a/helm/alfresco-content-services/values.yaml
+++ b/helm/alfresco-content-services/values.yaml
@@ -13,7 +13,7 @@ repository:
   replicaCount: 2
   image:
     repository: alfresco/alfresco-content-repository
-    tag: "6.2.0-A2"
+    tag: "6.2.0-A5"
     pullPolicy: Always
     internalPort: 8080
     hazelcastPort: 5701
@@ -487,3 +487,6 @@ s3connector:
 # or uncomment the following line if you don't want/need to pass it as a parameter on every install command :
 # registryPullSecrets: private-repo-registry-secret
 # for more information: https://github.com/Alfresco/alfresco-anaxes-shipyard/blob/master/SECRETS.md
+
+alfresco-sync-service:
+   enabled : true

--- a/test/postman/docker-compose/acs-test-docker-compose-collection.json
+++ b/test/postman/docker-compose/acs-test-docker-compose-collection.json
@@ -1483,6 +1483,42 @@
 						}
 					},
 					"response": []
+				},
+				{
+					"name": "sync-service-healthcheck",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									"pm.globals.get(\"url\");",
+									"",
+									"pm.test(\"syncServiceHealthcheck\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									""
+								]
+							}
+						}
+					],
+					"request": {
+						"url": "http://localhost:8080/syncservice/healthcheck",
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/x-www-form-urlencoded",
+								"description": ""
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"description": ""
+					},
+					"response": []
 				}
 			]
 		}

--- a/test/postman/helm/acs-test-helm-collection.json
+++ b/test/postman/helm/acs-test-helm-collection.json
@@ -1972,6 +1972,42 @@
 						}
 					},
 					"response": []
+				},
+				{
+					"name": "sync-service-healthcheck",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									"pm.globals.get(\"url\");",
+									"",
+									"pm.test(\"syncServiceHealthcheck\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									""
+								]
+							}
+						}
+					],
+					"request": {
+						"url": "{{protocol}}://{{url}}/syncservice/healthcheck",
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/x-www-form-urlencoded",
+								"description": ""
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"description": ""
+					},
+					"response": []
 				}
 			]
 		}


### PR DESCRIPTION
   - included sync service 3.1.2-RC2 in the docker-compose.yaml.
   - included the sync service chart (1.0.0-RC1) as a dependency in the requirements.yaml file.
   - in requirements.yaml allowed parent chart to view properties from the child sync chart by importing props found under 'syncservice'.
     The ACS chart needs the following property from the sync chart: .Values.syncservice.service.externalPort.  The usage can be seen in config-repository.yaml
   - added two postman tests, one for the docker-compose and one for the helm chart. The tests verify that the sync healtheck returns 200.
   - updated sync service to use ACS's postgres database in docker-compose.yml
   - Recalculated the min memory requirements for the entire docker-compose stack rezulting in ~13GB.
   - Removed some obsolete docs regarding container memory detection by the JVM, in newer JVM versions the container memory is automatically detected.
   - dsync.service.uris points to the nginx ingress in docker-compose.yml
   - updated ngix image to 3.0.1 which contains the configuration for sync service in docker-compose.yml
   - updated postman test to use nginx ingress