### PR TITLE
REPO-4643: Update ACS 6.1.1

### DIFF
--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -12,7 +12,7 @@ version: "2"
 
 services:
     alfresco:
-        image: alfresco/alfresco-content-repository:6.1.1-RC3
+        image: alfresco/alfresco-content-repository:6.1.1
         mem_limit: 1700m
         environment:
             JAVA_OPTS: "

--- a/helm/alfresco-content-services/ai-reference-values.yaml
+++ b/helm/alfresco-content-services/ai-reference-values.yaml
@@ -1,7 +1,7 @@
 repository:
   image:
     repository: quay.io/alfresco/alfresco-content-repository-aws
-    tag: "6.1.1-RC3"
+    tag: "6.1.1"
 
 share:
   image:

--- a/helm/alfresco-content-services/values.yaml
+++ b/helm/alfresco-content-services/values.yaml
@@ -13,7 +13,7 @@ repository:
   replicaCount: 2
   image:
     repository: alfresco/alfresco-content-repository
-    tag: "6.1.1-RC3"
+    tag: "6.1.1"
     pullPolicy: Always
     internalPort: 8080
     hazelcastPort: 5701


### PR DESCRIPTION
Updated CS to version `6.1.1`.
Chart version is already set to `2.1.0`.