### PR TITLE
OPSEXP-613: Revert artefacts to SP versions

### DIFF
--- a/docker-compose/6.0.N-docker-compose.yml
+++ b/docker-compose/6.0.N-docker-compose.yml
@@ -14,7 +14,7 @@ version: "2"
 
 services:
     alfresco:
-        image: alfresco/alfresco-content-repository:6.0.1.5
+        image: alfresco/alfresco-content-repository:6.0.1.6
         mem_limit: 1500m 
         environment:
             JAVA_OPTS: "
@@ -84,7 +84,7 @@ services:
             - 5432:5432
 
     solr6:
-        image: alfresco/alfresco-search-services:1.4.3.2
+        image: alfresco/alfresco-search-services:1.4.3
         mem_limit: 2500m
         environment:
             #Solr needs to know how to register itself with Alfresco

--- a/docker-compose/6.1.N-docker-compose.yml
+++ b/docker-compose/6.1.N-docker-compose.yml
@@ -13,7 +13,7 @@ version: "2"
 
 services:
     alfresco:
-        image: alfresco/alfresco-content-repository:6.1.1.3
+        image: alfresco/alfresco-content-repository:6.1.1
         mem_limit: 1700m
         environment:
             JAVA_OPTS: "
@@ -47,7 +47,7 @@ services:
 
     transform-router:
         mem_limit: 512m
-        image: quay.io/alfresco/alfresco-transform-router:1.0.2.1
+        image: quay.io/alfresco/alfresco-transform-router:1.0.2
         environment:
           JAVA_OPTS: " -XX:MinRAMPercentage=50 -XX:MaxRAMPercentage=80"
           ACTIVEMQ_URL: "nio://activemq:61616"
@@ -120,7 +120,7 @@ services:
             - shared-file-store-volume:/tmp/Alfresco/sfs
 
     share:
-        image: alfresco/alfresco-share:6.1.1.1
+        image: alfresco/alfresco-share:6.1.1
         mem_limit: 1g
         environment:
             REPO_HOST: "alfresco"
@@ -146,7 +146,7 @@ services:
             - 5432:5432
 
     solr6:
-        image: alfresco/alfresco-search-services:1.4.3.2
+        image: alfresco/alfresco-search-services:1.4.3
         mem_limit: 2g
         environment:
             #Solr needs to know how to register itself with Alfresco

--- a/docker-compose/6.2.N-docker-compose.yml
+++ b/docker-compose/6.2.N-docker-compose.yml
@@ -12,7 +12,7 @@ version: "2"
 
 services:
     alfresco:
-        image: quay.io/alfresco/alfresco-content-repository:6.2.2.5
+        image: quay.io/alfresco/alfresco-content-repository:6.2.2
         mem_limit: 1700m
         environment:
             JAVA_OPTS: "
@@ -112,7 +112,7 @@ services:
             - 5432:5432
 
     solr6:
-        image: alfresco/alfresco-search-services:1.4.3.2
+        image: alfresco/alfresco-search-services:1.4.3
         mem_limit: 2g
         environment:
             #Solr needs to know how to register itself with Alfresco

--- a/helm/alfresco-content-services/6.0.N_values.yaml
+++ b/helm/alfresco-content-services/6.0.N_values.yaml
@@ -16,7 +16,7 @@ repository:
     type: Recreate
   image:
     repository: alfresco/alfresco-content-repository
-    tag: "6.0.1.5"
+    tag: "6.0.1.6"
     pullPolicy: Always
     internalPort: 8080
     hazelcastPort: 5701
@@ -365,7 +365,7 @@ alfresco-search:
     # Port of the external solr6 instance.
 #    port: "8983"
   searchServicesImage:
-    tag: "1.4.3.2"
+    tag: "1.4.3"
   repository: &repositoryHostPort
     # The value for "host" is the name of this chart
     host: alfresco-cs

--- a/helm/alfresco-content-services/6.1.N_values.yaml
+++ b/helm/alfresco-content-services/6.1.N_values.yaml
@@ -16,7 +16,7 @@ repository:
     type: Recreate
   image:
     repository: alfresco/alfresco-content-repository
-    tag: "6.1.1.3"
+    tag: "6.1.1"
     pullPolicy: Always
     internalPort: 8080
     hazelcastPort: 5701
@@ -68,7 +68,7 @@ transformrouter:
   replicaCount: 2
   image:
     repository: quay.io/alfresco/alfresco-transform-router
-    tag: "1.0.2.1"
+    tag: "1.0.2"
     pullPolicy: Always
     internalPort: 8095
   service:
@@ -295,7 +295,7 @@ share:
   replicaCount: 1
   image:
     repository: alfresco/alfresco-share
-    tag: "6.1.1.1"
+    tag: "6.1.1"
     pullPolicy: Always
     internalPort: 8080
   service:
@@ -365,7 +365,7 @@ alfresco-search:
     # Port of the external solr6 instance.
 #    port: "8983"
   searchServicesImage:
-    tag: "1.4.3.2"
+    tag: "1.4.3"
   repository: &repositoryHostPort
     # The value for "host" is the name of this chart
     host: alfresco-cs

--- a/helm/alfresco-content-services/6.2.N_values.yaml
+++ b/helm/alfresco-content-services/6.2.N_values.yaml
@@ -16,7 +16,7 @@ repository:
     type: Recreate
   image:
     repository: quay.io/alfresco/alfresco-content-repository
-    tag: "6.2.2.5"
+    tag: "6.2.2"
     pullPolicy: Always
     internalPort: 8080
     hazelcastPort: 5701
@@ -68,7 +68,7 @@ transformrouter:
   replicaCount: 2
   image:
     repository: quay.io/alfresco/alfresco-transform-router
-    tag: "1.3.0"
+    tag: "1.3.1"
     pullPolicy: Always
     internalPort: 8095
   service:
@@ -396,7 +396,7 @@ alfresco-search:
     # Port of the external solr6 instance.
 #    port: "8983"
   searchServicesImage:
-    tag: "1.4.3.2"
+    tag: "1.4.3"
   repository: &repositoryHostPort
     # The value for "host" is the name of this chart
     host: alfresco-cs


### PR DESCRIPTION
We should NOT be using hotfix versions in our reference deployments according to our policy.

NOTE: There is no "6.0.1" tag for the repository available so I've updated to the latest hotfix for the 6.0.N deployment.