### PR TITLE
ACS-112: Added ADW url to notes

### DIFF
--- a/helm/alfresco-content-services/templates/NOTES.txt
+++ b/helm/alfresco-content-services/templates/NOTES.txt
@@ -9,6 +9,7 @@ You can access all components of Alfresco Content Services Community using the s
 
   Content: {{ $alfurl }}/alfresco
   Share: {{ $alfurl }}/share
+  Alfresco Digital Workspace: {{ $alfurl }}/workspace/
   Api-Explorer: {{ $alfurl }}/api-explorer
 {{ if index .Values "alfresco-search" "ingress" "enabled" }}  Solr: {{ $alfurl }}/solr {{ end }}
 {{ if (index .Values "alfresco-insight-zeppelin") }}{{ if (index .Values "alfresco-insight-zeppelin" "enabled") }}  Zeppelin: {{ $alfurl }}/zeppelin {{ end }}{{ end }}


### PR DESCRIPTION
After runnig `helm install alfresco-incubator/alfresco-content-services...` a list of URL's is listed and ADW url is not present in that list, but it is deployed. I have added that line in NOTES.txt file