### PR TITLE
fix(MNT-21042): added rollingUpdate values with sensible defaults

### DIFF
--- a/helm/alfresco-content-services/templates/deployment-ai-transformer.yaml
+++ b/helm/alfresco-content-services/templates/deployment-ai-transformer.yaml
@@ -13,6 +13,11 @@ metadata:
     component: transformers
 spec:
   replicas: {{ .Values.aiTransformer.replicaCount }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: {{ .Values.rollingUpdateMaxSurge | default 1 }}
+      maxUnavailable: {{ .Values.rollingUpdateMaxUnavailable | default 0 }}    
   template:
     metadata:
       labels:

--- a/helm/alfresco-content-services/templates/deployment-filestore.yaml
+++ b/helm/alfresco-content-services/templates/deployment-filestore.yaml
@@ -12,6 +12,11 @@ metadata:
     component: transformers
 spec:
   replicas: {{ .Values.filestore.replicaCount }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: {{ .Values.rollingUpdateMaxSurge | default 1 }}
+      maxUnavailable: {{ .Values.rollingUpdateMaxUnavailable | default 0 }}    
   template:
     metadata:
       labels:

--- a/helm/alfresco-content-services/templates/deployment-imagemagick.yaml
+++ b/helm/alfresco-content-services/templates/deployment-imagemagick.yaml
@@ -12,6 +12,11 @@ metadata:
     component: transformers
 spec:
   replicas: {{ .Values.imagemagick.replicaCount }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: {{ .Values.rollingUpdateMaxSurge | default 1 }}
+      maxUnavailable: {{ .Values.rollingUpdateMaxUnavailable | default 0 }}    
   template:
     metadata:
       labels:

--- a/helm/alfresco-content-services/templates/deployment-libreoffice.yaml
+++ b/helm/alfresco-content-services/templates/deployment-libreoffice.yaml
@@ -12,6 +12,11 @@ metadata:
     component: transformers
 spec:
   replicas: {{ .Values.libreoffice.replicaCount }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: {{ .Values.rollingUpdateMaxSurge | default 1 }}
+      maxUnavailable: {{ .Values.rollingUpdateMaxUnavailable | default 0 }}    
   template:
     metadata:
       labels:

--- a/helm/alfresco-content-services/templates/deployment-pdfrenderer.yaml
+++ b/helm/alfresco-content-services/templates/deployment-pdfrenderer.yaml
@@ -12,6 +12,11 @@ metadata:
     component: transformers
 spec:
   replicas: {{ .Values.pdfrenderer.replicaCount }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: {{ .Values.rollingUpdateMaxSurge | default 1 }}
+      maxUnavailable: {{ .Values.rollingUpdateMaxUnavailable | default 0 }}    
   template:
     metadata:
       labels:

--- a/helm/alfresco-content-services/templates/deployment-repository.yaml
+++ b/helm/alfresco-content-services/templates/deployment-repository.yaml
@@ -11,6 +11,11 @@ metadata:
     component: repository
 spec:
   replicas: {{ .Values.repository.replicaCount }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: {{ .Values.rollingUpdateMaxSurge | default 1 }}
+      maxUnavailable: {{ .Values.rollingUpdateMaxUnavailable | default 0 }}    
   template:
     metadata:
       labels:
@@ -72,6 +77,10 @@ spec:
             periodSeconds: {{ .Values.repository.livenessProbe.periodSeconds }}
             failureThreshold: 1
             timeoutSeconds: {{ .Values.repository.livenessProbe.timeoutSeconds }}
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/bash", "-c", "sleep 20"]            
       {{- if or (eq .Values.database.external false) (.Values.persistence.repository.enabled) }}
       initContainers:
       {{- if eq .Values.database.external false }}

--- a/helm/alfresco-content-services/templates/deployment-share.yaml
+++ b/helm/alfresco-content-services/templates/deployment-share.yaml
@@ -11,6 +11,11 @@ metadata:
     component: share
 spec:
   replicas: {{ .Values.share.replicaCount }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: {{ .Values.rollingUpdateMaxSurge | default 1 }}
+      maxUnavailable: {{ .Values.rollingUpdateMaxUnavailable | default 0 }}    
   template:
     metadata:
       labels:
@@ -49,3 +54,7 @@ spec:
             periodSeconds: {{ .Values.share.livenessProbe.periodSeconds }}
             failureThreshold: 1
             timeoutSeconds: {{ .Values.share.livenessProbe.timeoutSeconds }}
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/bash", "-c", "sleep 20"]            

--- a/helm/alfresco-content-services/templates/deployment-tika.yaml
+++ b/helm/alfresco-content-services/templates/deployment-tika.yaml
@@ -12,6 +12,11 @@ metadata:
     component: transformers
 spec:
   replicas: {{ .Values.tika.replicaCount }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: {{ .Values.rollingUpdateMaxSurge | default 1 }}
+      maxUnavailable: {{ .Values.rollingUpdateMaxUnavailable | default 0 }}    
   template:
     metadata:
       labels:

--- a/helm/alfresco-content-services/templates/deployment-transform-misc.yaml
+++ b/helm/alfresco-content-services/templates/deployment-transform-misc.yaml
@@ -12,6 +12,11 @@ metadata:
     component: transformers
 spec:
   replicas: {{ .Values.transformmisc.replicaCount }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: {{ .Values.rollingUpdateMaxSurge | default 1 }}
+      maxUnavailable: {{ .Values.rollingUpdateMaxUnavailable | default 0 }}    
   template:
     metadata:
       labels:

--- a/helm/alfresco-content-services/templates/deployment-transform-router.yaml
+++ b/helm/alfresco-content-services/templates/deployment-transform-router.yaml
@@ -10,6 +10,11 @@ metadata:
     component: transformrouter
 spec:
   replicas: {{ .Values.transformrouter.replicaCount }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: {{ .Values.rollingUpdateMaxSurge | default 1 }}
+      maxUnavailable: {{ .Values.rollingUpdateMaxUnavailable | default 0 }}    
   template:
     metadata:
       labels:


### PR DESCRIPTION
This PR fixes https://issues.alfresco.com/jira/browse/MNT-21042

- [x] Added rolling update strategy deployment configuration `maxUnavailble=0` to ensure no unvailable pod replicas with `maxSurge=1`

- [x] Added Container `PreStop` lifecycle hook to wait in order to properly drain existing connections before pod shutdown
    
repository-deployment.yaml  
```
spec:   
  replicas: {{ .Values.repository.replicaCount }}  
  # Sensible default values for rolling updates
  strategy: 
    type: RollingUpdate 
    rollingUpdate:  
      maxSurge: {{ .Values.rollingUpdateMaxSurge | default 1 }} 
      maxUnavailable: {{ .Values.rollingUpdateMaxUnavailable | default 0 }}     
  template: 
    metadata:   
      containers:   
        - name: {{ .Chart.Name }}   
          # sleep to drain any existing connections
          lifecycle:    
            preStop:    
              exec: 
                command: ["/bin/bash", "-c", "sleep 20"]    
```

Resolution: Rolling update starts  new pod and initiates old pod shutdown only after existing connections are drained to achieve zero donwtime update 
