### PR TITLE
ATS-707: Bump ACS Deployment to T-Engines 2.2.0-TEST1

### DIFF
--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -74,7 +74,7 @@ services:
           - activemq
 
     alfresco-pdf-renderer:
-        image: alfresco/alfresco-pdf-renderer:2.1.1
+        image: alfresco/alfresco-pdf-renderer:2.2.0-TEST1
         mem_limit: 1g
         environment:
             JAVA_OPTS: " -Xms256m -Xmx512m"
@@ -86,7 +86,7 @@ services:
         - activemq
 
     imagemagick:
-        image: alfresco/alfresco-imagemagick:2.1.1
+        image: alfresco/alfresco-imagemagick:2.2.0-TEST1
         mem_limit: 1g
         environment:
             JAVA_OPTS: " -Xms256m -Xmx512m"
@@ -98,7 +98,7 @@ services:
         - activemq
 
     libreoffice:
-        image: alfresco/alfresco-libreoffice:2.1.1
+        image: alfresco/alfresco-libreoffice:2.2.0-TEST1
         mem_limit: 1g
         environment:
             JAVA_OPTS: " -Xms256m -Xmx512m"
@@ -110,7 +110,7 @@ services:
         - activemq
 
     tika:
-        image: alfresco/alfresco-tika:2.1.1
+        image: alfresco/alfresco-tika:2.2.0-TEST1
         mem_limit: 1g
         environment:
             JAVA_OPTS: " -Xms256m -Xmx512m"
@@ -122,7 +122,7 @@ services:
             - activemq
 
     transform-misc:
-        image: alfresco/alfresco-transform-misc:2.1.1
+        image: alfresco/alfresco-transform-misc:2.2.0-TEST1
         mem_limit: 1g
         environment:
             JAVA_OPTS: " -Xms256m -Xmx512m"

--- a/helm/alfresco-content-services/values.yaml
+++ b/helm/alfresco-content-services/values.yaml
@@ -90,7 +90,7 @@ pdfrenderer:
   replicaCount: 2
   image:
     repository: alfresco/alfresco-pdf-renderer
-    tag: "2.1.1"
+    tag: "2.2.0-TEST1"
     pullPolicy: Always
     internalPort: 8090
   service:
@@ -123,7 +123,7 @@ imagemagick:
   replicaCount: 2
   image:
     repository: alfresco/alfresco-imagemagick
-    tag: "2.1.1"
+    tag: "2.2.0-TEST1"
     pullPolicy: Always
     internalPort: 8090
   service:
@@ -156,7 +156,7 @@ libreoffice:
   replicaCount: 2
   image:
     repository: alfresco/alfresco-libreoffice
-    tag: "2.1.1"
+    tag: "2.2.0-TEST1"
     pullPolicy: Always
     internalPort: 8090
   service:
@@ -189,7 +189,7 @@ tika:
   replicaCount: 2
   image:
     repository: alfresco/alfresco-tika
-    tag: "2.1.1"
+    tag: "2.2.0-TEST1"
     pullPolicy: Always
     internalPort: 8090
   service:
@@ -222,7 +222,7 @@ transformmisc:
   replicaCount: 2
   image:
     repository: alfresco/alfresco-transform-misc
-    tag: "2.1.1"
+    tag: "2.2.0-TEST1"
     pullPolicy: Always
     internalPort: 8090
   service:


### PR DESCRIPTION
- initially 2.1.1 to 2.2.0-TEST1 (for existing core x5 T-Engines)
- note: future PRs will update docker-compose to single Core AIO T-Engine (along with T-Router & local transform urls etc)