### PR TITLE
DOCS-5951 Remove Download Trial license link

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Alfresco provides tested Helm charts as a "deployment template" for customers wh
 
 The Helm charts in this repository provide a PostgreSQL database in a Docker container and do not configure
 any logging. This design has been chosen so that they can be installed in a Kubernetes cluster without
-changes and are still flexible to be adopted to your actual environment. 
+changes and are still flexible to be adopted to your actual environment.
 
 For your environment, you should use these charts as a starting point and modify them so that ACS integrates
 into your infrastructure. You typically want to remove the PostgreSQL container and connect the cs-repository
@@ -54,8 +54,7 @@ Another typical change would be the integration of your company-wide monitoring 
 ## Other information
 * See alternative commands and start up [tutorial with AWS support](https://github.com/Alfresco/alfresco-anaxes-shipyard/blob/master/docs/running-a-cluster.md)
 * [Tips and tricks](https://github.com/Alfresco/alfresco-anaxes-shipyard/blob/master/docs/tips-and-tricks.md) for working with Kubernetes and Alfresco Content Services.
-* The images downloaded directly from Docker Hub, or Quay.io are for a limited trial of the Enterprise version of Alfresco Content Services that goes into read-only mode after 2 days. Request an extended 30-day trial at
- https://www.alfresco.com/platform/content-services-ecm/trial/docker
+* The images downloaded directly from Docker Hub, or Quay.io are for a limited trial of the Enterprise version of Alfresco Content Services that goes into read-only mode after 2 days. If you'd like to try Alfresco Content Services for a longer period, request the 30-day [Download Trial](https://www.alfresco.com/platform/content-services-ecm/trial/download).
 * Alfresco customers can request Quay.io credentials by logging a ticket with [Alfresco Support](https://support.alfresco.com/). These credentials are required to pull private (Enterprise-only) Docker images from Quay.io.
 
 ## On Cloud Supported/unsupported endpoints/features/amps

--- a/docs/docker-compose-deployment.md
+++ b/docs/docker-compose-deployment.md
@@ -8,7 +8,7 @@ To deploy Alfresco Content Services using _docker-compose_, you'll need to insta
 
 | Component      | Installation Guide |
 | ---------------| ------------------ |
-| License        | [30-day trial license](https://www.alfresco.com/platform/content-services-ecm/trial/download) for Enterprise |
+| Download Trial | [30-day trial](https://www.alfresco.com/platform/content-services-ecm/trial/download) for Enterprise |
 | Docker         | https://docs.docker.com/ |
 | Docker Compose | https://docs.docker.com/compose/install/ |
 
@@ -22,10 +22,10 @@ To deploy Alfresco Content Services using _docker-compose_, you'll need to insta
 3. Log in to Quay.io with your credentials: ```docker login quay.io```
 * Alfresco customers can request Quay.io credentials by logging a ticket with [Alfresco Support](https://support.alfresco.com/).
 4. Run ```docker-compose up```
-5. Navigate to the Admin Console and apply your trial license:
+5. Navigate to the Admin Console and apply your license:
 * [http://<machine_ip>:8080/alfresco/service/enterprise/admin/admin-license](http://localhost:8080/alfresco/service/enterprise/admin/admin-license) (```<machine_ip>``` will usually just be ```localhost```)
 * Default username and password is ```admin```
-* See [Uploading a new license](https://docs.alfresco.com/6.1/tasks/at-adminconsole-license.html) for more details
+* See [Uploading a new license](https://docs.alfresco.com/6.2/tasks/at-adminconsole-license.html) for more details
 6. Open the following URLs in your browser to check that everything starts up:
 * Administration and REST APIs: [http://<machine_ip>:8080/alfresco](http://localhost:8080/alfresco)
 * Alfresco Digital Workspace: [http://<machine_ip>:8080/workspace](http://localhost:8080/workspace)

--- a/helm/alfresco-content-services/README.md
+++ b/helm/alfresco-content-services/README.md
@@ -24,7 +24,7 @@ $ helm install alfresco-incubator/alfresco-content-services
 This chart bootstraps an ACS deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
 ## Prerequisites
-  - [30-day trial license](https://www.alfresco.com/platform/content-services-ecm/trial/download) for Enterprise
+  - [30-day trial](https://www.alfresco.com/platform/content-services-ecm/trial/download) for Enterprise
   - Kubernetes 1.4+ with Beta APIs enabled
   - Minimum of 16GB Memory to distribute among ACS Cluster nodes
 


### PR DESCRIPTION
The only available method of obtaining a 30-day license for docker-compose is through the “ACS Download Trial” web page.