### PR TITLE
REPO-4620 : ACS Chart Forces Declaration of Sync Values

### DIFF
--- a/helm/alfresco-content-services/requirements.yaml
+++ b/helm/alfresco-content-services/requirements.yaml
@@ -25,6 +25,3 @@ dependencies:
   version: 1.0.0-RC1
   condition: alfresco-sync-service.enabled
   repository: https://kubernetes-charts.alfresco.com/stable
-  import-values:
-    - child: syncservice
-      parent: syncservice

--- a/helm/alfresco-content-services/templates/NOTES.txt
+++ b/helm/alfresco-content-services/templates/NOTES.txt
@@ -13,7 +13,7 @@ You can access all components of Alfresco Content Services Community using the s
 {{ if index .Values "alfresco-search" "ingress" "enabled" }}  Solr: {{ $alfurl }}/solr {{ end }}
 {{ if (index .Values "alfresco-insight-zeppelin") }}{{ if (index .Values "alfresco-insight-zeppelin" "enabled") }}  Zeppelin: {{ $alfurl }}/zeppelin {{ end }}{{ end }}
 {{- if index .Values "alfresco-sync-service" "enabled" }}
-  {{ $alfportdsync := tpl (.Values.externalPort | default .Values.syncservice.service.externalPort | toString ) $ }}
+  {{ $alfportdsync := tpl (.Values.externalPort | toString ) $ }}
   {{ $alfurldsync := printf "%s://%s:%s" $alfprotocol $alfhost $alfportdsync }}
    Sync service: {{ $alfurldsync }}/syncservice/healthcheck 
 {{ end }}

--- a/helm/alfresco-content-services/templates/config-repository.yaml
+++ b/helm/alfresco-content-services/templates/config-repository.yaml
@@ -65,7 +65,7 @@ data:
       -Dmessaging.broker.password={{ .Values.messageBroker.password }}
       {{- end }}
       {{- if index .Values "alfresco-sync-service" "enabled" }}
-      -Ddsync.service.uris={{ .Values.externalProtocol | default "http" }}://{{ .Values.externalHost }}:{{ .Values.externalPort | default .Values.syncservice.service.externalPort }}/syncservice
+      -Ddsync.service.uris={{ .Values.externalProtocol | default "http" }}://{{ .Values.externalHost }}:{{ .Values.externalPort }}/syncservice
       {{- else }}
       -Devents.subsystem.autoStart=false
       {{- end }}"


### PR DESCRIPTION
   - Removed references of Sync service externalPort, Sync service will be accesed only though the nginx proxy, there's no need for the ACS parent chart to know the Kubernetes Service port