### PR TITLE
REPO-4670: Update helm chart docker image information

### DIFF
--- a/docs/helm-chart-releases.md
+++ b/docs/helm-chart-releases.md
@@ -1,22 +1,22 @@
 ## Stable Helm Chart Releases
 
-|Chart version|ACS version|
-|:---:|:---:|
-|1.0.0|6.0.0|
-|1.0.1|6.0.0|
-|1.0.2|6.0.0|
-|1.0.3|6.0.0|
-|1.0.5|6.0.0.1|
-|1.0.6|6.0.0.1|
-|1.0.7|6.0.0.1|
-|1.0.8|6.0.0.1|
-|1.0.10|6.0.1|
-|1.2.2|6.0.1.2|
-|1.2.3|6.0.1.3|
-|2.0.0|6.1.0|
-|2.0.1|6.1.0.5|
-|2.1.0|6.1.1|
-|3.0.0|6.2.0|
-|4.0.0|6.3.0|
+|Chart version|ACS version|Repository Docker Image|Transformrouter Docker Image|Pdfrenderer Docker Image|Imagemagick Docker Image|Libreoffice Docker Image|Tika Docker Image|Filestore Docker Image|Share Docker Image|
+|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+|1.0.0|6.0.0|alfresco/alfresco-content-repository:6.0.0|Not included|alfresco/alfresco-pdf-renderer:1.2|alfresco/alfresco-imagemagick:1.2|alfresco/alfresco-libreoffice:1.2|Not included|Not included|alfresco/alfresco-share:6.0.b|
+|1.0.1|6.0.0|alfresco/alfresco-content-repository:6.0.0|Not included|alfresco/alfresco-pdf-renderer:1.2|alfresco/alfresco-imagemagick:1.2|alfresco/alfresco-libreoffice:1.2|Not included|Not included|alfresco/alfresco-share:6.0|
+|1.0.2|6.0.0|alfresco/alfresco-content-repository:6.0.0|Not included|alfresco/alfresco-pdf-renderer:1.2|alfresco/alfresco-imagemagick:1.2|alfresco/alfresco-libreoffice:1.2|Not included|Not included|alfresco/alfresco-share:6.0|
+|1.0.3|6.0.0|alfresco/alfresco-content-repository:6.0.0|Not included|alfresco/alfresco-pdf-renderer:1.2|alfresco/alfresco-imagemagick:1.2|alfresco/alfresco-libreoffice:1.2|Not included|Not included|alfresco/alfresco-share:6.0|
+|1.0.5|6.0.0.1|alfresco/alfresco-content-repository:6.0.0.1|Not included|alfresco/alfresco-pdf-renderer:1.2|alfresco/alfresco-imagemagick:1.2|alfresco/alfresco-libreoffice:1.2|Not included|Not included|alfresco/alfresco-share:6.0|
+|1.0.6|6.0.0.1|alfresco/alfresco-content-repository:6.0.0.1|Not included|alfresco/alfresco-pdf-renderer:1.2|alfresco/alfresco-imagemagick:1.2|alfresco/alfresco-libreoffice:1.2|Not included|Not included|alfresco/alfresco-share:6.0|
+|1.0.7|6.0.0.1|alfresco/alfresco-content-repository:6.0.0.1|Not included|alfresco/alfresco-pdf-renderer:1.2|alfresco/alfresco-imagemagick:1.2|alfresco/alfresco-libreoffice:1.2|Not included|Not included|alfresco/alfresco-share:6.0|
+|1.0.8|6.0.0.1|alfresco/alfresco-content-repository:6.0.0.1|Not included|alfresco/alfresco-pdf-renderer:1.2|alfresco/alfresco-imagemagick:1.2|alfresco/alfresco-libreoffice:1.2|Not included|Not included|alfresco/alfresco-share:6.0|
+|1.0.10|6.0.1|alfresco/alfresco-content-repository:6.0.1|Not included|alfresco/alfresco-pdf-renderer:1.2|alfresco/alfresco-imagemagick:1.2|alfresco/alfresco-libreoffice:1.2|Not included|Not included|alfresco/alfresco-share:6.0|
+|1.2.2|6.0.1.2|alfresco/alfresco-content-repository:6.0.1.2|Not included|alfresco/alfresco-pdf-renderer:1.2|alfresco/alfresco-imagemagick:1.2|alfresco/alfresco-libreoffice:1.2|Not included|Not included|alfresco/alfresco-share:6.0.1.1|
+|1.2.3|6.0.1.3|alfresco/alfresco-content-repository:6.0.1.3|Not included|alfresco/alfresco-pdf-renderer:1.2|alfresco/alfresco-imagemagick:1.2|alfresco/alfresco-libreoffice:1.2|Not included|Not included|alfresco/alfresco-share:6.0.1.1|
+|2.0.0|6.1.0|alfresco/alfresco-content-repository:6.1.0|quay.io/alfresco/alfresco-transform-router:1.0.1|quay.io/alfresco/alfresco-pdf-renderer:2.0.10|quay.io/alfresco/alfresco-imagemagick:2.0.10|quay.io/alfresco/alfresco-libreoffice:2.0.10|quay.io/alfresco/alfresco-tika:2.0.10|alfresco/alfresco-shared-file-store:0.5.2|alfresco/alfresco-share:6.1.0|
+|2.0.1|6.1.0.5|alfresco/alfresco-content-repository:6.1.0.5|quay.io/alfresco/alfresco-transform-router:1.0.2.1|quay.io/alfresco/alfresco-pdf-renderer:2.0.17|quay.io/alfresco/alfresco-imagemagick:2.0.17|quay.io/alfresco/alfresco-libreoffice:2.0.17|quay.io/alfresco/alfresco-tika:2.0.17|alfresco/alfresco-shared-file-store:0.5.2|alfresco/alfresco-share:6.1.0|
+|2.1.0|6.1.1| | | | |
+|3.0.0|6.2.0| | | | |
+|4.0.0|6.3.0| | | | |
 
 Note that 2.1.0, 3.0.0 and 4.0.0 are not released yet.

--- a/docs/helm-chart-releases.md
+++ b/docs/helm-chart-releases.md
@@ -1,22 +1,98 @@
 ## Stable Helm Chart Releases
 
-|Chart version|ACS version|Repository Docker Image|Transformrouter Docker Image|Pdfrenderer Docker Image|Imagemagick Docker Image|Libreoffice Docker Image|Tika Docker Image|Filestore Docker Image|Share Docker Image|
-|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
-|1.0.0|6.0.0|alfresco/alfresco-content-repository:6.0.0|Not included|alfresco/alfresco-pdf-renderer:1.2|alfresco/alfresco-imagemagick:1.2|alfresco/alfresco-libreoffice:1.2|Not included|Not included|alfresco/alfresco-share:6.0.b|
-|1.0.1|6.0.0|alfresco/alfresco-content-repository:6.0.0|Not included|alfresco/alfresco-pdf-renderer:1.2|alfresco/alfresco-imagemagick:1.2|alfresco/alfresco-libreoffice:1.2|Not included|Not included|alfresco/alfresco-share:6.0|
-|1.0.2|6.0.0|alfresco/alfresco-content-repository:6.0.0|Not included|alfresco/alfresco-pdf-renderer:1.2|alfresco/alfresco-imagemagick:1.2|alfresco/alfresco-libreoffice:1.2|Not included|Not included|alfresco/alfresco-share:6.0|
-|1.0.3|6.0.0|alfresco/alfresco-content-repository:6.0.0|Not included|alfresco/alfresco-pdf-renderer:1.2|alfresco/alfresco-imagemagick:1.2|alfresco/alfresco-libreoffice:1.2|Not included|Not included|alfresco/alfresco-share:6.0|
-|1.0.5|6.0.0.1|alfresco/alfresco-content-repository:6.0.0.1|Not included|alfresco/alfresco-pdf-renderer:1.2|alfresco/alfresco-imagemagick:1.2|alfresco/alfresco-libreoffice:1.2|Not included|Not included|alfresco/alfresco-share:6.0|
-|1.0.6|6.0.0.1|alfresco/alfresco-content-repository:6.0.0.1|Not included|alfresco/alfresco-pdf-renderer:1.2|alfresco/alfresco-imagemagick:1.2|alfresco/alfresco-libreoffice:1.2|Not included|Not included|alfresco/alfresco-share:6.0|
-|1.0.7|6.0.0.1|alfresco/alfresco-content-repository:6.0.0.1|Not included|alfresco/alfresco-pdf-renderer:1.2|alfresco/alfresco-imagemagick:1.2|alfresco/alfresco-libreoffice:1.2|Not included|Not included|alfresco/alfresco-share:6.0|
-|1.0.8|6.0.0.1|alfresco/alfresco-content-repository:6.0.0.1|Not included|alfresco/alfresco-pdf-renderer:1.2|alfresco/alfresco-imagemagick:1.2|alfresco/alfresco-libreoffice:1.2|Not included|Not included|alfresco/alfresco-share:6.0|
-|1.0.10|6.0.1|alfresco/alfresco-content-repository:6.0.1|Not included|alfresco/alfresco-pdf-renderer:1.2|alfresco/alfresco-imagemagick:1.2|alfresco/alfresco-libreoffice:1.2|Not included|Not included|alfresco/alfresco-share:6.0|
-|1.2.2|6.0.1.2|alfresco/alfresco-content-repository:6.0.1.2|Not included|alfresco/alfresco-pdf-renderer:1.2|alfresco/alfresco-imagemagick:1.2|alfresco/alfresco-libreoffice:1.2|Not included|Not included|alfresco/alfresco-share:6.0.1.1|
-|1.2.3|6.0.1.3|alfresco/alfresco-content-repository:6.0.1.3|Not included|alfresco/alfresco-pdf-renderer:1.2|alfresco/alfresco-imagemagick:1.2|alfresco/alfresco-libreoffice:1.2|Not included|Not included|alfresco/alfresco-share:6.0.1.1|
-|2.0.0|6.1.0|alfresco/alfresco-content-repository:6.1.0|quay.io/alfresco/alfresco-transform-router:1.0.1|quay.io/alfresco/alfresco-pdf-renderer:2.0.10|quay.io/alfresco/alfresco-imagemagick:2.0.10|quay.io/alfresco/alfresco-libreoffice:2.0.10|quay.io/alfresco/alfresco-tika:2.0.10|alfresco/alfresco-shared-file-store:0.5.2|alfresco/alfresco-share:6.1.0|
-|2.0.1|6.1.0.5|alfresco/alfresco-content-repository:6.1.0.5|quay.io/alfresco/alfresco-transform-router:1.0.2.1|quay.io/alfresco/alfresco-pdf-renderer:2.0.17|quay.io/alfresco/alfresco-imagemagick:2.0.17|quay.io/alfresco/alfresco-libreoffice:2.0.17|quay.io/alfresco/alfresco-tika:2.0.17|alfresco/alfresco-shared-file-store:0.5.2|alfresco/alfresco-share:6.1.0|
-|2.1.0|6.1.1| | | | |
-|3.0.0|6.2.0| | | | |
-|4.0.0|6.3.0| | | | |
+### Helm Chart Version 2.0.1 - ACS Version 6.1.0.5
+* Repository: [alfresco/alfresco-content-repository:6.1.0.5](https://hub.docker.com/layers/alfresco/alfresco-content-repository/6.0.0.1/images/sha256-1ee046695e6de76531fffc7ec0b87f5569f7dde1f60321f80321c136154ab644)
+* Share: [alfresco/alfresco-share:6.1.0](https://hub.docker.com/layers/alfresco/alfresco-share/6.1.0/images/sha256-0dfa83b790293f970c32effee1be39f891c0e0cc54b49ccea448739e230c5791)
+* Pdfrenderer: [quay.io/alfresco/alfresco-pdf-renderer:2.0.17](https://quay.io/repository/alfresco/alfresco-pdf-renderer/manifest/sha256:d9be5deb165d44141497373257041fc701b4d825f12997b15212bbe637ed7d53)
+* Imagemagick: [quay.io/alfresco/alfresco-imagemagick:2.0.17](https://quay.io/repository/alfresco/alfresco-imagemagick/manifest/sha256:cea7e75550548c095360f7122e65eea1cfd128799a462f80e99cfccb28ab4e7c)
+* Libreoffice: [quay.io/alfresco/alfresco-libreoffice:2.0.17](https://quay.io/repository/alfresco/alfresco-libreoffice/manifest/sha256:6716b86560d012fcc8b32a7505fdbe2c555fa3f106fa0e05003cae275d3f64c8)
+* Transformrouter: [quay.io/alfresco/alfresco-transform-router:1.0.2.1](https://quay.io/repository/alfresco/alfresco-transform-router/manifest/sha256:3396a78dc3b9a7e92c4159a1b15a48f1e55ee03cdf04a65895d54e89bb4cab23)
+* Tika: [quay.io/alfresco/alfresco-tika:2.0.17](https://quay.io/repository/alfresco/alfresco-tika/manifest/sha256:84122a831cd5b4f8ef7ac2cb7c79b3a72e5b14aad5ee1fc0bd2dd4ea1d95fd4d)
+* Filestore: [alfresco/alfresco-shared-file-store:0.5.2](https://hub.docker.com/layers/alfresco/alfresco-shared-file-store/0.5.2/images/sha256-4457788253ba0c19f4f48074fd23d8f6063f2940cf431d2647cc030932215826)
 
-Note that 2.1.0, 3.0.0 and 4.0.0 are not released yet.
+### Helm Chart Version 2.0.0 - ACS Version 6.1.0
+* Repository: [alfresco/alfresco-content-repository:6.1.0](https://hub.docker.com/layers/alfresco/alfresco-content-repository/6.1.0/images/sha256-57efcc66254346b3cefba0350263ec8e978f73c10d1d6edd3721f18e3c928352)
+* Share: [alfresco/alfresco-share:6.1.0](https://hub.docker.com/layers/alfresco/alfresco-share/6.1.0/images/sha256-0dfa83b790293f970c32effee1be39f891c0e0cc54b49ccea448739e230c5791)
+* Pdfrenderer: [quay.io/alfresco/alfresco-pdf-renderer:2.0.10](https://quay.io/repository/alfresco/alfresco-pdf-renderer/manifest/sha256:90422901d8200984c390f20944415c06c5be8b54c0d984901423444d5fbbe37d)
+* Imagemagick: [quay.io/alfresco/alfresco-imagemagick:2.0.10](https://quay.io/repository/alfresco/alfresco-imagemagick/manifest/sha256:f4958f0999c6dc83d5b9632154f5983706b08a31de5ccaa9a98dd320b2d7f225)
+* Libreoffice: [quay.io/alfresco/alfresco-libreoffice:2.0.10](https://quay.io/repository/alfresco/alfresco-libreoffice/manifest/sha256:c1284173c3500da22ff4807499e429bb9bd4dc10a1e2c95bfb2ca950dfe84d7f)
+* Transformrouter: [quay.io/alfresco/alfresco-transform-router:1.0.1](https://quay.io/repository/alfresco/alfresco-transform-router/manifest/sha256:cb193eb7132082293f506141410587add5527ce0d858c2353f75cba1f2c4e14d)
+* Tika: [quay.io/alfresco/alfresco-tika:2.0.10](https://quay.io/repository/alfresco/alfresco-tika/manifest/sha256:03e6a932e56beb5a2f4231d1b69ee732d3e6326410f47ce6fd1e66b6683850fc)
+* Filestore: [alfresco/alfresco-shared-file-store:0.5.2](https://hub.docker.com/layers/alfresco/alfresco-shared-file-store/0.5.2/images/sha256-4457788253ba0c19f4f48074fd23d8f6063f2940cf431d2647cc030932215826)
+
+### Helm Chart Version 1.2.3 - ACS Version 6.0.1.3
+* Repository: [alfresco/alfresco-content-repository:6.0.1.3](https://hub.docker.com/layers/alfresco/alfresco-content-repository/6.0.1.3/images/sha256-e0131dde2d658d37b0020d2f197b7de57175f0a38f8680aaa8cd378d07f68790)
+* Share: [alfresco/alfresco-share:6.0.1.1](https://hub.docker.com/layers/alfresco/alfresco-share/6.0.1.1/images/sha256-239baabfe0d8fc935dcfce8ee6d30236b0a8bee8eff79ff66373585eb8bb35aa)
+* Pdfrenderer: [alfresco/alfresco-pdf-renderer:1.2](https://hub.docker.com/layers/alfresco/alfresco-pdf-renderer/1.2/images/sha256-962544face9f6d6d1f0a049e711fb3daa2bd975bf4a46b5723c2add2b24bf32c)
+* Imagemagick: [alfresco/alfresco-imagemagick:1.2](https://hub.docker.com/layers/alfresco/alfresco-imagemagick/1.2/images/sha256-fd0b2dfc642eff3189b7877b0595553c84ab1b4ea291b685dab8f80985e2987c)
+* Libreoffice: [alfresco/alfresco-libreoffice:1.2](https://hub.docker.com/layers/alfresco/alfresco-libreoffice/1.2/images/sha256-18627d9f5dc71e1608d658df38002d74d441edf031e2c2241c1d41d60c9153be)
+
+### Helm Chart Version 1.2.2 - ACS Version 6.0.1.2
+* Repository: [alfresco/alfresco-content-repository:6.0.1.2](https://hub.docker.com/layers/alfresco/alfresco-content-repository/6.0.1.2/images/sha256-730b6ca521b7a60d31e936167f090200a02db6fa649c9428082006eed4ed0ee1)
+* Share: [alfresco/alfresco-share:6.0.1.1](https://hub.docker.com/layers/alfresco/alfresco-share/6.0.1.1/images/sha256-239baabfe0d8fc935dcfce8ee6d30236b0a8bee8eff79ff66373585eb8bb35aa)
+* Pdfrenderer: [alfresco/alfresco-pdf-renderer:1.2](https://hub.docker.com/layers/alfresco/alfresco-pdf-renderer/1.2/images/sha256-962544face9f6d6d1f0a049e711fb3daa2bd975bf4a46b5723c2add2b24bf32c)
+* Imagemagick: [alfresco/alfresco-imagemagick:1.2](https://hub.docker.com/layers/alfresco/alfresco-imagemagick/1.2/images/sha256-fd0b2dfc642eff3189b7877b0595553c84ab1b4ea291b685dab8f80985e2987c)
+* Libreoffice: [alfresco/alfresco-libreoffice:1.2](https://hub.docker.com/layers/alfresco/alfresco-libreoffice/1.2/images/sha256-18627d9f5dc71e1608d658df38002d74d441edf031e2c2241c1d41d60c9153be)
+
+### Helm Chart Version 1.0.10 - ACS Version 6.0.1
+* Repository: alfresco/alfresco-content-repository:6.0.1
+* Share: [alfresco/alfresco-share:6.0](https://hub.docker.com/layers/alfresco/alfresco-share/6.0/images/sha256-22aecaf1b6d56bba5e5f9f134bdcde86eb23a750febc4c4e1087c0963a0acf18)
+* Pdfrenderer: [alfresco/alfresco-pdf-renderer:1.2](https://hub.docker.com/layers/alfresco/alfresco-pdf-renderer/1.2/images/sha256-962544face9f6d6d1f0a049e711fb3daa2bd975bf4a46b5723c2add2b24bf32c)
+* Imagemagick: [alfresco/alfresco-imagemagick:1.2](https://hub.docker.com/layers/alfresco/alfresco-imagemagick/1.2/images/sha256-fd0b2dfc642eff3189b7877b0595553c84ab1b4ea291b685dab8f80985e2987c)
+* Libreoffice: [alfresco/alfresco-libreoffice:1.2](https://hub.docker.com/layers/alfresco/alfresco-libreoffice/1.2/images/sha256-18627d9f5dc71e1608d658df38002d74d441edf031e2c2241c1d41d60c9153be)
+
+### Helm Chart Version 1.0.8 - ACS Version 6.0.0.1
+* Repository: [alfresco/alfresco-content-repository:6.0.0.1](https://hub.docker.com/layers/alfresco/alfresco-content-repository/6.0.0.1/images/sha256-1ee046695e6de76531fffc7ec0b87f5569f7dde1f60321f80321c136154ab644)
+* Share: [alfresco/alfresco-share:6.0](https://hub.docker.com/layers/alfresco/alfresco-share/6.0/images/sha256-22aecaf1b6d56bba5e5f9f134bdcde86eb23a750febc4c4e1087c0963a0acf18)
+* Pdfrenderer: [alfresco/alfresco-pdf-renderer:1.2](https://hub.docker.com/layers/alfresco/alfresco-pdf-renderer/1.2/images/sha256-962544face9f6d6d1f0a049e711fb3daa2bd975bf4a46b5723c2add2b24bf32c)
+* Imagemagick: [alfresco/alfresco-imagemagick:1.2](https://hub.docker.com/layers/alfresco/alfresco-imagemagick/1.2/images/sha256-fd0b2dfc642eff3189b7877b0595553c84ab1b4ea291b685dab8f80985e2987c)
+* Libreoffice: [alfresco/alfresco-libreoffice:1.2](https://hub.docker.com/layers/alfresco/alfresco-libreoffice/1.2/images/sha256-18627d9f5dc71e1608d658df38002d74d441edf031e2c2241c1d41d60c9153be)
+
+### Helm Chart Version 1.0.7 - ACS Version 6.0.0.1
+* Repository: [alfresco/alfresco-content-repository:6.0.0.1](https://hub.docker.com/layers/alfresco/alfresco-content-repository/6.0.0.1/images/sha256-1ee046695e6de76531fffc7ec0b87f5569f7dde1f60321f80321c136154ab644)
+* Share: [alfresco/alfresco-share:6.0](https://hub.docker.com/layers/alfresco/alfresco-share/6.0/images/sha256-22aecaf1b6d56bba5e5f9f134bdcde86eb23a750febc4c4e1087c0963a0acf18)
+* Pdfrenderer: [alfresco/alfresco-pdf-renderer:1.2](https://hub.docker.com/layers/alfresco/alfresco-pdf-renderer/1.2/images/sha256-962544face9f6d6d1f0a049e711fb3daa2bd975bf4a46b5723c2add2b24bf32c)
+* Imagemagick: [alfresco/alfresco-imagemagick:1.2](https://hub.docker.com/layers/alfresco/alfresco-imagemagick/1.2/images/sha256-fd0b2dfc642eff3189b7877b0595553c84ab1b4ea291b685dab8f80985e2987c)
+* Libreoffice: [alfresco/alfresco-libreoffice:1.2](https://hub.docker.com/layers/alfresco/alfresco-libreoffice/1.2/images/sha256-18627d9f5dc71e1608d658df38002d74d441edf031e2c2241c1d41d60c9153be)
+
+### Helm Chart Version 1.0.6 - ACS Version 6.0.0.1
+* Repository: [alfresco/alfresco-content-repository:6.0.0.1](https://hub.docker.com/layers/alfresco/alfresco-content-repository/6.0.0.1/images/sha256-1ee046695e6de76531fffc7ec0b87f5569f7dde1f60321f80321c136154ab644)
+* Share: [alfresco/alfresco-share:6.0](https://hub.docker.com/layers/alfresco/alfresco-share/6.0/images/sha256-22aecaf1b6d56bba5e5f9f134bdcde86eb23a750febc4c4e1087c0963a0acf18)
+* Pdfrenderer: [alfresco/alfresco-pdf-renderer:1.2](https://hub.docker.com/layers/alfresco/alfresco-pdf-renderer/1.2/images/sha256-962544face9f6d6d1f0a049e711fb3daa2bd975bf4a46b5723c2add2b24bf32c)
+* Imagemagick: [alfresco/alfresco-imagemagick:1.2](https://hub.docker.com/layers/alfresco/alfresco-imagemagick/1.2/images/sha256-fd0b2dfc642eff3189b7877b0595553c84ab1b4ea291b685dab8f80985e2987c)
+* Libreoffice: [alfresco/alfresco-libreoffice:1.2](https://hub.docker.com/layers/alfresco/alfresco-libreoffice/1.2/images/sha256-18627d9f5dc71e1608d658df38002d74d441edf031e2c2241c1d41d60c9153be)
+
+### Helm Chart Version 1.0.5 - ACS Version 6.0.0.1
+* Repository: [alfresco/alfresco-content-repository:6.0.0.1](https://hub.docker.com/layers/alfresco/alfresco-content-repository/6.0.0.1/images/sha256-1ee046695e6de76531fffc7ec0b87f5569f7dde1f60321f80321c136154ab644)
+* Share: [alfresco/alfresco-share:6.0](https://hub.docker.com/layers/alfresco/alfresco-share/6.0/images/sha256-22aecaf1b6d56bba5e5f9f134bdcde86eb23a750febc4c4e1087c0963a0acf18)
+* Pdfrenderer: [alfresco/alfresco-pdf-renderer:1.2](https://hub.docker.com/layers/alfresco/alfresco-pdf-renderer/1.2/images/sha256-962544face9f6d6d1f0a049e711fb3daa2bd975bf4a46b5723c2add2b24bf32c)
+* Imagemagick: [alfresco/alfresco-imagemagick:1.2](https://hub.docker.com/layers/alfresco/alfresco-imagemagick/1.2/images/sha256-fd0b2dfc642eff3189b7877b0595553c84ab1b4ea291b685dab8f80985e2987c)
+* Libreoffice: [alfresco/alfresco-libreoffice:1.2](https://hub.docker.com/layers/alfresco/alfresco-libreoffice/1.2/images/sha256-18627d9f5dc71e1608d658df38002d74d441edf031e2c2241c1d41d60c9153be)
+
+### Helm Chart Version 1.0.3 - ACS Version 6.0.0
+* Repository: [alfresco/alfresco-content-repository:6.0.0](https://hub.docker.com/layers/alfresco/alfresco-content-repository/6.0.0/images/sha256-dcbb92445900579257003c4b2c584ffa3243b807c2e82c09c64ea61694c75b5c)
+* Share: [alfresco/alfresco-share:6.0](https://hub.docker.com/layers/alfresco/alfresco-share/6.0/images/sha256-22aecaf1b6d56bba5e5f9f134bdcde86eb23a750febc4c4e1087c0963a0acf18)
+* Pdfrenderer: [alfresco/alfresco-pdf-renderer:1.2](https://hub.docker.com/layers/alfresco/alfresco-pdf-renderer/1.2/images/sha256-962544face9f6d6d1f0a049e711fb3daa2bd975bf4a46b5723c2add2b24bf32c)
+* Imagemagick: [alfresco/alfresco-imagemagick:1.2](https://hub.docker.com/layers/alfresco/alfresco-imagemagick/1.2/images/sha256-fd0b2dfc642eff3189b7877b0595553c84ab1b4ea291b685dab8f80985e2987c)
+* Libreoffice: [alfresco/alfresco-libreoffice:1.2](https://hub.docker.com/layers/alfresco/alfresco-libreoffice/1.2/images/sha256-18627d9f5dc71e1608d658df38002d74d441edf031e2c2241c1d41d60c9153be)
+
+### Helm Chart Version 1.0.2 - ACS Version 6.0.0
+* Repository: [alfresco/alfresco-content-repository:6.0.0](https://hub.docker.com/layers/alfresco/alfresco-content-repository/6.0.0/images/sha256-dcbb92445900579257003c4b2c584ffa3243b807c2e82c09c64ea61694c75b5c)
+* Share: [alfresco/alfresco-share:6.0](https://hub.docker.com/layers/alfresco/alfresco-share/6.0/images/sha256-22aecaf1b6d56bba5e5f9f134bdcde86eb23a750febc4c4e1087c0963a0acf18)
+* Pdfrenderer: [alfresco/alfresco-pdf-renderer:1.2](https://hub.docker.com/layers/alfresco/alfresco-pdf-renderer/1.2/images/sha256-962544face9f6d6d1f0a049e711fb3daa2bd975bf4a46b5723c2add2b24bf32c)
+* Imagemagick: [alfresco/alfresco-imagemagick:1.2](https://hub.docker.com/layers/alfresco/alfresco-imagemagick/1.2/images/sha256-fd0b2dfc642eff3189b7877b0595553c84ab1b4ea291b685dab8f80985e2987c)
+* Libreoffice: [alfresco/alfresco-libreoffice:1.2](https://hub.docker.com/layers/alfresco/alfresco-libreoffice/1.2/images/sha256-18627d9f5dc71e1608d658df38002d74d441edf031e2c2241c1d41d60c9153be)
+
+### Helm Chart Version 1.0.1 - ACS Version 6.0.0
+* Repository: [alfresco/alfresco-content-repository:6.0.0](https://hub.docker.com/layers/alfresco/alfresco-content-repository/6.0.0/images/sha256-dcbb92445900579257003c4b2c584ffa3243b807c2e82c09c64ea61694c75b5c)
+* Share: [alfresco/alfresco-share:6.0](https://hub.docker.com/layers/alfresco/alfresco-share/6.0/images/sha256-22aecaf1b6d56bba5e5f9f134bdcde86eb23a750febc4c4e1087c0963a0acf18)
+* Pdfrenderer: [alfresco/alfresco-pdf-renderer:1.2](https://hub.docker.com/layers/alfresco/alfresco-pdf-renderer/1.2/images/sha256-962544face9f6d6d1f0a049e711fb3daa2bd975bf4a46b5723c2add2b24bf32c)
+* Imagemagick: [alfresco/alfresco-imagemagick:1.2](https://hub.docker.com/layers/alfresco/alfresco-imagemagick/1.2/images/sha256-fd0b2dfc642eff3189b7877b0595553c84ab1b4ea291b685dab8f80985e2987c)
+* Libreoffice: [alfresco/alfresco-libreoffice:1.2](https://hub.docker.com/layers/alfresco/alfresco-libreoffice/1.2/images/sha256-18627d9f5dc71e1608d658df38002d74d441edf031e2c2241c1d41d60c9153be)
+
+### Helm Chart Version 1.0.0 - ACS Version 6.0.0
+* Repository: [alfresco/alfresco-content-repository:6.0.0](https://hub.docker.com/layers/alfresco/alfresco-content-repository/6.0.0/images/sha256-dcbb92445900579257003c4b2c584ffa3243b807c2e82c09c64ea61694c75b5c)
+* Share: [alfresco/alfresco-share:6.0.b](https://hub.docker.com/layers/alfresco/alfresco-share/6.0.b/images/sha256-c802cbdb37fe08392b927f31fb0cb1449735db05145f77fa70ab4c7d3f69b523)
+* Pdfrenderer: [alfresco/alfresco-pdf-renderer:1.2](https://hub.docker.com/layers/alfresco/alfresco-pdf-renderer/1.2/images/sha256-962544face9f6d6d1f0a049e711fb3daa2bd975bf4a46b5723c2add2b24bf32c)
+* Imagemagick: [alfresco/alfresco-imagemagick:1.2](https://hub.docker.com/layers/alfresco/alfresco-imagemagick/1.2/images/sha256-fd0b2dfc642eff3189b7877b0595553c84ab1b4ea291b685dab8f80985e2987c)
+* Libreoffice: [alfresco/alfresco-libreoffice:1.2](https://hub.docker.com/layers/alfresco/alfresco-libreoffice/1.2/images/sha256-18627d9f5dc71e1608d658df38002d74d441edf031e2c2241c1d41d60c9153be)


### PR DESCRIPTION
- Extend [docs/helm-chart-releases.md](https://github.com/Alfresco/acs-deployment/blob/master/docs/helm-chart-releases.md) file with docker image information which is part of ACS Helm chart.