### PR TITLE
OPSEXP-592: Fix SOLR issues

### DIFF
--- a/docker-compose/6.0.N-docker-compose.yml
+++ b/docker-compose/6.0.N-docker-compose.yml
@@ -95,6 +95,8 @@ services:
             - SOLR_SOLR_PORT=8983
             #Create the default alfresco and archive cores
             - SOLR_CREATE_ALFRESCO_DEFAULTS=alfresco,archive
+            #HTTP by default
+            - ALFRESCO_SECURE_COMMS=none
             - "SOLR_JAVA_MEM=-Xms2g -Xmx2g"
         ports:
             - 8083:8983 #Browser port

--- a/docs/helm/docker-desktop-deployment.md
+++ b/docs/helm/docker-desktop-deployment.md
@@ -99,7 +99,7 @@ The Enterprise Helm deployment is intended for a Cloud based Kubernetes cluster 
 Forutnately this can all be achieved with one, albeit large, command as shown below:
 
 ```bash
-helm install acs alfresco-stable/alfresco-content-services --devel \
+helm install acs alfresco/alfresco-content-services --devel \
 --set externalPort="80" \
 --set externalProtocol="http" \
 --set externalHost="localhost" \
@@ -115,6 +115,8 @@ helm install acs alfresco-stable/alfresco-content-services --devel \
 --set postgresql-syncservice.resources.limits.memory="500Mi" \
 --set postgresql.resources.requests.memory="500Mi" \
 --set postgresql.resources.limits.memory="500Mi" \
+--set alfresco-search.resources.requests.memory="1000Mi" \
+--set alfresco-search.resources.limits.memory="1000Mi" \
 --set share.resources.limits.memory="1500Mi" \
 --set share.resources.requests.memory="1500Mi" \
 --set repository.resources.limits.memory="2500Mi" \
@@ -132,7 +134,7 @@ The command above installs the latest version of ACS Enterprise. To deploy a pre
 2. Deploy the specific version of ACS by running the following command:
 
     ```bash
-    helm install acs alfresco-stable/alfresco-content-services --devel \
+    helm install acs alfresco/alfresco-content-services --devel \
     --values=MAJOR.MINOR.N_values.yaml \
     --set externalPort="80" \
     --set externalProtocol="http" \
@@ -149,6 +151,8 @@ The command above installs the latest version of ACS Enterprise. To deploy a pre
     --set postgresql-syncservice.resources.limits.memory="500Mi" \
     --set postgresql.resources.requests.memory="500Mi" \
     --set postgresql.resources.limits.memory="500Mi" \
+    --set alfresco-search.resources.requests.memory="1000Mi" \
+    --set alfresco-search.resources.limits.memory="1000Mi" \
     --set share.resources.limits.memory="1500Mi" \
     --set share.resources.requests.memory="1500Mi" \
     --set repository.resources.limits.memory="2500Mi" \
@@ -159,6 +163,19 @@ The command above installs the latest version of ACS Enterprise. To deploy a pre
     ```
 
 > NOTE: The command will wait until the deployment is ready so please be patient.
+
+## Access
+
+When the deployment has completed the following URLs will be available:
+
+* Repository: `http://localhost/alfresco`
+* Share: `http://localhost/share`
+* API Explorer: `http://localhost/api-explorer`
+
+If you deployed Enterprise you'll also have access to:
+
+* ADW: `http://localhost/workspace/`
+* Sync Service: `http://localhost/syncservice/healthcheck`
 
 ## Cleanup
 

--- a/docs/helm/eks-deployment.md
+++ b/docs/helm/eks-deployment.md
@@ -341,12 +341,12 @@ When the deployment has completed the following URLs will be available (replacin
 
 * Repository: `https://acs.YOUR-DOMAIN-NAME/alfresco`
 * Share: `https://acs.YOUR-DOMAIN-NAME/share`
-* Api-Explorer: `https://acs.YOUR-DOMAIN-NAME/api-explorer`
+* API Explorer: `https://acs.YOUR-DOMAIN-NAME/api-explorer`
 
 If you deployed Enterprise you'll also have access to:
 
 * ADW: `https://acs.YOUR-DOMAIN-NAME/workspace/`
-* Sync service: `https://acs.YOUR-DOMAIN-NAME/syncservice/healthcheck`
+* Sync Service: `https://acs.YOUR-DOMAIN-NAME/syncservice/healthcheck`
 
 If you requested an extended trial license navigate to the Admin Console and apply your license:
 

--- a/helm/alfresco-content-services/charts/alfresco-search/templates/deployment.yaml
+++ b/helm/alfresco-content-services/charts/alfresco-search/templates/deployment.yaml
@@ -64,7 +64,7 @@ spec:
             timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
           livenessProbe:
             httpGet:
-              path: /solr/alfresco/admin/luke
+              path: /solr/admin/info/system
               port: {{ template "alfresco-search.internalPort" . }}
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}

--- a/helm/alfresco-content-services/charts/alfresco-search/values.yaml
+++ b/helm/alfresco-content-services/charts/alfresco-search/values.yaml
@@ -41,9 +41,9 @@ environment:
   ALFRESCO_SECURE_COMMS: "none"
 resources:
   requests:
-    memory: "250Mi"
+    memory: "2000Mi"
   limits:
-    memory: "1024Mi"
+    memory: "2000Mi"
 # Defines the mounting points for the persistence required by the apps in the cluster
 # the solr data folder containing the indexes for the alfresco-search-services is mapped to alfresco-content-services/solr-data
 persistence:


### PR DESCRIPTION
- Changed default memory limits for search to 2G
- Also changed the URL to use for the liveness probe
- Fixed startup issue in 6.0.N docker compose
- Updated DfD guide to reduce the search memory