### PR TITLE
ATS-786: Bump to AIS 1.2.0-RC1

### DIFF
--- a/helm/alfresco-content-services/values.yaml
+++ b/helm/alfresco-content-services/values.yaml
@@ -255,7 +255,7 @@ aiTransformer:
   replicaCount: 2
   image:
     repository: quay.io/alfresco/alfresco-ai-docker-engine
-    tag: "1.2.0-A2"
+    tag: "1.2.0-RC1"
     pullPolicy: Always
     internalPort: 8090
   service:


### PR DESCRIPTION
- note: requires ATS (T-Router) 1.3.0-RC1 (or higher)