### PR TITLE
Bump to ADW 2.0.0

### DIFF
--- a/docker-compose/6.2.N-docker-compose.yml
+++ b/docker-compose/6.2.N-docker-compose.yml
@@ -138,7 +138,7 @@ services:
             - 61613:61613 # STOMP
 
     digital-workspace:
-        image: quay.io/alfresco/alfresco-digital-workspace:1.6.0
+        image: quay.io/alfresco/alfresco-digital-workspace:2.0.0-adw
         mem_limit: 128m
         environment:
             BASE_PATH: ./

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -148,7 +148,7 @@ services:
             - 61613:61613 # STOMP
 
     digital-workspace:
-        image: quay.io/alfresco/alfresco-digital-workspace:2.0.0-M2
+        image: quay.io/alfresco/alfresco-digital-workspace:2.0.0-adw
         mem_limit: 128m
         environment:
             BASE_PATH: ./

--- a/helm/alfresco-content-services/6.2.N_values.yaml
+++ b/helm/alfresco-content-services/6.2.N_values.yaml
@@ -424,7 +424,7 @@ alfresco-digital-workspace:
       nginx.ingress.kubernetes.io/proxy-body-size: "5g"
   image:
     repository: quay.io/alfresco/alfresco-digital-workspace
-    tag: 1.6.0
+    tag: 2.0.0-adw
     pullPolicy: Always
   env:
     APP_CONFIG_AUTH_TYPE: "BASIC"

--- a/helm/alfresco-content-services/values.yaml
+++ b/helm/alfresco-content-services/values.yaml
@@ -432,7 +432,7 @@ alfresco-digital-workspace:
       nginx.ingress.kubernetes.io/proxy-body-size: "5g"
   image:
     repository: quay.io/alfresco/alfresco-digital-workspace
-    tag: 2.0.0-M2
+    tag: 2.0.0-adw
     pullPolicy: Always
   env:
     APP_CONFIG_AUTH_TYPE: "BASIC"


### PR DESCRIPTION
- note: 2.0.0-adw (rather than 2.0.0)
- note: both master (7.0.0-Mx) *and* 6.2.N since new ADW / OOI extension targets ACS 6.2.2 or higher