### PR TITLE
ATS-739: Update ACS Deployment to ATS 1.2.0-A2

### DIFF
--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -52,25 +52,12 @@ services:
 
     transform-router:
         mem_limit: 512m
-        image: quay.io/alfresco/alfresco-transform-router:1.1.1
+        image: quay.io/alfresco/alfresco-transform-router:1.2.0-A2
         environment:
           JAVA_OPTS: " -Xms256m -Xmx512m"
           ACTIVEMQ_URL: "nio://activemq:61616"
 
-          IMAGEMAGICK_URL: "http://transform-core-aio:8090"
-          IMAGEMAGICK_QUEUE : "org.alfresco.transform.engine.aio.acs"
-
-          PDF_RENDERER_URL : "http://transform-core-aio:8090"
-          PDF_RENDERER_QUEUE : "org.alfresco.transform.engine.aio.acs"
-
-          LIBREOFFICE_URL : "http://transform-core-aio:8090"
-          LIBREOFFICE_QUEUE : "org.alfresco.transform.engine.aio.acs"
-
-          TIKA_URL : "http://transform-core-aio:8090"
-          TIKA_QUEUE : "org.alfresco.transform.engine.aio.acs"
-
-          MISC_URL : "http://transform-core-aio:8090"
-          MISC_QUEUE : "org.alfresco.transform.engine.aio.acs"
+          CORE_AIO_URL : "http://transform-core-aio:8090"
 
           FILE_STORE_URL: "http://shared-file-store:8099/alfresco/api/-default-/private/sfs/versions/1/file"
         ports:
@@ -79,7 +66,7 @@ services:
           - activemq
 
     transform-core-aio:
-        image: alfresco/alfresco-transform-core-aio:2.2.0-A4
+        image: alfresco/alfresco-transform-core-aio:2.2.0-A5
         mem_limit: 1536m
         environment:
             JAVA_OPTS: " -Xms256m -Xmx1536m"

--- a/helm/alfresco-content-services/values.yaml
+++ b/helm/alfresco-content-services/values.yaml
@@ -64,7 +64,7 @@ transformrouter:
   replicaCount: 2
   image:
     repository: quay.io/alfresco/alfresco-transform-router
-    tag: "1.1.1"
+    tag: "1.2.0-A2"
     pullPolicy: Always
     internalPort: 8095
   service:
@@ -88,7 +88,7 @@ pdfrenderer:
   replicaCount: 2
   image:
     repository: alfresco/alfresco-pdf-renderer
-    tag: "2.2.0-A4"
+    tag: "2.2.0-A5"
     pullPolicy: Always
     internalPort: 8090
   service:
@@ -121,7 +121,7 @@ imagemagick:
   replicaCount: 2
   image:
     repository: alfresco/alfresco-imagemagick
-    tag: "2.2.0-A4"
+    tag: "2.2.0-A5"
     pullPolicy: Always
     internalPort: 8090
   service:
@@ -154,7 +154,7 @@ libreoffice:
   replicaCount: 2
   image:
     repository: alfresco/alfresco-libreoffice
-    tag: "2.2.0-A4"
+    tag: "2.2.0-A5"
     pullPolicy: Always
     internalPort: 8090
   service:
@@ -187,7 +187,7 @@ tika:
   replicaCount: 2
   image:
     repository: alfresco/alfresco-tika
-    tag: "2.2.0-A4"
+    tag: "2.2.0-A5"
     pullPolicy: Always
     internalPort: 8090
   service:
@@ -220,7 +220,7 @@ transformmisc:
   replicaCount: 2
   image:
     repository: alfresco/alfresco-transform-misc
-    tag: "2.2.0-A4"
+    tag: "2.2.0-A5"
     pullPolicy: Always
     internalPort: 8090
   service:


### PR DESCRIPTION
- T-Router 1.2.0-A2 with T-Engines 2.2.0-A5
- change to single CORE_AIO_URL (ATS-736)