### PR TITLE
ATS-761: Bump to AIS 1.2.0-A1

### DIFF
--- a/helm/alfresco-content-services/ai-reference-values.yaml
+++ b/helm/alfresco-content-services/ai-reference-values.yaml
@@ -1,12 +1,12 @@
 repository:
   image:
     repository: quay.io/alfresco/alfresco-content-repository-aws
-    tag: "6.2.1"
+    tag: "6.2.2-RC1"
 
 share:
   image:
     repository: quay.io/alfresco/alfresco-share-aws
-    tag: "6.2.1"
+    tag: "6.2.2-RC2"
 
 ai:
   enabled: true

--- a/helm/alfresco-content-services/values.yaml
+++ b/helm/alfresco-content-services/values.yaml
@@ -255,7 +255,7 @@ aiTransformer:
   replicaCount: 2
   image:
     repository: quay.io/alfresco/alfresco-ai-docker-engine
-    tag: "1.1.2"
+    tag: "1.2.0-A2"
     pullPolicy: Always
     internalPort: 8090
   service:


### PR DESCRIPTION
- values.yaml & ai-reference-values.yaml

- note: requires ATS (T-Router) 1.3.0-A2 (or higher)