### PR TITLE
Don't execute sync service specific logic if it is disabled, in NOTES.txt

### DIFF
--- a/helm/alfresco-content-services/templates/NOTES.txt
+++ b/helm/alfresco-content-services/templates/NOTES.txt
@@ -5,9 +5,6 @@
 {{ $alfport := tpl (.Values.externalPort | default .Values.repository.service.externalPort | toString ) $ }}
 {{ $alfurl := printf "%s://%s:%s" $alfprotocol $alfhost $alfport }}
 
-{{ $alfportdsync := tpl (.Values.externalPort | default .Values.syncservice.service.externalPort | toString ) $ }}
-{{ $alfurldsync := printf "%s://%s:%s" $alfprotocol $alfhost $alfportdsync }}
-
 You can access all components of Alfresco Content Services Community using the same root address, but different paths as follows:
 
   Content: {{ $alfurl }}/alfresco
@@ -15,7 +12,11 @@ You can access all components of Alfresco Content Services Community using the s
   Api-Explorer: {{ $alfurl }}/api-explorer
 {{ if index .Values "alfresco-search" "ingress" "enabled" }}  Solr: {{ $alfurl }}/solr {{ end }}
 {{ if (index .Values "alfresco-insight-zeppelin") }}{{ if (index .Values "alfresco-insight-zeppelin" "enabled") }}  Zeppelin: {{ $alfurl }}/zeppelin {{ end }}{{ end }}
-{{- if index .Values "alfresco-sync-service" "enabled" }}  Sync service: {{ $alfurldsync }}/syncservice/healthcheck {{ end }}
+{{- if index .Values "alfresco-sync-service" "enabled" }}
+  {{ $alfportdsync := tpl (.Values.externalPort | default .Values.syncservice.service.externalPort | toString ) $ }}
+  {{ $alfurldsync := printf "%s://%s:%s" $alfprotocol $alfhost $alfportdsync }}
+   Sync service: {{ $alfurldsync }}/syncservice/healthcheck 
+{{ end }}
 {{ else }}
 If you have a specific DNS address for the cluster please run the following commands to get the application paths and configure ACS:
 


### PR DESCRIPTION
Small fix in NOTES.txt to skip defining some variables when Sync service is disable.