### PR TITLE
[MNT-22131] Pull Share image from Docker Hub

### DIFF
--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -96,7 +96,7 @@ services:
             - shared-file-store-volume:/tmp/Alfresco/sfs
 
     share:
-        image: quay.io/alfresco/alfresco-share:7.0.0-M3
+        image: alfresco/alfresco-share:7.0.0-M3
         mem_limit: 1g
         environment:
             REPO_HOST: "alfresco"

--- a/helm/alfresco-content-services/values.yaml
+++ b/helm/alfresco-content-services/values.yaml
@@ -338,7 +338,7 @@ filestore:
 share:
   replicaCount: 1
   image:
-    repository: quay.io/alfresco/alfresco-share
+    repository: alfresco/alfresco-share
     tag: "7.0.0-M3"
     pullPolicy: Always
     internalPort: 8080


### PR DESCRIPTION
Customers do not have access to pull Share image from quay.io