### PR TITLE
OPSEXP-599: db max_connections not taken into consideration

### DIFF
--- a/helm/alfresco-content-services/6.0.N_values.yaml
+++ b/helm/alfresco-content-services/6.0.N_values.yaml
@@ -436,7 +436,7 @@ postgresql:
   postgresqlUsername: alfresco
   postgresqlPassword: alfresco
   postgresqlDatabase: alfresco
-  postgresConfig:
+  postgresqlExtendedConf:
     max_connections: 300
     log_min_messages: LOG
   persistence:
@@ -463,7 +463,7 @@ postgresql-syncservice:
   postgresqlUsername: alfresco
   postgresqlPassword: admin
   postgresqlDatabase: syncservice-postgresql
-  postgresConfig:
+  postgresqlExtendedConf:
     max_connections: 450
     log_min_messages: LOG
   service:

--- a/helm/alfresco-content-services/6.1.N_values.yaml
+++ b/helm/alfresco-content-services/6.1.N_values.yaml
@@ -436,7 +436,7 @@ postgresql:
   postgresqlUsername: alfresco
   postgresqlPassword: alfresco
   postgresqlDatabase: alfresco
-  postgresConfig:
+  postgresqlExtendedConf:
     max_connections: 300
     log_min_messages: LOG
   persistence:
@@ -463,7 +463,7 @@ postgresql-syncservice:
   postgresqlUsername: alfresco
   postgresqlPassword: admin
   postgresqlDatabase: syncservice-postgresql
-  postgresConfig:
+  postgresqlExtendedConf:
     max_connections: 450
     log_min_messages: LOG
   service:

--- a/helm/alfresco-content-services/6.2.N_values.yaml
+++ b/helm/alfresco-content-services/6.2.N_values.yaml
@@ -467,7 +467,7 @@ postgresql:
   postgresqlUsername: alfresco
   postgresqlPassword: alfresco
   postgresqlDatabase: alfresco
-  postgresConfig:
+  postgresqlExtendedConf:
     max_connections: 300
     log_min_messages: LOG
   persistence:
@@ -494,7 +494,7 @@ postgresql-syncservice:
   postgresqlUsername: alfresco
   postgresqlPassword: admin
   postgresqlDatabase: syncservice-postgresql
-  postgresConfig:
+  postgresqlExtendedConf:
     max_connections: 450
     log_min_messages: LOG
   service:

--- a/helm/alfresco-content-services/community_values.yaml
+++ b/helm/alfresco-content-services/community_values.yaml
@@ -345,7 +345,7 @@ postgresql:
   postgresqlUsername: alfresco
   postgresqlPassword: alfresco
   postgresqlDatabase: alfresco
-  postgresConfig:
+  postgresqlExtendedConf:
     max_connections: 300
     log_min_messages: LOG
   persistence:

--- a/helm/alfresco-content-services/templates/config-ai-transformer.yaml
+++ b/helm/alfresco-content-services/templates/config-ai-transformer.yaml
@@ -1,5 +1,5 @@
-# Defines the properties required by the alfresco-ai-transformer container
 {{- if .Values.ai.enabled }}
+# Defines the properties required by the alfresco-ai-transformer container
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/helm/alfresco-content-services/templates/config-email.yaml
+++ b/helm/alfresco-content-services/templates/config-email.yaml
@@ -1,5 +1,5 @@
-# Defines the email configmap for the alfresco content repository app
 {{- if .Values.email.server.enabled }}
+# Defines the email configmap for the alfresco content repository app
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/helm/alfresco-content-services/templates/config-transformer-routes.yaml
+++ b/helm/alfresco-content-services/templates/config-transformer-routes.yaml
@@ -1,5 +1,5 @@
-# Defines transformer routes
 {{- if .Values.ai.enabled }}
+# Defines transformer routes
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/helm/alfresco-content-services/templates/deployment-ai-transformer.yaml
+++ b/helm/alfresco-content-services/templates/deployment-ai-transformer.yaml
@@ -1,6 +1,6 @@
+{{- if .Values.ai.enabled }}
 # Defines the deployment for the ai transformer app
 # Details: https://github.com/Alfresco/alfresco-ai-transformers/tree/master/alfresco-ai-docker-engine
-{{- if .Values.ai.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/helm/alfresco-content-services/templates/svc-ai-transformer.yaml
+++ b/helm/alfresco-content-services/templates/svc-ai-transformer.yaml
@@ -1,5 +1,5 @@
-# Defines the service for the ai transformer app
 {{- if .Values.ai.enabled }}
+# Defines the service for the ai transformer app
 apiVersion: v1
 kind: Service
 metadata:

--- a/helm/alfresco-content-services/values.yaml
+++ b/helm/alfresco-content-services/values.yaml
@@ -473,7 +473,7 @@ postgresql:
   postgresqlUsername: alfresco
   postgresqlPassword: alfresco
   postgresqlDatabase: alfresco
-  postgresConfig:
+  postgresqlExtendedConf:
     max_connections: 300
     log_min_messages: LOG
   persistence:
@@ -502,7 +502,7 @@ postgresql-syncservice:
   postgresqlUsername: alfresco
   postgresqlPassword: admin
   postgresqlDatabase: syncservice-postgresql
-  postgresConfig:
+  postgresqlExtendedConf:
     max_connections: 450
     log_min_messages: LOG
   service:


### PR DESCRIPTION
Bitnami helm chart is expecting different values for extra posgresql configuration ->
https://github.com/bitnami/charts/blob/master/bitnami/postgresql/values.yaml#L201