### PR TITLE
ATS-774: Bump AI T-Engine to final AIS 1.2.0 (for k8s)

### DIFF
--- a/helm/alfresco-content-services/ai-reference-values.yaml
+++ b/helm/alfresco-content-services/ai-reference-values.yaml
@@ -1,12 +1,12 @@
 repository:
   image:
     repository: quay.io/alfresco/alfresco-content-repository-aws
-    tag: "6.2.2-RC1"
+    tag: "6.2.2-RC2"
 
 share:
   image:
     repository: quay.io/alfresco/alfresco-share-aws
-    tag: "6.2.2-RC2"
+    tag: "6.2.2"
 
 ai:
   enabled: true

--- a/helm/alfresco-content-services/values.yaml
+++ b/helm/alfresco-content-services/values.yaml
@@ -255,7 +255,7 @@ aiTransformer:
   replicaCount: 2
   image:
     repository: quay.io/alfresco/alfresco-ai-docker-engine
-    tag: "1.2.0-RC1"
+    tag: "1.2.0"
     pullPolicy: Always
     internalPort: 8090
   service:


### PR DESCRIPTION
- note: also bump ai-reference-values.yaml although these depend on builds for:
-- ACS Packaging
-- Share