### PR TITLE
REPO-4569: Use registryPullSecrets as a global value for parent and child Alfresco Helm charts

### DIFF
--- a/docs/helm-deployment-aws_kops.md
+++ b/docs/helm-deployment-aws_kops.md
@@ -386,7 +386,7 @@ kubectl create -f secrets.yaml --namespace $DESIREDNAMESPACE
 secret "quay-registry-secret" created
 ```
 
-**Note:** When installing the ACS Helm chart, we'll add the variable ```--set registryPullSecrets=quay-registry-secret```.
+**Note:** When installing the ACS Helm chart, we'll add the variable ```--set global.alfrescoRegistryPullSecrets=quay-registry-secret```.
 
 ### Deploying Alfresco Content Services
 
@@ -420,7 +420,7 @@ helm install alfresco-incubator/alfresco-content-services \
 --set alfresco-search.resources.requests.memory="2500Mi",alfresco-search.resources.limits.memory="2500Mi" \
 --set alfresco-search.environment.SOLR_JAVA_MEM="-Xms2000M -Xmx2000M" \
 --set postgresql.postgresPassword="$ALF_DB_PWD" \
---set registryPullSecrets=quay-registry-secret \
+--set global.alfrescoRegistryPullSecrets=quay-registry-secret \
 --namespace=$DESIREDNAMESPACE
 ```
 
@@ -466,7 +466,7 @@ helm install alfresco-incubator/alfresco-content-services \
 --set database.user="myuser" \
 --set database.password="mypass" \
 --set database.url="jdbc:postgresql://mydb.eu-west-1.rds.amazonaws.com:5432/mydb" \
---set registryPullSecrets=quay-registry-secret \
+--set global.alfrescoRegistryPullSecrets=quay-registry-secret \
 --namespace=$DESIREDNAMESPACE
 ```
 
@@ -509,7 +509,7 @@ helm install alfresco-incubator/alfresco-content-services \
 --set messageBroker.url="$MESSAGE_BROKER_URL" \
 --set messageBroker.user="$MESSAGE_BROKER_USER" \
 --set messageBroker.password="$MESSAGE_BROKER_PASSWORD" \
---set registryPullSecrets=quay-registry-secret \
+--set global.alfrescoRegistryPullSecrets=quay-registry-secret \
 --namespace=$DESIREDNAMESPACE
 ```
 
@@ -533,7 +533,7 @@ helm install alfresco-incubator/alfresco-content-services \
 --set s3connector.config.bucketName=myBucket \
 --set s3connector.secrets.encryption=kms \
 --set s3connector.secrets.awsKmsKeyId=Your KMS Key ID \
---set registryPullSecrets=quay-registry-secret \
+--set global.alfrescoRegistryPullSecrets=quay-registry-secret \
 --namespace=$DESIREDNAMESPACE
 ```
 

--- a/docs/use-cases/acs-deployment-with-external-database-kops.md
+++ b/docs/use-cases/acs-deployment-with-external-database-kops.md
@@ -67,7 +67,7 @@ helm install alfresco-incubator/alfresco-content-services \
 --set externalPort="443" \
 ...
 ...
---set registryPullSecrets=quay-registry-secret \
+--set global.alfrescoRegistryPullSecrets=quay-registry-secret \
 --set repository.image.repository="alfresco/alfresco-content-repository-aws" \
 --set repository.image.tag="0.1.3-repo-6.0.0.3" \
 --set postgresql.enabled=false \

--- a/docs/use-cases/acs-deployment-with-s3-connector-kops.md
+++ b/docs/use-cases/acs-deployment-with-s3-connector-kops.md
@@ -143,7 +143,7 @@ helm install alfresco-incubator/alfresco-content-services \
 --set externalPort="443" \
 ...
 ...
---set registryPullSecrets=quay-registry-secret \
+--set global.alfrescoRegistryPullSecrets=quay-registry-secret \
 --set s3connector.enabled=true \
 --set s3connector.config.bucketName="$ACS_S3_BUCKET" \
 --set s3connector.config.bucketLocation="$AWS_DEFAULT_REGION" \

--- a/helm/alfresco-content-services/Chart.yaml
+++ b/helm/alfresco-content-services/Chart.yaml
@@ -2,7 +2,7 @@
 # that goes into read-only mode after 2-days.
 # Request an extended 30-day trial at https://www.alfresco.com/platform/content-services-ecm/trial/docker
 name: alfresco-content-services
-version: 4.0.0
+version: 4.0.1
 appVersion: 6.3.0
 description: A Helm chart for deploying Alfresco Content Services
 keywords:

--- a/helm/alfresco-content-services/requirements.yaml
+++ b/helm/alfresco-content-services/requirements.yaml
@@ -10,7 +10,7 @@ dependencies:
   repository: https://kubernetes-charts.storage.googleapis.com/
   condition: postgresql.enabled
 - name: alfresco-search
-  version: 1.0.0
+  version: 1.0.1
   repository: https://kubernetes-charts.alfresco.com/stable
   condition: alfresco-search.enabled
 - name: alfresco-infrastructure
@@ -18,10 +18,10 @@ dependencies:
   condition: alfresco-content-services.alfresco-infrastructure.enabled
   repository: https://kubernetes-charts.alfresco.com/stable
 - name: alfresco-digital-workspace
-  version: 1.2.0
+  version: 2.0.0
   condition: alfresco-digital-workspace.enabled
   repository: https://kubernetes-charts.alfresco.com/stable
 - name: alfresco-sync-service
-  version: 1.0.0
+  version: 2.0.0-RC2
   condition: alfresco-sync-service.enabled
   repository: https://kubernetes-charts.alfresco.com/stable

--- a/helm/alfresco-content-services/templates/deployment-ai-transformer.yaml
+++ b/helm/alfresco-content-services/templates/deployment-ai-transformer.yaml
@@ -20,10 +20,10 @@ spec:
         release: {{ .Release.Name }}
         component: transformers
     spec:
-      {{- if .Values.registryPullSecrets }}
+      {{- if .Values.global.alfrescoRegistryPullSecrets }}
       # only set this secret if a private docker registry variable is defined
       imagePullSecrets:
-        - name: {{ .Values.registryPullSecrets }}
+        - name: {{ .Values.global.alfrescoRegistryPullSecrets }}
       {{- end }}
       affinity:
         podAntiAffinity:

--- a/helm/alfresco-content-services/templates/deployment-filestore.yaml
+++ b/helm/alfresco-content-services/templates/deployment-filestore.yaml
@@ -19,10 +19,10 @@ spec:
         release: {{ .Release.Name }}
         component: transformers
     spec:
-      {{- if .Values.registryPullSecrets }}
+      {{- if .Values.global.alfrescoRegistryPullSecrets }}
       # only set this secret if a private docker registry variable is defined
       imagePullSecrets:
-        - name: {{ .Values.registryPullSecrets }}
+        - name: {{ .Values.global.alfrescoRegistryPullSecrets }}
       {{- end }}
       affinity:
         podAntiAffinity:

--- a/helm/alfresco-content-services/templates/deployment-imagemagick.yaml
+++ b/helm/alfresco-content-services/templates/deployment-imagemagick.yaml
@@ -19,10 +19,10 @@ spec:
         release: {{ .Release.Name }}
         component: transformers
     spec:
-      {{- if .Values.registryPullSecrets }}
+      {{- if .Values.global.alfrescoRegistryPullSecrets }}
       # only set this secret if a private docker registry variable is defined
       imagePullSecrets:
-        - name: {{ .Values.registryPullSecrets }}
+        - name: {{ .Values.global.alfrescoRegistryPullSecrets }}
       {{- end }}
       affinity:
         podAntiAffinity:

--- a/helm/alfresco-content-services/templates/deployment-libreoffice.yaml
+++ b/helm/alfresco-content-services/templates/deployment-libreoffice.yaml
@@ -19,10 +19,10 @@ spec:
         release: {{ .Release.Name }}
         component: transformers
     spec:
-      {{- if .Values.registryPullSecrets }}
+      {{- if .Values.global.alfrescoRegistryPullSecrets }}
       # only set this secret if a private docker registry variable is defined
       imagePullSecrets:
-        - name: {{ .Values.registryPullSecrets }}
+        - name: {{ .Values.global.alfrescoRegistryPullSecrets }}
       {{- end }}
       affinity:
         podAntiAffinity:

--- a/helm/alfresco-content-services/templates/deployment-pdfrenderer.yaml
+++ b/helm/alfresco-content-services/templates/deployment-pdfrenderer.yaml
@@ -19,10 +19,10 @@ spec:
         release: {{ .Release.Name }}
         component: transformers
     spec:
-      {{- if .Values.registryPullSecrets }}
+      {{- if .Values.global.alfrescoRegistryPullSecrets }}
       # only set this secret if a private docker registry variable is defined
       imagePullSecrets:
-        - name: {{ .Values.registryPullSecrets }}
+        - name: {{ .Values.global.alfrescoRegistryPullSecrets }}
       {{- end }}
       affinity:
         podAntiAffinity:

--- a/helm/alfresco-content-services/templates/deployment-repository.yaml
+++ b/helm/alfresco-content-services/templates/deployment-repository.yaml
@@ -18,10 +18,10 @@ spec:
         release: {{ .Release.Name }}
         component: repository
     spec:
-      {{- if .Values.registryPullSecrets }}
+      {{- if .Values.global.alfrescoRegistryPullSecrets }}
       # only set this secret if a private docker registry variable is defined
       imagePullSecrets:
-        - name: {{ .Values.registryPullSecrets }}
+        - name: {{ .Values.global.alfrescoRegistryPullSecrets }}
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}

--- a/helm/alfresco-content-services/templates/deployment-share.yaml
+++ b/helm/alfresco-content-services/templates/deployment-share.yaml
@@ -18,10 +18,10 @@ spec:
         release: {{ .Release.Name }}
         component: share
     spec:
-      {{- if .Values.registryPullSecrets }}
+      {{- if .Values.global.alfrescoRegistryPullSecrets }}
       # only set this secret if a private docker registry variable is defined
       imagePullSecrets:
-        - name: {{ .Values.registryPullSecrets }}
+        - name: {{ .Values.global.alfrescoRegistryPullSecrets }}
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}

--- a/helm/alfresco-content-services/templates/deployment-tika.yaml
+++ b/helm/alfresco-content-services/templates/deployment-tika.yaml
@@ -19,10 +19,10 @@ spec:
         release: {{ .Release.Name }}
         component: transformers
     spec:
-      {{- if .Values.registryPullSecrets }}
+      {{- if .Values.global.alfrescoRegistryPullSecrets }}
       # only set this secret if a private docker registry variable is defined
       imagePullSecrets:
-        - name: {{ .Values.registryPullSecrets }}
+        - name: {{ .Values.global.alfrescoRegistryPullSecrets }}
       {{- end }}
       affinity:
         podAntiAffinity:

--- a/helm/alfresco-content-services/templates/deployment-transform-misc.yaml
+++ b/helm/alfresco-content-services/templates/deployment-transform-misc.yaml
@@ -19,10 +19,10 @@ spec:
         release: {{ .Release.Name }}
         component: transformers
     spec:
-      {{- if .Values.registryPullSecrets }}
+      {{- if .Values.global.alfrescoRegistryPullSecrets }}
       # only set this secret if a private docker registry variable is defined
       imagePullSecrets:
-        - name: {{ .Values.registryPullSecrets }}
+        - name: {{ .Values.global.alfrescoRegistryPullSecrets }}
       {{- end }}
       affinity:
         podAntiAffinity:

--- a/helm/alfresco-content-services/templates/deployment-transform-router.yaml
+++ b/helm/alfresco-content-services/templates/deployment-transform-router.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       # only set this secret if a private docker registry variable is defined
       imagePullSecrets:
-        - name: {{ .Values.registryPullSecrets }}
+        - name: {{ .Values.global.alfrescoRegistryPullSecrets }}
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:

--- a/helm/alfresco-content-services/values.yaml
+++ b/helm/alfresco-content-services/values.yaml
@@ -402,7 +402,6 @@ alfresco-search:
     # Alfresco Search services endpoint ('/solr') is disabled by default
     # To enable it please see: acs-deployment configuration table](https://github.com/Alfresco/acs-deployment/tree/master/helm/alfresco-content-services#configuration)
     enabled: false
-  registryPullSecrets: "quay-registry-secret"
 
 alfresco-digital-workspace:
   enabled: true
@@ -474,10 +473,14 @@ s3connector:
 
 # If there is a need to pull images from a private docker repo, a secret can be defined in helm and passed as an argument
 # to the install command:
-# e.g.: helm install alfresco-content-services --set registryPullSecrets=private-repo-registry-secret
+# e.g.: helm install alfresco-content-services --set global.alfrescoRegistryPullSecrets=quay-registry-secret
 # or uncomment the following line if you don't want/need to pass it as a parameter on every install command :
-# registryPullSecrets: private-repo-registry-secret
+# global.alfrescoRegistryPullSecrets: quay-registry-secret
 # for more information: https://github.com/Alfresco/alfresco-anaxes-shipyard/blob/master/SECRETS.md
+
+# Global definition of Docker registry pull secret which can be accessed by dependent ACS Helm chart(s)
+global:
+  alfrescoRegistryPullSecrets:
 
 alfresco-sync-service:
    enabled : true

--- a/helm/deploy-acs-with-ai.sh
+++ b/helm/deploy-acs-with-ai.sh
@@ -33,7 +33,7 @@ helm install alfresco-content-services \
     --set persistence.solr.data.subPath="${DESIREDNAMESPACE}/alfresco-content-services/solr-data" \
     --set postgresql.postgresPassword="${ALF_DB_PWD}" \
     --set postgresql.persistence.subPath="${DESIREDNAMESPACE}/alfresco-content-services/database-data" \
-    --set registryPullSecrets="${QUAY_PULL_SECRET}" \
+    --set global.alfrescoRegistryPullSecrets="${QUAY_PULL_SECRET}" \
     --set ai.aws.accessKey="${AI_AWS_ACCESS_KEY_ID}" \
     --set ai.aws.secretAccessKey="${AI_AWS_SECRET_KEY}" \
     --set ai.aws.region="${AI_AWS_REGION}" \


### PR DESCRIPTION
- Defined a new global variable called alfrescoRegistryPullSecrets in ACS parent and child helm chart and updated chart versions
- These changes are made for ACS Helm chart version 6.2 for `master` branch