### PR TITLE
OPSEXP-555: keystore additions

### DIFF
--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -12,15 +12,19 @@ version: "2"
 
 services:
     alfresco:
-        image: alfresco/alfresco-content-repository:7.0.0-M1
+        image: alfresco/alfresco-content-repository:7.0.0-A5
         mem_limit: 1700m
         environment:
             JAVA_TOOL_OPTIONS: "
+                -Dencryption.keystore.type=JCEKS
+                -Dencryption.cipherAlgorithm=DESede/CBC/PKCS5Padding
+                -Dencryption.keyAlgorithm=DESede
+                -Dencryption.keystore.location=/usr/local/tomcat/shared/classes/alfresco/extension/keystore/keystore
                 -Dmetadata-keystore.password=mp6yc0UD9e
                 -Dmetadata-keystore.aliases=metadata
-                -Dmetadata-keystore.metadata.password=mp6yc0UD9e
-                -Dmetadata-keystore.metadata.algorithm=AES
-            "
+                -Dmetadata-keystore.metadata.password=oKIWzVdEdA
+                -Dmetadata-keystore.metadata.algorithm=DESede
+                "
             JAVA_OPTS: "
                 -Ddb.driver=org.postgresql.Driver
                 -Ddb.username=alfresco

--- a/helm/alfresco-content-services/6.0.N_values.yaml
+++ b/helm/alfresco-content-services/6.0.N_values.yaml
@@ -43,6 +43,7 @@ repository:
       -Dtransform.service.enabled=true
 
       -Xms2000M -Xmx2000M"
+    JAVA_TOOL_OPTIONS: " -Dmetadata-keystore.aliases=metadata -Dmetadata-keystore.metadata.algorithm=AES"
   resources:
     requests:
       memory: "3000Mi"

--- a/helm/alfresco-content-services/6.1.N_values.yaml
+++ b/helm/alfresco-content-services/6.1.N_values.yaml
@@ -43,6 +43,7 @@ repository:
       -Dtransform.service.enabled=true
 
       -Xms2000M -Xmx2000M"
+    JAVA_TOOL_OPTIONS: " -Dmetadata-keystore.aliases=metadata -Dmetadata-keystore.metadata.algorithm=AES"
   resources:
     requests:
       memory: "3000Mi"

--- a/helm/alfresco-content-services/6.2.N_values.yaml
+++ b/helm/alfresco-content-services/6.2.N_values.yaml
@@ -43,6 +43,7 @@ repository:
       -Dtransform.service.enabled=true
 
       -Xms2000M -Xmx2000M"
+    JAVA_TOOL_OPTIONS: " -Dmetadata-keystore.aliases=metadata -Dmetadata-keystore.metadata.algorithm=AES"
   resources:
     requests:
       memory: "3000Mi"

--- a/helm/alfresco-content-services/community_values.yaml
+++ b/helm/alfresco-content-services/community_values.yaml
@@ -39,6 +39,7 @@ repository:
       -Dindex.subsystem.name=solr6
       -Ddeployment.method=HELM_CHART
       -Xms2000M -Xmx2000M"
+    JAVA_TOOL_OPTIONS: " -Dmetadata-keystore.aliases=metadata -Dmetadata-keystore.metadata.algorithm=AES"
   resources:
     requests:
       memory: "3000Mi"

--- a/helm/alfresco-content-services/templates/config-repository.yaml
+++ b/helm/alfresco-content-services/templates/config-repository.yaml
@@ -149,7 +149,3 @@ data:
       {{- end }}
       {{- end }}
       {{- end }}
-      -Dmetadata-keystore.password=$METADATA_KEYSTORE_PASSWORD
-      -Dmetadata-keystore.aliases=metadata
-      -Dmetadata-keystore.metadata.password=$METADATA_KEY_PASSWORD
-      -Dmetadata-keystore.metadata.algorithm=AES"

--- a/helm/alfresco-content-services/templates/config-repository.yaml
+++ b/helm/alfresco-content-services/templates/config-repository.yaml
@@ -148,4 +148,6 @@ data:
       -Ds3.awsKmsKeyId=$KMSKEYID
       {{- end }}
       {{- end }}
-      {{- end }}"
+      {{- end }}
+      -Dmetadata-keystore.password=$METADATA_KEYSTORE_PASSWORD
+      -Dmetadata-keystore.metadata.password=$METADATA_KEY_PASSWORD"

--- a/helm/alfresco-content-services/templates/config-repository.yaml
+++ b/helm/alfresco-content-services/templates/config-repository.yaml
@@ -148,4 +148,4 @@ data:
       -Ds3.awsKmsKeyId=$KMSKEYID
       {{- end }}
       {{- end }}
-      {{- end }}
+      {{- end }}"

--- a/helm/alfresco-content-services/values.yaml
+++ b/helm/alfresco-content-services/values.yaml
@@ -45,9 +45,7 @@ repository:
       -Dencryption.cipherAlgorithm=DESede/CBC/PKCS5Padding
       -Dencryption.keyAlgorithm=DESede
       -Dencryption.keystore.location=/usr/local/tomcat/shared/classes/alfresco/extension/keystore/keystore
-      -Dmetadata-keystore.password=mp6yc0UD9e
       -Dmetadata-keystore.aliases=metadata
-      -Dmetadata-keystore.metadata.password=oKIWzVdEdA
       -Dmetadata-keystore.metadata.algorithm=DESede"
   resources:
     requests:
@@ -600,7 +598,7 @@ metadataKeystore:
   # keystorePassword: ""
   # keyPassword: ""
   defaultKeystorePassword: "mp6yc0UD9e"
-  defaultKeyPassword: "mp6yc0UD9e"
+  defaultKeyPassword: "oKIWzVdEdA"
 
 alfresco-sync-service:
   syncservice:

--- a/helm/alfresco-content-services/values.yaml
+++ b/helm/alfresco-content-services/values.yaml
@@ -16,7 +16,7 @@ repository:
     type: Recreate
   image:
     repository: alfresco/alfresco-content-repository
-    tag: "7.0.0-M1"
+    tag: "7.0.0-A5"
     pullPolicy: Always
     internalPort: 8080
     hazelcastPort: 5701
@@ -41,6 +41,14 @@ repository:
       -Ddeployment.method=HELM_CHART
       -Dtransform.service.enabled=true
       -Xms2000M -Xmx2000M"
+    JAVA_TOOL_OPTIONS: " -Dencryption.keystore.type=JCEKS
+      -Dencryption.cipherAlgorithm=DESede/CBC/PKCS5Padding
+      -Dencryption.keyAlgorithm=DESede
+      -Dencryption.keystore.location=/usr/local/tomcat/shared/classes/alfresco/extension/keystore/keystore
+      -Dmetadata-keystore.password=mp6yc0UD9e
+      -Dmetadata-keystore.aliases=metadata
+      -Dmetadata-keystore.metadata.password=oKIWzVdEdA
+      -Dmetadata-keystore.metadata.algorithm=DESede"
   resources:
     requests:
       memory: "3000Mi"


### PR DESCRIPTION
Added new keystore props to the helm deployments, also altered the values files for older version but kept the metadata pass and key pass configurable and secured with secrets