### PR TITLE
Adding custom init/side containers for db waiting or log agregators

### DIFF
--- a/helm/alfresco-content-services/templates/deployment-repository.yaml
+++ b/helm/alfresco-content-services/templates/deployment-repository.yaml
@@ -33,6 +33,9 @@ spec:
         - name: {{ .Values.global.alfrescoRegistryPullSecrets }}
       {{- end }}
       containers:
+        {{- if .Values.repository.extraSideContainers }}
+{{ tpl .Values.repository.extraInitContainers . | indent 8 }}
+        {{- end }}
         - name: {{ .Chart.Name }}
           image: "{{ .Values.repository.image.repository }}:{{ .Values.repository.image.tag }}"
           imagePullPolicy: {{ .Values.repository.image.pullPolicy }}

--- a/helm/alfresco-content-services/templates/deployment-repository.yaml
+++ b/helm/alfresco-content-services/templates/deployment-repository.yaml
@@ -34,7 +34,7 @@ spec:
       {{- end }}
       containers:
         {{- if .Values.repository.extraSideContainers }}
-{{ tpl .Values.repository.extraInitContainers . | indent 8 }}
+{{ tpl .Values.repository.extraSideContainers . | indent 8 }}
         {{- end }}
         - name: {{ .Chart.Name }}
           image: "{{ .Values.repository.image.repository }}:{{ .Values.repository.image.tag }}"

--- a/helm/alfresco-content-services/templates/deployment-repository.yaml
+++ b/helm/alfresco-content-services/templates/deployment-repository.yaml
@@ -33,9 +33,9 @@ spec:
         - name: {{ .Values.global.alfrescoRegistryPullSecrets }}
       {{- end }}
       containers:
-        {{- if .Values.repository.extraSideContainers }}
+      {{- if .Values.repository.extraSideContainers }}
 {{ tpl .Values.repository.extraSideContainers . | indent 8 }}
-        {{- end }}
+      {{- end }}
         - name: {{ .Chart.Name }}
           image: "{{ .Values.repository.image.repository }}:{{ .Values.repository.image.tag }}"
           imagePullPolicy: {{ .Values.repository.image.pullPolicy }}

--- a/helm/alfresco-content-services/templates/deployment-repository.yaml
+++ b/helm/alfresco-content-services/templates/deployment-repository.yaml
@@ -110,6 +110,9 @@ spec:
                 command: ["/bin/bash", "-c", "sleep 20"]
       {{- if or (eq .Values.database.external false) (.Values.persistence.repository.enabled) }}
       initContainers:
+      {{- if .Values.repository.extraInitContainers }}
+{{ tpl .Values.repository.extraInitContainers . | indent 8 }}
+      {{- end }}
       {{- if eq .Values.database.external false }}
         # wait for the DB to startup before this deployment can start
         - name: init-db


### PR DESCRIPTION
Added this feature so we could put in custom wait for db init containers.
Also for the possibility of adding extra side containers if necessary.

```
      {{- if .Values.repository.extraSideContainers }}
{{ tpl .Values.repository.extraSideContainers . | indent 8 }}
      {{- end }}
      {{- if .Values.repository.extraInitContainers }}
{{ tpl .Values.repository.extraInitContainers . | indent 8 }}
      {{- end }}
```