### PR TITLE
ACS-91: Disable network policy setting in helm chart

### DIFF
--- a/helm/alfresco-content-services/values.yaml
+++ b/helm/alfresco-content-services/values.yaml
@@ -446,7 +446,7 @@ ai:
 
 # choose if you want network policy enabled
 networkpolicysetting:
-  enabled: true
+  enabled: false
 
 # Defines properties required by alfresco for connecting to the database
 # Note! : If you set database.external to true you will have to setup the driver, user, password and JdbcUrl

--- a/helm/alfresco-content-services/values.yaml
+++ b/helm/alfresco-content-services/values.yaml
@@ -50,12 +50,12 @@ repository:
   # The repository readiness probe is used to check startup only as a failure
   # of the liveness probe later will result in the pod being restarted.
   readinessProbe:
-    initialDelaySeconds: 60
+    initialDelaySeconds: 150
     periodSeconds: 20
     timeoutSeconds: 10
     failureThreshold: 6
   livenessProbe:
-    initialDelaySeconds: 130
+    initialDelaySeconds: 300
     periodSeconds: 20
     timeoutSeconds: 10
 
@@ -590,4 +590,6 @@ global:
     - quay-registry-secret
 
 alfresco-sync-service:
-   enabled : true
+  enabled : true
+  # networkpolicysetting:
+  #   enabled: false

--- a/helm/alfresco-content-services/values.yaml
+++ b/helm/alfresco-content-services/values.yaml
@@ -343,11 +343,11 @@ share:
   environment:
     CATALINA_OPTS: " -Xms1000M -Xmx1000M"
   readinessProbe:
-    initialDelaySeconds: 60
+    initialDelaySeconds: 150
     periodSeconds: 20
     timeoutSeconds: 10
   livenessProbe:
-    initialDelaySeconds: 130
+    initialDelaySeconds: 300
     periodSeconds: 20
     timeoutSeconds: 10
 
@@ -394,7 +394,7 @@ alfresco-infrastructure:
 alfresco-search:
   enabled: true
 # If enabled is set to false, then external host and port need to point to the external instance of SOLR6, and in this case:
-# Note: Rule_05-network-policy-search will be disable.
+# Note: Rule_05-network-policy-search will be disabled.
 # Note: Rule_04-network-policy-repository internal trafic to SOLR6 instance will be disabled.
 # Note: ingress-repository will not block external trafic to */solr/*
 #  external:
@@ -432,7 +432,7 @@ alfresco-digital-workspace:
     APP_CONFIG_AUTH_TYPE: "BASIC"
     API_URL: "{protocol}//{hostname}{:port}"
   networkpolicysetting:
-    enabled: true
+    enabled: false
 
 # choose if you want AI capabilities
 ai:
@@ -591,5 +591,5 @@ global:
 
 alfresco-sync-service:
   enabled : true
-  # networkpolicysetting:
-  #   enabled: false
+  networkpolicysetting:
+    enabled: false

--- a/helm/alfresco-content-services/values.yaml
+++ b/helm/alfresco-content-services/values.yaml
@@ -50,12 +50,12 @@ repository:
   # The repository readiness probe is used to check startup only as a failure
   # of the liveness probe later will result in the pod being restarted.
   readinessProbe:
-    initialDelaySeconds: 150
+    initialDelaySeconds: 60
     periodSeconds: 20
     timeoutSeconds: 10
     failureThreshold: 6
   livenessProbe:
-    initialDelaySeconds: 300
+    initialDelaySeconds: 130
     periodSeconds: 20
     timeoutSeconds: 10
 
@@ -343,11 +343,11 @@ share:
   environment:
     CATALINA_OPTS: " -Xms1000M -Xmx1000M"
   readinessProbe:
-    initialDelaySeconds: 150
+    initialDelaySeconds: 60
     periodSeconds: 20
     timeoutSeconds: 10
   livenessProbe:
-    initialDelaySeconds: 300
+    initialDelaySeconds: 130
     periodSeconds: 20
     timeoutSeconds: 10
 


### PR DESCRIPTION
Following info on ACS-91 and feedback from Abdul, set networkpolicysetting: enabled: to false.