### PR TITLE
ATS-808: Bump AIS T-Engine to 1.2.1-RC1

### DIFF
--- a/helm/alfresco-content-services/values.yaml
+++ b/helm/alfresco-content-services/values.yaml
@@ -255,7 +255,7 @@ aiTransformer:
   replicaCount: 2
   image:
     repository: quay.io/alfresco/alfresco-ai-docker-engine
-    tag: "1.2.0"
+    tag: "1.2.1-RC1"
     pullPolicy: Always
     internalPort: 8090
   service:


### PR DESCRIPTION
- AIS service pack - targeting ACS 6.2.2 (as part of S/H release train)