### PR TITLE
OPSEXP-130: Share ingress setup + pin ingress-nginx version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ branches:
   only:
     - master
     - /feature.*/
+    - /fix.*/
 
 before_install:
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -173,7 +173,7 @@ _helm_deploy: &helm_deploy
     EOF
 
     # install ingress
-    helm upgrade --install $release_name_ingress ingress-nginx/ingress-nginx --version=3.9.0 \
+    helm upgrade --install $release_name_ingress ingress-nginx/ingress-nginx --version=3.7.1 \
     --set controller.scope.enabled=true \
     --set controller.scope.namespace=$namespace \
     --set rbac.create=true \

--- a/.travis.yml
+++ b/.travis.yml
@@ -173,7 +173,7 @@ _helm_deploy: &helm_deploy
     EOF
 
     # install ingress
-    helm upgrade --install $release_name_ingress ingress-nginx/ingress-nginx \
+    helm upgrade --install $release_name_ingress ingress-nginx/ingress-nginx --version=3.9.0 \
     --set controller.scope.enabled=true \
     --set controller.scope.namespace=$namespace \
     --set rbac.create=true \

--- a/docker-compose/6.2.N-docker-compose.yml
+++ b/docker-compose/6.2.N-docker-compose.yml
@@ -12,7 +12,7 @@ version: "2"
 
 services:
     alfresco:
-        image: alfresco/alfresco-content-repository:6.2.2.3
+        image: quay.io/alfresco/alfresco-content-repository:6.2.2.5
         mem_limit: 1700m
         environment:
             JAVA_OPTS: "

--- a/docs/helm/docker-desktop-deployment.md
+++ b/docs/helm/docker-desktop-deployment.md
@@ -39,7 +39,7 @@ kubectl create namespace alfresco
 Deploy an ingress controller into the alfresco namespace using the command below:
 
 ```bash
-helm install acs-ingress ingress-nginx/ingress-nginx \
+helm install acs-ingress ingress-nginx/ingress-nginx --version=3.9.0 \
 --set controller.scope.enabled=true \
 --set controller.scope.namespace=alfresco \
 --set rbac.create=true \

--- a/docs/helm/docker-desktop-deployment.md
+++ b/docs/helm/docker-desktop-deployment.md
@@ -39,7 +39,7 @@ kubectl create namespace alfresco
 Deploy an ingress controller into the alfresco namespace using the command below:
 
 ```bash
-helm install acs-ingress ingress-nginx/ingress-nginx --version=3.9.0 \
+helm install acs-ingress ingress-nginx/ingress-nginx --version=3.7.1 \
 --set controller.scope.enabled=true \
 --set controller.scope.namespace=alfresco \
 --set rbac.create=true \

--- a/docs/helm/eks-deployment.md
+++ b/docs/helm/eks-deployment.md
@@ -224,7 +224,7 @@ kubectl create namespace alfresco
     ```bash
     helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
 
-    helm install acs-ingress ingress-nginx/ingress-nginx --version=3.9.0 \
+    helm install acs-ingress ingress-nginx/ingress-nginx --version=3.7.1 \
     --set controller.scope.enabled=true \
     --set controller.scope.namespace=alfresco \
     --set rbac.create=true \

--- a/docs/helm/eks-deployment.md
+++ b/docs/helm/eks-deployment.md
@@ -224,7 +224,7 @@ kubectl create namespace alfresco
     ```bash
     helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
 
-    helm install acs-ingress ingress-nginx/ingress-nginx \
+    helm install acs-ingress ingress-nginx/ingress-nginx --version=3.9.0 \
     --set controller.scope.enabled=true \
     --set controller.scope.namespace=alfresco \
     --set rbac.create=true \

--- a/helm/alfresco-content-services/6.2.N_values.yaml
+++ b/helm/alfresco-content-services/6.2.N_values.yaml
@@ -15,8 +15,8 @@ repository:
   strategy:
     type: Recreate
   image:
-    repository: alfresco/alfresco-content-repository
-    tag: "6.2.2.3"
+    repository: quay.io/alfresco/alfresco-content-repository
+    tag: "6.2.2.5"
     pullPolicy: Always
     internalPort: 8080
     hazelcastPort: 5701

--- a/helm/alfresco-content-services/requirements.yaml
+++ b/helm/alfresco-content-services/requirements.yaml
@@ -13,3 +13,9 @@ dependencies:
   version: 7.1.0-M10
   repository: https://kubernetes-charts.alfresco.com/stable
   condition: alfresco-content-services.alfresco-digital-workspace.enabled,alfresco-digital-workspace.enabled
+- name: activemq
+  version: 2.0.0
+- name: alfresco-search
+  version: 1.0.4
+- name: alfresco-sync-service
+  version: 3.0.6

--- a/helm/alfresco-content-services/templates/ingress-share.yaml
+++ b/helm/alfresco-content-services/templates/ingress-share.yaml
@@ -19,7 +19,7 @@ metadata:
     nginx.ingress.kubernetes.io/session-cookie-expires: "604800"
     nginx.ingress.kubernetes.io/configuration-snippet: |
       location ~ ^(/.*/proxy/alfresco/api/solr/.*)$ {return 403 ;}
-                  location ~ ^(/.*/-default-/proxy/alfresco/api/.*)$ {return 403;}
+      location ~ ^(/.*/-default-/proxy/alfresco/api/.*)$ {return 403;}
 {{- if .Values.share.ingress.annotations }}
 {{ toYaml .Values.share.ingress.annotations | indent 4 }}
 {{- end }}

--- a/helm/alfresco-content-services/templates/ingress-share.yaml
+++ b/helm/alfresco-content-services/templates/ingress-share.yaml
@@ -12,6 +12,11 @@ metadata:
     kubernetes.io/ingress.class: "nginx"
     # Default limit is 1m, document(s) above this size will throw 413 (Request Entity Too Large) error
     nginx.ingress.kubernetes.io/proxy-body-size: {{ .Values.repository.ingress.maxUploadSize }}
+    nginx.ingress.kubernetes.io/affinity: "cookie"
+    nginx.ingress.kubernetes.io/session-cookie-name": "alfrescoShare"
+    nginx.ingress.kubernetes.io/session-cookie-path": "/share"
+    nginx.ingress.kubernetes.io/session-cookie-max-age": "604800"
+    nginx.ingress.kubernetes.io/session-cookie-expires": "604800"
     nginx.ingress.kubernetes.io/configuration-snippet: |
       location ~ ^(/.*/proxy/alfresco/api/solr/.*)$ {return 403 ;}
                   location ~ ^(/.*/-default-/proxy/alfresco/api/.*)$ {return 403;}

--- a/helm/alfresco-content-services/templates/ingress-share.yaml
+++ b/helm/alfresco-content-services/templates/ingress-share.yaml
@@ -13,10 +13,10 @@ metadata:
     # Default limit is 1m, document(s) above this size will throw 413 (Request Entity Too Large) error
     nginx.ingress.kubernetes.io/proxy-body-size: {{ .Values.repository.ingress.maxUploadSize }}
     nginx.ingress.kubernetes.io/affinity: "cookie"
-    nginx.ingress.kubernetes.io/session-cookie-name": "alfrescoShare"
-    nginx.ingress.kubernetes.io/session-cookie-path": "/share"
-    nginx.ingress.kubernetes.io/session-cookie-max-age": "604800"
-    nginx.ingress.kubernetes.io/session-cookie-expires": "604800"
+    nginx.ingress.kubernetes.io/session-cookie-name: "alfrescoShare"
+    nginx.ingress.kubernetes.io/session-cookie-path: "/share"
+    nginx.ingress.kubernetes.io/session-cookie-max-age: "604800"
+    nginx.ingress.kubernetes.io/session-cookie-expires: "604800"
     nginx.ingress.kubernetes.io/configuration-snippet: |
       location ~ ^(/.*/proxy/alfresco/api/solr/.*)$ {return 403 ;}
                   location ~ ^(/.*/-default-/proxy/alfresco/api/.*)$ {return 403;}


### PR DESCRIPTION
- added share ingress cookie
- edited docs and Travis to pin ingress-nginx chart version to 3.7.1
- added local charts to requirements to fix helm 3.41 linting
