### PR TITLE
SEARCH-1915 Metadata keystore configuration

### DIFF
--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -12,7 +12,7 @@ version: "2"
 
 services:
     alfresco:
-        image: alfresco/alfresco-content-repository:6.2.1
+        image: alfresco/alfresco-content-repository:6.3.0-A8
         mem_limit: 1700m
         environment:
             JAVA_OPTS: "
@@ -32,6 +32,13 @@ services:
                 -Daos.baseUrlOverwrite=http://localhost:8080/alfresco/aos
                 -Dmessaging.broker.url=\"failover:(nio://activemq:61616)?timeout=3000&jms.useCompression=true\"
                 -Ddeployment.method=DOCKER_COMPOSE
+                -Dencryption.keystore.type=pkcs12
+                -Dencryption.cipherAlgorithm=AES/CBC/PKCS5Padding
+                -Dencryption.keyAlgorithm=AES
+                -Dmetadata-keystore.password=mp6yc0UD9e
+                -Dmetadata-keystore.aliases=metadata
+                -Dmetadata-keystore.metadata.password=mp6yc0UD9e
+                -Dmetadata-keystore.metadata.algorithm=AES
 
                 -Dtransform.service.enabled=true
                 -Dtransform.service.url=http://transform-router:8095

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -12,7 +12,7 @@ version: "2"
 
 services:
     alfresco:
-        image: alfresco/alfresco-content-repository:6.3.0-A8
+        image: alfresco/alfresco-content-repository:6.3.0-A9
         mem_limit: 1700m
         environment:
             JAVA_OPTS: "
@@ -32,9 +32,6 @@ services:
                 -Daos.baseUrlOverwrite=http://localhost:8080/alfresco/aos
                 -Dmessaging.broker.url=\"failover:(nio://activemq:61616)?timeout=3000&jms.useCompression=true\"
                 -Ddeployment.method=DOCKER_COMPOSE
-                -Dencryption.keystore.type=pkcs12
-                -Dencryption.cipherAlgorithm=AES/CBC/PKCS5Padding
-                -Dencryption.keyAlgorithm=AES
                 -Dmetadata-keystore.password=mp6yc0UD9e
                 -Dmetadata-keystore.aliases=metadata
                 -Dmetadata-keystore.metadata.password=mp6yc0UD9e

--- a/docs/use-cases/acs-deployment-with-custom-metadata-keystore.md
+++ b/docs/use-cases/acs-deployment-with-custom-metadata-keystore.md
@@ -1,11 +1,11 @@
 # Alfresco Content Services Deployment with custom metadata keystore
 
-Alfresco content repository Docker images comes with a precreated default keystore that contains a key. See more information in [docs.alfresco.com](https://docs.alfresco.com/6.2/concepts/alf-keystores.html) and [Dockerfile](https://github.com/Alfresco/acs-packaging/blob/master/docker-alfresco/Dockerfile#L81-L85).
+Alfresco content repository Docker images comes with a precreated default keystore that contains a secret key. See more information in [docs.alfresco.com](https://docs.alfresco.com/6.2/concepts/alf-keystores.html) and [Dockerfile](https://github.com/Alfresco/acs-packaging/blob/master/docker-alfresco/Dockerfile#L81-L85).
 
-It is recommended to generate a new keystore in production systems. The new keystore can be mounted to the content-repository docker image to this location "/usr/local/tomcat/shared/classes/alfresco/keystore/". If the standard names of the keystore and the key are used, it is only required to change password values in [values.yaml](../../helm/alfresco-content-services/values.yaml):
+It is recommended to generate a new keystore in production systems. It can be mounted to the content-repository docker image to this location "/usr/local/tomcat/shared/classes/alfresco/keystore/". If the standard names of the keystore and the key are used, it is only required to change password values in [values.yaml](../../helm/alfresco-content-services/values.yaml):
 ```yaml
 metadataKeystore:
   keystorePassword: ""
   keyPassword: ""
 ```
-Otherwise, please refer to the full lit of configuration options in [docs.alfresco.com](https://docs.alfresco.com/6.2/concepts/keystore-config.html)
+Otherwise, please refer to the full list of configuration options in [docs.alfresco.com](https://docs.alfresco.com/6.2/concepts/keystore-config.html)

--- a/docs/use-cases/acs-deployment-with-custom-metadata-keystore.md
+++ b/docs/use-cases/acs-deployment-with-custom-metadata-keystore.md
@@ -1,0 +1,11 @@
+# Alfresco Content Services Deployment with custom metadata keystore
+
+Alfresco content repository Docker images comes with a precreated default keystore that contains a key. See more information in [docs.alfresco.com](https://docs.alfresco.com/6.2/concepts/alf-keystores.html) and [Dockerfile](https://github.com/Alfresco/acs-packaging/blob/master/docker-alfresco/Dockerfile#L81-L85).
+
+It is recommended to generate a new keystore in production systems. The new keystore can be mounted to the content-repository docker image to this location "/usr/local/tomcat/shared/classes/alfresco/keystore/". If the standard names of the keystore and the key are used, it is only required to change password values in [values.yaml](../../helm/alfresco-content-services/values.yaml):
+```yaml
+metadataKeystore:
+  keystorePassword: ""
+  keyPassword: ""
+```
+Otherwise, please refer to the full lit of configuration options in [docs.alfresco.com](https://docs.alfresco.com/6.2/concepts/keystore-config.html)

--- a/helm/alfresco-content-services/templates/config-repository.yaml
+++ b/helm/alfresco-content-services/templates/config-repository.yaml
@@ -134,9 +134,6 @@ data:
       -Ds3.secretKey=$SECRETKEY
       -Ds3.encryption=$ENCRYPTION
       -Ds3.awsKmsKeyId=$KMSKEYID
-      -Dencryption.keystore.type=pkcs12
-      -Dencryption.cipherAlgorithm=AES/CBC/PKCS5Padding
-      -Dencryption.keyAlgorithm=AES
       -Dmetadata-keystore.password=$METADATA_KEYSTORE_PASSWORD
       -Dmetadata-keystore.aliases=metadata
       -Dmetadata-keystore.metadata.password=$METADATA_KEY_PASSWORD

--- a/helm/alfresco-content-services/templates/config-repository.yaml
+++ b/helm/alfresco-content-services/templates/config-repository.yaml
@@ -133,4 +133,11 @@ data:
       -Ds3.accessKey=$ACCESSKEY
       -Ds3.secretKey=$SECRETKEY
       -Ds3.encryption=$ENCRYPTION
-      -Ds3.awsKmsKeyId=$KMSKEYID"
+      -Ds3.awsKmsKeyId=$KMSKEYID
+      -Dencryption.keystore.type=pkcs12
+      -Dencryption.cipherAlgorithm=AES/CBC/PKCS5Padding
+      -Dencryption.keyAlgorithm=AES
+      -Dmetadata-keystore.password=$METADATA_KEYSTORE_PASSWORD
+      -Dmetadata-keystore.aliases=metadata
+      -Dmetadata-keystore.metadata.password=$METADATA_KEY_PASSWORD
+      -Dmetadata-keystore.metadata.algorithm=AES"

--- a/helm/alfresco-content-services/templates/deployment-repository.yaml
+++ b/helm/alfresco-content-services/templates/deployment-repository.yaml
@@ -53,6 +53,8 @@ spec:
               # mail password
               name: {{ template "content-services.shortname" . }}-mail-password
           {{- end }}
+          - secretRef:
+              name: {{ template "content-services.shortname" . }}-metadata-keystore-secret
           - configMapRef:
               # config map to use, defined in config-repository.yaml
               name: {{ template "content-services.shortname" . }}-repository-configmap

--- a/helm/alfresco-content-services/templates/secret-metadata-keystore.yaml
+++ b/helm/alfresco-content-services/templates/secret-metadata-keystore.yaml
@@ -10,5 +10,5 @@ metadata:
     component: repository
 type: Opaque
 data:
-  METADATA_KEYSTORE_PASSWORD: {{ .Values.metadata-keystore.keystore-password | default .Values.metadata-keystore.default-keystore-password | b64enc | quote }}
-  METADATA_KEY_PASSWORD: {{ .Values.metadata-keystore.key-password | default .Values.metadata-keystore.default-key-password | b64enc | quote }}
+  METADATA_KEYSTORE_PASSWORD: {{ .Values.metadataKeystore.keystorePassword | default .Values.metadataKeystore.defaultKeystorePassword | b64enc | quote }}
+  METADATA_KEY_PASSWORD: {{ .Values.metadataKeystore.keyPassword | default .Values.metadataKeystore.defaultKeyPassword | b64enc | quote }}

--- a/helm/alfresco-content-services/templates/secret-metadata-keystore.yaml
+++ b/helm/alfresco-content-services/templates/secret-metadata-keystore.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "content-services.shortname" . }}-metadata-keystore-secret
+  labels:
+    app: {{ template "content-services.shortname" . }}-repository
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    component: repository
+type: Opaque
+data:
+  METADATA_KEYSTORE_PASSWORD: {{ .Values.metadata-keystore.keystore-password | default .Values.metadata-keystore.default-keystore-password | b64enc | quote }}
+  METADATA_KEY_PASSWORD: {{ .Values.metadata-keystore.key-password | default .Values.metadata-keystore.default-key-password | b64enc | quote }}

--- a/helm/alfresco-content-services/values.yaml
+++ b/helm/alfresco-content-services/values.yaml
@@ -15,7 +15,7 @@ repository:
     type: Recreate
   image:
     repository: alfresco/alfresco-content-repository
-    tag: "6.3.0-A8"
+    tag: "6.3.0-A9"
     pullPolicy: Always
     internalPort: 8080
     hazelcastPort: 5701

--- a/helm/alfresco-content-services/values.yaml
+++ b/helm/alfresco-content-services/values.yaml
@@ -558,11 +558,11 @@ imap:
     to:
       default:
 
-metadata-keystore:
-  # keystore-password: ""
-  # key-password: ""
-  default-keystore-password: "mp6yc0UD9e"
-  default-key-password: "mp6yc0UD9e"
+metadataKeystore:
+  # keystorePassword: ""
+  # keyPassword: ""
+  defaultKeystorePassword: "mp6yc0UD9e"
+  defaultKeyPassword: "mp6yc0UD9e"
 
 # If there is a need to pull images from a private docker repo, a secret can be defined in helm and passed as an argument
 # to the install command:

--- a/helm/alfresco-content-services/values.yaml
+++ b/helm/alfresco-content-services/values.yaml
@@ -15,7 +15,7 @@ repository:
     type: Recreate
   image:
     repository: alfresco/alfresco-content-repository
-    tag: "6.2.1"
+    tag: "6.3.0-A8"
     pullPolicy: Always
     internalPort: 8080
     hazelcastPort: 5701
@@ -557,6 +557,12 @@ imap:
       default:
     to:
       default:
+
+metadata-keystore:
+  # keystore-password: ""
+  # key-password: ""
+  default-keystore-password: "mp6yc0UD9e"
+  default-key-password: "mp6yc0UD9e"
 
 # If there is a need to pull images from a private docker repo, a secret can be defined in helm and passed as an argument
 # to the install command:


### PR DESCRIPTION
This PR provides default config for metadata keystore. 
See also https://github.com/Alfresco/acs-packaging/pull/999

Please note that the documentation https://docs.alfresco.com/6.2/concepts/alf-keystores.html still needs to be updated.