### PR TITLE
ATS-708 / ATS-709: Update to ATS 1.2.0-RC1 & T-engines to 2.2.0

### DIFF
--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -66,7 +66,7 @@ services:
           - activemq
 
     transform-core-aio:
-        image: alfresco/alfresco-transform-core-aio:2.2.0-A5
+        image: alfresco/alfresco-transform-core-aio:2.2.0
         mem_limit: 1536m
         environment:
             JAVA_OPTS: " -Xms256m -Xmx1536m"

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -52,7 +52,7 @@ services:
 
     transform-router:
         mem_limit: 512m
-        image: quay.io/alfresco/alfresco-transform-router:1.2.0-A2
+        image: quay.io/alfresco/alfresco-transform-router:1.2.0-RC1
         environment:
           JAVA_OPTS: " -Xms256m -Xmx512m"
           ACTIVEMQ_URL: "nio://activemq:61616"

--- a/helm/alfresco-content-services/values.yaml
+++ b/helm/alfresco-content-services/values.yaml
@@ -64,7 +64,7 @@ transformrouter:
   replicaCount: 2
   image:
     repository: quay.io/alfresco/alfresco-transform-router
-    tag: "1.2.0-A2"
+    tag: "1.2.0-RC1"
     pullPolicy: Always
     internalPort: 8095
   service:

--- a/helm/alfresco-content-services/values.yaml
+++ b/helm/alfresco-content-services/values.yaml
@@ -88,7 +88,7 @@ pdfrenderer:
   replicaCount: 2
   image:
     repository: alfresco/alfresco-pdf-renderer
-    tag: "2.2.0-A5"
+    tag: "2.2.0"
     pullPolicy: Always
     internalPort: 8090
   service:
@@ -121,7 +121,7 @@ imagemagick:
   replicaCount: 2
   image:
     repository: alfresco/alfresco-imagemagick
-    tag: "2.2.0-A5"
+    tag: "2.2.0"
     pullPolicy: Always
     internalPort: 8090
   service:
@@ -154,7 +154,7 @@ libreoffice:
   replicaCount: 2
   image:
     repository: alfresco/alfresco-libreoffice
-    tag: "2.2.0-A5"
+    tag: "2.2.0"
     pullPolicy: Always
     internalPort: 8090
   service:
@@ -187,7 +187,7 @@ tika:
   replicaCount: 2
   image:
     repository: alfresco/alfresco-tika
-    tag: "2.2.0-A5"
+    tag: "2.2.0"
     pullPolicy: Always
     internalPort: 8090
   service:
@@ -220,7 +220,7 @@ transformmisc:
   replicaCount: 2
   image:
     repository: alfresco/alfresco-transform-misc
-    tag: "2.2.0-A5"
+    tag: "2.2.0"
     pullPolicy: Always
     internalPort: 8090
   service:


### PR DESCRIPTION
- ATS-708: Bump to T-Core/T-Engines 2.2.0
- ATS-709: Bump to ATS 1.2.0-RC1 (T-Service/T-Router)