### PR TITLE
ATS-462: Update ACS Helm Deployment from AIS 1.0.1 to 1.0.2 (for ACS 6.1.1)

### DIFF
--- a/helm/alfresco-content-services/values.yaml
+++ b/helm/alfresco-content-services/values.yaml
@@ -265,7 +265,7 @@ aiTransformer:
   replicaCount: 2
   image:
     repository: quay.io/alfresco/alfresco-ai-docker-engine
-    tag: "1.0.1"
+    tag: "1.0.2"
     pullPolicy: Always
     internalPort: 8090
   service:


### PR DESCRIPTION
- note: master will be updated again soon to AIS 1.1.0-RC1 or higher (see ATS-547)
- this specific change will be cherry-picked to support/SP/2.N (for ACS 6.1.1)