### PR TITLE
REPO-4977: Helm client version 3.x is not compatible with ACS helm charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ The **master** branch of this repository will endeavour to support the following
 - [MiniKube](docs/helm-deployment-minikube.md) (latest): For development and POCs
 - [Helm - AWS Cloud with Kubernetes using Kops](docs/helm-deployment-aws_kops.md) (latest): As a deployment template which can be used as the basis for your specific deployment needs
 
+**Note**: The ACS helm chart is currently not supported by Helm cli version v3.x due to deprecated annotations defined in one of the dependent chart, please use Helm cli v2.x in the interim while Helm v3.x support is resolved.
+
 For the Community Edition, go to the [acs-community-deployment](https://github.com/Alfresco/acs-community-deployment).
 The only differences between these projects are:
 * In the Enterprise chart, the images for the transformers are used, instead of the included binaries.

--- a/README.md
+++ b/README.md
@@ -11,8 +11,6 @@ The **master** branch of this repository will endeavour to support the following
 - [MiniKube](docs/helm-deployment-minikube.md) (latest): For development and POCs
 - [Helm - AWS Cloud with Kubernetes using Kops](docs/helm-deployment-aws_kops.md) (latest): As a deployment template which can be used as the basis for your specific deployment needs
 
-**Note**: The ACS helm chart is currently not supported by Helm cli version v3.x due to deprecated annotations defined in one of the dependent chart, please use Helm cli v2.x in the interim while Helm v3.x support is resolved.
-
 For the Community Edition, go to the [acs-community-deployment](https://github.com/Alfresco/acs-community-deployment).
 The only differences between these projects are:
 * In the Enterprise chart, the images for the transformers are used, instead of the included binaries.

--- a/helm/alfresco-content-services/requirements.yaml
+++ b/helm/alfresco-content-services/requirements.yaml
@@ -22,6 +22,6 @@ dependencies:
   condition: alfresco-digital-workspace.enabled
   repository: https://kubernetes-charts.alfresco.com/stable
 - name: alfresco-sync-service
-  version: 2.0.1
+  version: 3.0.2
   condition: alfresco-sync-service.enabled
   repository: https://kubernetes-charts.alfresco.com/stable

--- a/helm/alfresco-content-services/requirements.yaml
+++ b/helm/alfresco-content-services/requirements.yaml
@@ -22,6 +22,6 @@ dependencies:
   condition: alfresco-digital-workspace.enabled
   repository: https://kubernetes-charts.alfresco.com/stable
 - name: alfresco-sync-service
-  version: 2.0.0
+  version: 2.0.1
   condition: alfresco-sync-service.enabled
   repository: https://kubernetes-charts.alfresco.com/stable


### PR DESCRIPTION
- Bump `alfresco-sync-service` chart version to `3.0.2`

Helm k8 annotation error:
```
Error: unable to build kubernetes objects from release manifest: error validating "": error validating data: ValidationError(Deployment.spec.template.spec.containers[0]): unknown field "terminationGracePeriodSeconds" in io.k8s.api.core.v1.Container
```