### PR TITLE
REPO-4916 MNT-21041: ACS Helm upgrade to update configuration values does not restart affected pods

### DIFF
--- a/helm/alfresco-content-services/requirements.yaml
+++ b/helm/alfresco-content-services/requirements.yaml
@@ -10,7 +10,7 @@ dependencies:
   repository: https://kubernetes-charts.storage.googleapis.com/
   condition: postgresql.enabled
 - name: alfresco-search
-  version: 1.0.1
+  version: 1.0.2
   repository: https://kubernetes-charts.alfresco.com/stable
   condition: alfresco-search.enabled
 - name: alfresco-infrastructure

--- a/helm/alfresco-content-services/templates/config-repository.yaml
+++ b/helm/alfresco-content-services/templates/config-repository.yaml
@@ -72,7 +72,7 @@ data:
       -Dmessaging.broker.password={{ .Values.messageBroker.password }}
       {{- end }}
       {{- if index .Values "alfresco-sync-service" "enabled" }}
-      -Ddsync.service.uris={{ .Values.externalProtocol | default "http" }}://{{ .Values.externalHost }}:{{ .Values.externalPort }}/syncservice
+      -Ddsync.service.uris={{ $alfprotocol }}://{{ $alfhost }}:{{ $alfport }}/syncservice
       {{- else }}
       -Devents.subsystem.autoStart=false
       {{- end }}"

--- a/helm/alfresco-content-services/templates/deployment-ai-transformer.yaml
+++ b/helm/alfresco-content-services/templates/deployment-ai-transformer.yaml
@@ -15,6 +15,8 @@ spec:
   replicas: {{ .Values.aiTransformer.replicaCount }}
   template:
     metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/config-ai-transformer.yaml") . | sha256sum }}
       labels:
         app: {{ template "content-services.shortname" . }}-ai-transformer
         release: {{ .Release.Name }}

--- a/helm/alfresco-content-services/templates/deployment-filestore.yaml
+++ b/helm/alfresco-content-services/templates/deployment-filestore.yaml
@@ -13,6 +13,8 @@ metadata:
 spec:
   replicas: {{ .Values.filestore.replicaCount }}
   template:
+    annotations:
+      checksum/config: {{ include (print $.Template.BasePath "/config-filestore.yaml") . | sha256sum }}
     metadata:
       labels:
         app: {{ template "alfresco.shortname" . }}-filestore

--- a/helm/alfresco-content-services/templates/deployment-imagemagick.yaml
+++ b/helm/alfresco-content-services/templates/deployment-imagemagick.yaml
@@ -14,6 +14,8 @@ spec:
   replicas: {{ .Values.imagemagick.replicaCount }}
   template:
     metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/config-imagemagick.yaml") . | sha256sum }}
       labels:
         app: {{ template "content-services.shortname" . }}-imagemagick
         release: {{ .Release.Name }}

--- a/helm/alfresco-content-services/templates/deployment-libreoffice.yaml
+++ b/helm/alfresco-content-services/templates/deployment-libreoffice.yaml
@@ -14,6 +14,8 @@ spec:
   replicas: {{ .Values.libreoffice.replicaCount }}
   template:
     metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/config-libreoffice.yaml") . | sha256sum }}
       labels:
         app: {{ template "content-services.shortname" . }}-libreoffice
         release: {{ .Release.Name }}

--- a/helm/alfresco-content-services/templates/deployment-pdfrenderer.yaml
+++ b/helm/alfresco-content-services/templates/deployment-pdfrenderer.yaml
@@ -14,6 +14,8 @@ spec:
   replicas: {{ .Values.pdfrenderer.replicaCount }}
   template:
     metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/config-pdfrenderer.yaml") . | sha256sum }}
       labels:
         app: {{ template "content-services.shortname" . }}-pdfrenderer
         release: {{ .Release.Name }}

--- a/helm/alfresco-content-services/templates/deployment-repository.yaml
+++ b/helm/alfresco-content-services/templates/deployment-repository.yaml
@@ -15,6 +15,8 @@ spec:
     metadata:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/config-repository.yaml") . | sha256sum }}
+        checksum/secretDatabase: {{ include (print $.Template.BasePath "/secret-database.yaml") . | sha256sum }}
+        checksum/secretS3: {{ include (print $.Template.BasePath "/secret-s3.yaml") . | sha256sum }}
       labels:
         app: {{ template "content-services.shortname" . }}-repository
         release: {{ .Release.Name }}

--- a/helm/alfresco-content-services/templates/deployment-repository.yaml
+++ b/helm/alfresco-content-services/templates/deployment-repository.yaml
@@ -13,6 +13,8 @@ spec:
   replicas: {{ .Values.repository.replicaCount }}
   template:
     metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/config-repository.yaml") . | sha256sum }}
       labels:
         app: {{ template "content-services.shortname" . }}-repository
         release: {{ .Release.Name }}

--- a/helm/alfresco-content-services/templates/deployment-share.yaml
+++ b/helm/alfresco-content-services/templates/deployment-share.yaml
@@ -13,6 +13,8 @@ spec:
   replicas: {{ .Values.share.replicaCount }}
   template:
     metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/config-share.yaml") . | sha256sum }}
       labels:
         app: {{ template "content-services.shortname" . }}-share
         release: {{ .Release.Name }}

--- a/helm/alfresco-content-services/templates/deployment-tika.yaml
+++ b/helm/alfresco-content-services/templates/deployment-tika.yaml
@@ -14,6 +14,8 @@ spec:
   replicas: {{ .Values.tika.replicaCount }}
   template:
     metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/config-tika.yaml") . | sha256sum }}
       labels:
         app: {{ template "content-services.shortname" . }}-tika
         release: {{ .Release.Name }}

--- a/helm/alfresco-content-services/templates/deployment-transform-misc.yaml
+++ b/helm/alfresco-content-services/templates/deployment-transform-misc.yaml
@@ -14,6 +14,8 @@ spec:
   replicas: {{ .Values.transformmisc.replicaCount }}
   template:
     metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/config-transform-misc.yaml") . | sha256sum }}
       labels:
         app: {{ template "content-services.shortname" . }}-transform-misc
         release: {{ .Release.Name }}

--- a/helm/alfresco-content-services/templates/deployment-transform-router.yaml
+++ b/helm/alfresco-content-services/templates/deployment-transform-router.yaml
@@ -12,6 +12,9 @@ spec:
   replicas: {{ .Values.transformrouter.replicaCount }}
   template:
     metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/config-transform-router.yaml") . | sha256sum }}
+        checksum/config-routes: {{ include (print $.Template.BasePath "/config-transformer-routes.yaml") . | sha256sum }}
       labels:
         app: {{ template "alfresco.shortname" . }}-router
         release: {{ .Release.Name }}


### PR DESCRIPTION
- #278 
- Enhance the PR by covering secrets (i.e. if passwords or aws access key/secrets are changed then it should trigger a new repository pod with updated credentials).