### PR TITLE
MNT-21042: ACS Helm upgrade fails to perform rolling update with zero downtime

### DIFF
--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -134,7 +134,7 @@ services:
             - activemq
 
     shared-file-store:
-        image: alfresco/alfresco-shared-file-store:0.5.3
+        image: alfresco/alfresco-shared-file-store:0.6.0
         mem_limit: 512m
         environment:
             JAVA_OPTS: " -Xms256m -Xmx512m"

--- a/helm/alfresco-content-services/requirements.yaml
+++ b/helm/alfresco-content-services/requirements.yaml
@@ -10,7 +10,7 @@ dependencies:
   repository: https://kubernetes-charts.storage.googleapis.com/
   condition: postgresql.enabled
 - name: alfresco-search
-  version: 1.0.2
+  version: 1.0.3
   repository: https://kubernetes-charts.alfresco.com/stable
   condition: alfresco-search.enabled
 - name: alfresco-infrastructure

--- a/helm/alfresco-content-services/requirements.yaml
+++ b/helm/alfresco-content-services/requirements.yaml
@@ -18,7 +18,7 @@ dependencies:
   condition: alfresco-content-services.alfresco-infrastructure.enabled
   repository: https://kubernetes-charts.alfresco.com/stable
 - name: alfresco-digital-workspace
-  version: 2.2.0
+  version: 2.2.1
   condition: alfresco-digital-workspace.enabled
   repository: https://kubernetes-charts.alfresco.com/stable
 - name: alfresco-sync-service

--- a/helm/alfresco-content-services/templates/deployment-ai-transformer.yaml
+++ b/helm/alfresco-content-services/templates/deployment-ai-transformer.yaml
@@ -16,8 +16,7 @@ spec:
   strategy:
     type: RollingUpdate
     rollingUpdate:
-      maxSurge: {{ .Values.rollingUpdateMaxSurge | default 1 }}
-      maxUnavailable: {{ .Values.rollingUpdateMaxUnavailable | default 0 }}    
+{{ toYaml .Values.global.strategy.rollingUpdate | indent 6 }}
   template:
     metadata:
       annotations:

--- a/helm/alfresco-content-services/templates/deployment-filestore.yaml
+++ b/helm/alfresco-content-services/templates/deployment-filestore.yaml
@@ -15,8 +15,7 @@ spec:
   strategy:
     type: RollingUpdate
     rollingUpdate:
-      maxSurge: {{ .Values.rollingUpdateMaxSurge | default 1 }}
-      maxUnavailable: {{ .Values.rollingUpdateMaxUnavailable | default 0 }}    
+{{ toYaml .Values.global.strategy.rollingUpdate | indent 6 }}
   template:
     annotations:
       checksum/config: {{ include (print $.Template.BasePath "/config-filestore.yaml") . | sha256sum }}

--- a/helm/alfresco-content-services/templates/deployment-imagemagick.yaml
+++ b/helm/alfresco-content-services/templates/deployment-imagemagick.yaml
@@ -15,8 +15,7 @@ spec:
   strategy:
     type: RollingUpdate
     rollingUpdate:
-      maxSurge: {{ .Values.rollingUpdateMaxSurge | default 1 }}
-      maxUnavailable: {{ .Values.rollingUpdateMaxUnavailable | default 0 }}    
+{{ toYaml .Values.global.strategy.rollingUpdate | indent 6 }}
   template:
     metadata:
       annotations:

--- a/helm/alfresco-content-services/templates/deployment-libreoffice.yaml
+++ b/helm/alfresco-content-services/templates/deployment-libreoffice.yaml
@@ -15,8 +15,7 @@ spec:
   strategy:
     type: RollingUpdate
     rollingUpdate:
-      maxSurge: {{ .Values.rollingUpdateMaxSurge | default 1 }}
-      maxUnavailable: {{ .Values.rollingUpdateMaxUnavailable | default 0 }}    
+{{ toYaml .Values.global.strategy.rollingUpdate | indent 6 }}
   template:
     metadata:
       annotations:

--- a/helm/alfresco-content-services/templates/deployment-pdfrenderer.yaml
+++ b/helm/alfresco-content-services/templates/deployment-pdfrenderer.yaml
@@ -15,8 +15,7 @@ spec:
   strategy:
     type: RollingUpdate
     rollingUpdate:
-      maxSurge: {{ .Values.rollingUpdateMaxSurge | default 1 }}
-      maxUnavailable: {{ .Values.rollingUpdateMaxUnavailable | default 0 }}    
+{{ toYaml .Values.global.strategy.rollingUpdate | indent 6 }}
   template:
     metadata:
       annotations:

--- a/helm/alfresco-content-services/templates/deployment-repository.yaml
+++ b/helm/alfresco-content-services/templates/deployment-repository.yaml
@@ -12,10 +12,11 @@ metadata:
 spec:
   replicas: {{ .Values.repository.replicaCount }}
   strategy:
-    type: {{ .Values.repository.updateStrategyType | default "RollingUpdate" }}
-    rollingUpdate:
-      maxSurge: {{ .Values.rollingUpdateMaxSurge | default 1 }}
-      maxUnavailable: {{ .Values.rollingUpdateMaxUnavailable | default 0 }}    
+    type: Recreate
+    rollingUpdate: null
+    # rollingUpdate:
+    #   maxSurge: {{ .Values.rollingUpdateMaxSurge | default 1 }}
+    #   maxUnavailable: {{ .Values.rollingUpdateMaxUnavailable | default 0 }}    
   template:
     metadata:
       annotations:

--- a/helm/alfresco-content-services/templates/deployment-repository.yaml
+++ b/helm/alfresco-content-services/templates/deployment-repository.yaml
@@ -12,7 +12,7 @@ metadata:
 spec:
   replicas: {{ .Values.repository.replicaCount }}
   strategy:
-    type: RollingUpdate
+    type: {{ .Values.repository.updateStrategyType | default "RollingUpdate" }}
     rollingUpdate:
       maxSurge: {{ .Values.rollingUpdateMaxSurge | default 1 }}
       maxUnavailable: {{ .Values.rollingUpdateMaxUnavailable | default 0 }}    

--- a/helm/alfresco-content-services/templates/deployment-repository.yaml
+++ b/helm/alfresco-content-services/templates/deployment-repository.yaml
@@ -14,7 +14,7 @@ spec:
   strategy:
     {{- if eq .Values.repository.strategy.type "Recreate" }}
     type: {{ .Values.repository.strategy.type }}
-    rollingUpdate: {{ .Values.repository.strategy.rollingUpdate }}
+    rollingUpdate: null
     {{- else }}
     type: RollingUpdate
     rollingUpdate:

--- a/helm/alfresco-content-services/templates/deployment-repository.yaml
+++ b/helm/alfresco-content-services/templates/deployment-repository.yaml
@@ -18,8 +18,7 @@ spec:
     {{- else }}
     type: RollingUpdate
     rollingUpdate:
-      maxSurge: {{ .Values.rollingUpdateMaxSurge | default 1 }}
-      maxUnavailable: {{ .Values.rollingUpdateMaxUnavailable | default 0 }}
+{{ toYaml .Values.global.strategy.rollingUpdate | indent 6 }}
     {{- end }}
   template:
     metadata:

--- a/helm/alfresco-content-services/templates/deployment-repository.yaml
+++ b/helm/alfresco-content-services/templates/deployment-repository.yaml
@@ -12,11 +12,15 @@ metadata:
 spec:
   replicas: {{ .Values.repository.replicaCount }}
   strategy:
-    type: Recreate
-    rollingUpdate: null
-    # rollingUpdate:
-    #   maxSurge: {{ .Values.rollingUpdateMaxSurge | default 1 }}
-    #   maxUnavailable: {{ .Values.rollingUpdateMaxUnavailable | default 0 }}    
+    {{- if eq .Values.repository.strategy.type "Recreate" }}
+    type: {{ .Values.repository.strategy.type }}
+    rollingUpdate: {{ .Values.repository.strategy.rollingUpdate }}
+    {{- else }}
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: {{ .Values.rollingUpdateMaxSurge | default 1 }}
+      maxUnavailable: {{ .Values.rollingUpdateMaxUnavailable | default 0 }}
+    {{- end }}
   template:
     metadata:
       annotations:

--- a/helm/alfresco-content-services/templates/deployment-share.yaml
+++ b/helm/alfresco-content-services/templates/deployment-share.yaml
@@ -14,8 +14,7 @@ spec:
   strategy:
     type: RollingUpdate
     rollingUpdate:
-      maxSurge: {{ .Values.rollingUpdateMaxSurge | default 1 }}
-      maxUnavailable: {{ .Values.rollingUpdateMaxUnavailable | default 0 }}    
+{{ toYaml .Values.global.strategy.rollingUpdate | indent 6 }}
   template:
     metadata:
       annotations:

--- a/helm/alfresco-content-services/templates/deployment-tika.yaml
+++ b/helm/alfresco-content-services/templates/deployment-tika.yaml
@@ -15,8 +15,7 @@ spec:
   strategy:
     type: RollingUpdate
     rollingUpdate:
-      maxSurge: {{ .Values.rollingUpdateMaxSurge | default 1 }}
-      maxUnavailable: {{ .Values.rollingUpdateMaxUnavailable | default 0 }}    
+{{ toYaml .Values.global.strategy.rollingUpdate | indent 6 }}
   template:
     metadata:
       annotations:

--- a/helm/alfresco-content-services/templates/deployment-transform-misc.yaml
+++ b/helm/alfresco-content-services/templates/deployment-transform-misc.yaml
@@ -15,8 +15,7 @@ spec:
   strategy:
     type: RollingUpdate
     rollingUpdate:
-      maxSurge: {{ .Values.rollingUpdateMaxSurge | default 1 }}
-      maxUnavailable: {{ .Values.rollingUpdateMaxUnavailable | default 0 }}    
+{{ toYaml .Values.global.strategy.rollingUpdate | indent 6 }}
   template:
     metadata:
       annotations:

--- a/helm/alfresco-content-services/templates/deployment-transform-router.yaml
+++ b/helm/alfresco-content-services/templates/deployment-transform-router.yaml
@@ -13,8 +13,7 @@ spec:
   strategy:
     type: RollingUpdate
     rollingUpdate:
-      maxSurge: {{ .Values.rollingUpdateMaxSurge | default 1 }}
-      maxUnavailable: {{ .Values.rollingUpdateMaxUnavailable | default 0 }}    
+{{ toYaml .Values.global.strategy.rollingUpdate | indent 6 }}
   template:
     metadata:
       annotations:

--- a/helm/alfresco-content-services/values.yaml
+++ b/helm/alfresco-content-services/values.yaml
@@ -11,6 +11,8 @@
 
 repository:
   replicaCount: 2
+  # MNT-21042: enforce a Recreate update for the repository deployment
+  updateStrategyType: Recreate
   image:
     repository: alfresco/alfresco-content-repository
     tag: "6.3.0-A1"

--- a/helm/alfresco-content-services/values.yaml
+++ b/helm/alfresco-content-services/values.yaml
@@ -11,7 +11,6 @@
 
 repository:
   replicaCount: 2
-  # MNT-21042: enforce a Recreate update for the repository deployment
   updateStrategyType: Recreate
   image:
     repository: alfresco/alfresco-content-repository

--- a/helm/alfresco-content-services/values.yaml
+++ b/helm/alfresco-content-services/values.yaml
@@ -482,6 +482,10 @@ s3connector:
 # Global definition of Docker registry pull secret which can be accessed by dependent ACS Helm chart(s)
 global:
   alfrescoRegistryPullSecrets:
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
 
 alfresco-sync-service:
    enabled : true

--- a/helm/alfresco-content-services/values.yaml
+++ b/helm/alfresco-content-services/values.yaml
@@ -11,7 +11,9 @@
 
 repository:
   replicaCount: 2
-  updateStrategyType: Recreate
+  strategy:
+    type: Recreate
+    rollingUpdate: null
   image:
     repository: alfresco/alfresco-content-repository
     tag: "6.3.0-A1"

--- a/helm/alfresco-content-services/values.yaml
+++ b/helm/alfresco-content-services/values.yaml
@@ -284,7 +284,7 @@ filestore:
   replicaCount: 1
   image:
     repository: alfresco/alfresco-shared-file-store
-    tag: "0.5.3"
+    tag: "0.6.0"
     pullPolicy: Always
     internalPort: 8099
   service:

--- a/helm/alfresco-content-services/values.yaml
+++ b/helm/alfresco-content-services/values.yaml
@@ -13,7 +13,6 @@ repository:
   replicaCount: 2
   strategy:
     type: Recreate
-    rollingUpdate: null
   image:
     repository: alfresco/alfresco-content-repository
     tag: "6.3.0-A1"


### PR DESCRIPTION
- #279 
- Parameterise `strategy` annotation's `type` option for Repository deployment as `Recreate`
- `rollingUpdate` are defined as global parameters to enable Alfresco dependent helm charts can inherit values when ACS helm chart is updated.