### PR TITLE
OPSEXP-664: Allow custom repo debugging configuration to be provided for the ACS helm charts

### DIFF
--- a/helm/alfresco-content-services/6.0.N_values.yaml
+++ b/helm/alfresco-content-services/6.0.N_values.yaml
@@ -58,6 +58,11 @@ repository:
     initialDelaySeconds: 130
     periodSeconds: 20
     timeoutSeconds: 10
+  # Provide additional log statements by adding
+  # classes and/or packages in a key:value fashion
+  # extraLogStatements:
+  #   org.alfresco.repo.content.transform.TransformerDebug: debug
+  #   org.alfresco.repo.security.authentication.identityservice: debug
 
 # Declares the api-explorer service used by the content repository
 apiexplorer:

--- a/helm/alfresco-content-services/6.1.N_values.yaml
+++ b/helm/alfresco-content-services/6.1.N_values.yaml
@@ -58,6 +58,11 @@ repository:
     initialDelaySeconds: 130
     periodSeconds: 20
     timeoutSeconds: 10
+  # Provide additional log statements by adding
+  # classes and/or packages in a key:value fashion
+  # extraLogStatements:
+  #   org.alfresco.repo.content.transform.TransformerDebug: debug
+  #   org.alfresco.repo.security.authentication.identityservice: debug
 
 # Declares the api-explorer service used by the content repository
 apiexplorer:

--- a/helm/alfresco-content-services/6.2.N_values.yaml
+++ b/helm/alfresco-content-services/6.2.N_values.yaml
@@ -58,6 +58,11 @@ repository:
     initialDelaySeconds: 130
     periodSeconds: 20
     timeoutSeconds: 10
+  # Provide additional log statements by adding
+  # classes and/or packages in a key:value fashion
+  # extraLogStatements:
+  #   org.alfresco.repo.content.transform.TransformerDebug: debug
+  #   org.alfresco.repo.security.authentication.identityservice: debug
 
 # Declares the api-explorer service used by the content repository
 apiexplorer:
@@ -439,7 +444,6 @@ ai:
   #  region:
   #  s3Bucket:
   #  comprehendRoleARN:
-
 
 # Defines properties required by alfresco for connecting to the database
 # Note! : If you set database.external to true you will have to setup the driver, user, password and JdbcUrl

--- a/helm/alfresco-content-services/templates/config-dev-log4j-properties.yaml
+++ b/helm/alfresco-content-services/templates/config-dev-log4j-properties.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.repository.extraLogStatements }}
+# Defines log4j propeties
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "alfresco.shortname" . }}-dev-log4j-properties-configmap
+  labels:
+    {{- include "repository.labels" . | nindent 4 }}
+data:
+  dev-log4j.properties: |-
+  {{- range $key, $val := .Values.repository.extraLogStatements }}
+   log4j.logger.{{ $key }}={{ tpl $val $ }}
+  {{- end }}
+{{- end }}

--- a/helm/alfresco-content-services/templates/deployment-repository.yaml
+++ b/helm/alfresco-content-services/templates/deployment-repository.yaml
@@ -24,6 +24,7 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/config-repository.yaml") . | sha256sum }}
         checksum/secretDatabase: {{ include (print $.Template.BasePath "/secret-database.yaml") . | sha256sum }}
         checksum/secretS3: {{ include (print $.Template.BasePath "/secret-s3.yaml") . | sha256sum }}
+        checksum/config-log4j: {{ include (print $.Template.BasePath "/config-dev-log4j-properties.yaml") . | sha256sum }}
       labels:
         {{- include "repository.selectorLabels" . | nindent 8 }}
     spec:
@@ -69,6 +70,10 @@ spec:
 {{ toYaml .Values.repository.resources | indent 12 }}
           {{- if .Values.persistence.repository.enabled }}
           volumeMounts:
+          {{- if .Values.repository.extraLogStatements }}
+          - name: dev-log4j-properties-volume
+            mountPath: "/usr/local/tomcat/shared/classes/alfresco/extension/"
+          {{- end }}
           - name: data
             mountPath: {{ .Values.persistence.repository.data.mountPath }}
             subPath: {{ .Values.persistence.repository.data.subPath }}
@@ -173,6 +178,11 @@ spec:
               mountPath: /var/run/secrets/java.io/keystores
         {{- end }}
       volumes:
+      {{- if .Values.repository.extraLogStatements }}
+      - name : dev-log4j-properties-volume
+        configMap:
+          name: {{ template "alfresco.shortname" . }}-dev-log4j-properties-configmap
+      {{- end }}
       - name: data
         persistentVolumeClaim:
           claimName: {{ .Values.persistence.existingClaim }}

--- a/helm/alfresco-content-services/values.yaml
+++ b/helm/alfresco-content-services/values.yaml
@@ -66,6 +66,11 @@ repository:
     timeoutSeconds: 10
   extraVolumeMounts: []
   extraVolumes: []
+  # Provide additional log statements by adding
+  # classes and/or packages in a key:value fashion
+  # extraLogStatements:
+  #   org.alfresco.repo.content.transform.TransformerDebug: debug
+  #   org.alfresco.repo.security.authentication.identityservice: debug
 
 # Declares the api-explorer service used by the content repository
 apiexplorer:


### PR DESCRIPTION
Created mechanism to allow custom repo debugging configuration to be provided for the ACS helm charts via values files.