### PR TITLE
OPSEXP-755 & OPSEXP-756: Update nginx config

### DIFF
--- a/docker-compose/6.1.N-docker-compose.yml
+++ b/docker-compose/6.1.N-docker-compose.yml
@@ -178,7 +178,7 @@ services:
             BASEPATH: ./
 
     proxy:
-        image: alfresco/alfresco-acs-nginx:3.1.0
+        image: alfresco/alfresco-acs-nginx:3.1.1
         mem_limit: 128m
         depends_on:
             - alfresco

--- a/docker-compose/6.1.N-docker-compose.yml
+++ b/docker-compose/6.1.N-docker-compose.yml
@@ -178,7 +178,7 @@ services:
             BASEPATH: ./
 
     proxy:
-        image: alfresco/alfresco-acs-nginx:3.0.1
+        image: alfresco/alfresco-acs-nginx:3.1.0
         mem_limit: 128m
         depends_on:
             - alfresco

--- a/docker-compose/6.2.N-docker-compose.yml
+++ b/docker-compose/6.2.N-docker-compose.yml
@@ -144,7 +144,7 @@ services:
             BASE_PATH: ./
 
     proxy:
-        image: alfresco/alfresco-acs-nginx:3.1.0
+        image: alfresco/alfresco-acs-nginx:3.1.1
         mem_limit: 128m
         depends_on:
             - alfresco

--- a/docker-compose/6.2.N-docker-compose.yml
+++ b/docker-compose/6.2.N-docker-compose.yml
@@ -144,7 +144,7 @@ services:
             BASE_PATH: ./
 
     proxy:
-        image: alfresco/alfresco-acs-nginx:3.0.1
+        image: alfresco/alfresco-acs-nginx:3.1.0
         mem_limit: 128m
         depends_on:
             - alfresco

--- a/docker-compose/community-docker-compose.yml
+++ b/docker-compose/community-docker-compose.yml
@@ -106,8 +106,11 @@ services:
             - 61613:61613 # STOMP
 
     proxy:
-        image: alfresco/acs-community-ngnix:1.0.0
+        image: alfresco/alfresco-acs-nginx:3.1.0
         mem_limit: 128m
+        environment:
+          DISABLE_SYNCSERVICE: "true"
+          DISABLE_ADW: "true"
         depends_on:
             - alfresco
         ports:

--- a/docker-compose/community-docker-compose.yml
+++ b/docker-compose/community-docker-compose.yml
@@ -106,11 +106,12 @@ services:
             - 61613:61613 # STOMP
 
     proxy:
-        image: alfresco/alfresco-acs-nginx:3.1.0
+        image: alfresco/alfresco-acs-nginx:3.1.1
         mem_limit: 128m
         environment:
-          DISABLE_SYNCSERVICE: "true"
-          DISABLE_ADW: "true"
+            DISABLE_PROMETHEUS: "true"
+            DISABLE_SYNCSERVICE: "true"
+            DISABLE_ADW: "true"
         depends_on:
             - alfresco
         ports:

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -149,7 +149,7 @@ services:
             BASE_PATH: ./
 
     proxy:
-        image: alfresco/alfresco-acs-nginx:3.0.1
+        image: alfresco/alfresco-acs-nginx:3.1.0
         mem_limit: 128m
         depends_on:
             - alfresco

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -149,7 +149,7 @@ services:
             BASE_PATH: ./
 
     proxy:
-        image: alfresco/alfresco-acs-nginx:3.1.0
+        image: alfresco/alfresco-acs-nginx:3.1.1
         mem_limit: 128m
         depends_on:
             - alfresco

--- a/helm/alfresco-content-services/templates/ingress-share.yaml
+++ b/helm/alfresco-content-services/templates/ingress-share.yaml
@@ -18,8 +18,8 @@ metadata:
     nginx.ingress.kubernetes.io/session-cookie-max-age: "604800"
     nginx.ingress.kubernetes.io/session-cookie-expires: "604800"
     nginx.ingress.kubernetes.io/configuration-snippet: |
-      location ~ ^(/.*/proxy/alfresco/api/solr/.*)$ {return 403 ;}
-      location ~ ^(/.*/-default-/proxy/alfresco/api/.*)$ {return 403;}
+      location ~ ^(/.*/proxy/.*/api/solr/.*)$ {return 403 ;}
+      location ~ ^(/.*/-default-/proxy/.*/api/.*)$ {return 403;}
 {{- if .Values.share.ingress.annotations }}
 {{ toYaml .Values.share.ingress.annotations | indent 4 }}
 {{- end }}

--- a/test/postman/docker-compose/acs-test-docker-compose-collection.json
+++ b/test/postman/docker-compose/acs-test-docker-compose-collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "3b8257e1-fb3f-4699-9589-808305a0b4ae",
+		"_postman_id": "e5bdcb1a-bd5d-4e2e-bd37-733dcae20374",
 		"name": "acs-test-docker-compose-collection",
 		"description": "The Suite of cases tests ACS basic wiring:\n1) Acs-basic-auth\n* Request to validate the discovery api\n* Request to validate modules are applied correctly",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
@@ -15,7 +15,6 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "3218aa24-59e0-43a2-8289-13823135e1a1",
 								"exec": [
 									"",
 									"pm.globals.get(\"url\");",
@@ -85,7 +84,6 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "35d1998e-0308-4a42-aa30-33eac23d73c3",
 								"type": "text/javascript",
 								"exec": [
 									"pm.globals.get(\"url\");",
@@ -169,7 +167,6 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "46de3060-bd60-425e-8c7a-1aa3c9734dca",
 								"type": "text/javascript",
 								"exec": [
 									"pm.test(\"Status code is 200\", function () {",
@@ -230,7 +227,6 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "f157f0f3-8a14-4849-9481-405f2622f0f9",
 								"type": "text/javascript",
 								"exec": [
 									"var jsonData = pm.response.json();",
@@ -301,7 +297,6 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "bba7e131-b715-4ad7-9bc7-9eb3bffc4734",
 								"type": "text/javascript",
 								"exec": [
 									"pm.test(\"Status code is 200\", function () {",
@@ -361,7 +356,6 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "1e856931-34a4-4118-82de-9b87479c4d53",
 								"type": "text/javascript",
 								"exec": [
 									"pm.test(\"Status code is 200\", function () {",
@@ -421,7 +415,6 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "899304d6-6751-4e27-b6e7-d1628ac4b619",
 								"exec": [
 									"pm.globals.get(\"url\");",
 									"",
@@ -500,7 +493,6 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "22e5902c-84a4-4014-b0a3-e98187233cd1",
 								"exec": [
 									"",
 									"pm.globals.get(\"url\");",
@@ -561,7 +553,6 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "cad8952d-ffc0-49c9-b4a5-645d8c05b438",
 								"exec": [
 									"",
 									"pm.globals.get(\"url\");",
@@ -632,7 +623,6 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "5e990981-2486-4cf4-a0d3-2102c33a748f",
 								"type": "text/javascript",
 								"exec": [
 									"pm.globals.get(\"url\");",
@@ -697,7 +687,6 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "16a3cabb-124f-46ac-92da-b0eb7104e327",
 								"type": "text/javascript",
 								"exec": [
 									"pm.globals.get(\"url\");",
@@ -772,12 +761,231 @@
 					"response": []
 				},
 				{
+					"name": "share-alfresco-proxy",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.globals.get(\"url\");",
+									"",
+									"pm.test(\"searchAlfrescoProxyStatusCodeTest\", function () {",
+									"    pm.response.to.have.status(403);",
+									"});",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "saveHelperData",
+									"type": "any"
+								},
+								{
+									"key": "showPassword",
+									"value": false,
+									"type": "boolean"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{protocol}}://{{url}}/share/service/proxy/alfresco/api/solr/aclchangesets?fromId=1&maxResults=5",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"share",
+								"service",
+								"proxy",
+								"alfresco",
+								"api",
+								"solr",
+								"aclchangesets"
+							],
+							"query": [
+								{
+									"key": "fromId",
+									"value": "1"
+								},
+								{
+									"key": "maxResults",
+									"value": "5"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "share-alfresco-noauth-proxy",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.globals.get(\"url\");",
+									"",
+									"pm.test(\"searchAlfrescoNoauthProxyStatusCodeTest\", function () {",
+									"    pm.response.to.have.status(403);",
+									"});",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "saveHelperData",
+									"type": "any"
+								},
+								{
+									"key": "showPassword",
+									"value": false,
+									"type": "boolean"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{protocol}}://{{url}}/share/proxy/alfresco-noauth/api/solr/aclchangesets?fromId=1&maxResults=5",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"share",
+								"proxy",
+								"alfresco-noauth",
+								"api",
+								"solr",
+								"aclchangesets"
+							],
+							"query": [
+								{
+									"key": "fromId",
+									"value": "1"
+								},
+								{
+									"key": "maxResults",
+									"value": "5"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "share-alfresco-feed-proxy",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.globals.get(\"url\");",
+									"",
+									"pm.test(\"searchAlfrescoFeedProxyStatusCodeTest\", function () {",
+									"    pm.response.to.have.status(403);",
+									"});",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "saveHelperData",
+									"type": "any"
+								},
+								{
+									"key": "showPassword",
+									"value": false,
+									"type": "boolean"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{protocol}}://{{url}}/share/proxy/alfresco-feed/api/solr/aclchangesets?fromId=1&maxResults=5",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"share",
+								"proxy",
+								"alfresco-feed",
+								"api",
+								"solr",
+								"aclchangesets"
+							],
+							"query": [
+								{
+									"key": "fromId",
+									"value": "1"
+								},
+								{
+									"key": "maxResults",
+									"value": "5"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
 					"name": "alfresco-prometheus ",
 					"event": [
 						{
 							"listen": "test",
 							"script": {
-								"id": "4a711803-de47-4b3c-a8dc-c0f978e151b6",
 								"exec": [
 									"pm.globals.get(\"url\");",
 									"",
@@ -848,7 +1056,6 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "2c623e70-5aca-457a-a2d6-bddd544275c8",
 								"type": "text/javascript",
 								"exec": [
 									"pm.globals.get(\"url\");",
@@ -887,7 +1094,6 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "546d88cc-de47-4829-b60e-1fe442be1342",
 								"type": "text/javascript",
 								"exec": [
 									"pm.test(\"Status code is 200\", function () {",
@@ -942,7 +1148,6 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "9a8394d8-2c23-4db7-9795-d4d18ac1d51d",
 								"type": "text/javascript",
 								"exec": [
 									"pm.test(\"Status code is 200\", function () {",
@@ -997,7 +1202,6 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "a8262695-3ec7-4335-baec-ff6e1e0fa2b4",
 								"exec": [
 									"pm.test(\"Status code is 207\", function () {",
 									"    pm.response.to.have.status(207);",
@@ -1062,7 +1266,6 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "e9fc06ef-952a-4d0b-87ce-1c0573659f2a",
 								"exec": [
 									"pm.test(\"Status code is 200\", function () {",
 									"    pm.response.to.have.status(200);",
@@ -1113,7 +1316,6 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "38f65ab5-0111-4027-b7a5-7feefb61559f",
 								"exec": [
 									"pm.test(\"Status code is 200\", function () {",
 									"    pm.response.to.have.status(200);",
@@ -1175,7 +1377,6 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "0ed8f1fc-7fc2-4394-948f-cb3d35b08108",
 								"exec": [
 									"pm.test(\"Status code is 207\", function () {",
 									"    pm.response.to.have.status(207);",
@@ -1244,7 +1445,6 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "57cdd164-977d-475d-8af2-b15742f303a7",
 								"type": "text/javascript",
 								"exec": [
 									"pm.test(\"Status code is 200\", function () {",
@@ -1304,7 +1504,6 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "d631a358-d6f6-4cca-a50c-4d3d1115f5b7",
 								"exec": [
 									"pm.globals.get(\"url\");",
 									"",
@@ -1381,7 +1580,6 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "528f78fe-7306-4b05-987f-83f0c577b46f",
 								"exec": [
 									"pm.globals.get(\"url\");",
 									"",
@@ -1458,7 +1656,6 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "2c8f9c52-e7d3-437f-a09c-be677190b221",
 								"exec": [
 									"pm.globals.get(\"url\");",
 									"",
@@ -1504,15 +1701,13 @@
 					},
 					"response": []
 				}
-			],
-			"protocolProfileBehavior": {}
+			]
 		}
 	],
 	"event": [
 		{
 			"listen": "prerequest",
 			"script": {
-				"id": "8bf8383a-2f12-41b5-941e-0066948feb7f",
 				"type": "text/javascript",
 				"exec": [
 					""
@@ -1522,13 +1717,11 @@
 		{
 			"listen": "test",
 			"script": {
-				"id": "4804fb2f-a9a7-4061-8373-d729194f4f77",
 				"type": "text/javascript",
 				"exec": [
 					""
 				]
 			}
 		}
-	],
-	"protocolProfileBehavior": {}
+	]
 }

--- a/test/postman/helm/acs-test-helm-collection.json
+++ b/test/postman/helm/acs-test-helm-collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "8e75949a-909f-430a-b589-f477749ed089",
+		"_postman_id": "0e4bd97c-7f1a-42f5-af75-06143428c96c",
 		"name": "acs-test-collection",
 		"description": "The Suite of cases tests ACS basic wiring:\n1) Acs-basic-auth\n* Request to validate the discovery api\n* Request to validate modules are applied correctly",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
@@ -15,7 +15,6 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "9cfdcdb7-e909-483c-a820-54a073678cbc",
 								"exec": [
 									"",
 									"pm.globals.get(\"url\");",
@@ -95,7 +94,6 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "d700425e-113e-48fd-b975-63417df3813b",
 								"type": "text/javascript",
 								"exec": [
 									"pm.globals.get(\"url\");",
@@ -179,7 +177,6 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "c1af68da-3611-49ab-9112-50d25d711b18",
 								"type": "text/javascript",
 								"exec": [
 									"pm.test(\"Status code is 200\", function () {",
@@ -240,7 +237,6 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "2f6af13c-a661-4605-a9af-44193f3675fa",
 								"type": "text/javascript",
 								"exec": [
 									"var jsonData = pm.response.json();",
@@ -311,7 +307,6 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "d6756383-8d28-4f9f-9af6-665b13452569",
 								"type": "text/javascript",
 								"exec": [
 									"pm.test(\"Status code is 200\", function () {",
@@ -371,7 +366,6 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "220cf48b-2cdc-4346-82ca-0ce47aa281b5",
 								"type": "text/javascript",
 								"exec": [
 									"pm.test(\"Status code is 200\", function () {",
@@ -431,7 +425,6 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "76852005-c89f-4b84-b367-16ce889e00be",
 								"type": "text/javascript",
 								"exec": [
 									"pm.test(\"Status code is 200\", function () {",
@@ -491,7 +484,6 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "0e20b23e-f186-421d-aaa8-a1d2a77d21dc",
 								"exec": [
 									"pm.globals.get(\"url\");",
 									"",
@@ -570,7 +562,6 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "6d0c2508-f482-491b-b2ba-289081d033ce",
 								"exec": [
 									"",
 									"pm.globals.get(\"url\");",
@@ -670,7 +661,6 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "f04c40db-6bbe-45cf-a9c8-3dbee34a66b8",
 								"exec": [
 									"",
 									"pm.globals.get(\"url\");",
@@ -732,7 +722,6 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "34b7b770-e817-4dc2-ab12-f939a793de08",
 								"exec": [
 									"",
 									"pm.globals.get(\"url\");",
@@ -803,7 +792,6 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "23f01817-9e08-4c43-98ad-c94ec638d07f",
 								"type": "text/javascript",
 								"exec": [
 									"pm.globals.get(\"url\");",
@@ -868,7 +856,6 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "9d958167-4a8b-4422-91d4-4024eea21dfb",
 								"type": "text/javascript",
 								"exec": [
 									"pm.globals.get(\"url\");",
@@ -948,7 +935,6 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "c57a5f6e-a257-4179-aec3-ec4341a9e176",
 								"type": "text/javascript",
 								"exec": [
 									"pm.globals.get(\"url\");",
@@ -1019,12 +1005,159 @@
 					"response": []
 				},
 				{
+					"name": "share-alfresco-noauth-proxy",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.globals.get(\"url\");",
+									"",
+									"pm.test(\"searchAlfrescoNoauthProxyStatusCodeTest\", function () {",
+									"    pm.response.to.have.status(403);",
+									"});",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "saveHelperData",
+									"type": "any"
+								},
+								{
+									"key": "showPassword",
+									"value": false,
+									"type": "boolean"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{protocol}}://{{url}}/share/proxy/alfresco-noauth/api/solr/aclchangesets?fromId=1&maxResults=5",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"share",
+								"proxy",
+								"alfresco-noauth",
+								"api",
+								"solr",
+								"aclchangesets"
+							],
+							"query": [
+								{
+									"key": "fromId",
+									"value": "1"
+								},
+								{
+									"key": "maxResults",
+									"value": "5"
+								}
+							]
+						},
+						"description": "Check share access to alfresco via proxy is forbidden for some regex patterns"
+					},
+					"response": []
+				},
+				{
+					"name": "share-alfresco-feed-proxy",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.globals.get(\"url\");",
+									"",
+									"pm.test(\"searchAlfrescoFeedProxyStatusCodeTest\", function () {",
+									"    pm.response.to.have.status(403);",
+									"});",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "saveHelperData",
+									"type": "any"
+								},
+								{
+									"key": "showPassword",
+									"value": false,
+									"type": "boolean"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{protocol}}://{{url}}/share/proxy/alfresco-feed/api/solr/aclchangesets?fromId=1&maxResults=5",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"share",
+								"proxy",
+								"alfresco-feed",
+								"api",
+								"solr",
+								"aclchangesets"
+							],
+							"query": [
+								{
+									"key": "fromId",
+									"value": "1"
+								},
+								{
+									"key": "maxResults",
+									"value": "5"
+								}
+							]
+						},
+						"description": "Check share access to alfresco via proxy is forbidden for some regex patterns"
+					},
+					"response": []
+				},
+				{
 					"name": "alfresco-solr service",
 					"event": [
 						{
 							"listen": "test",
 							"script": {
-								"id": "e1116aba-f9f0-451e-bf92-23bd5777d312",
 								"type": "text/javascript",
 								"exec": [
 									"pm.globals.get(\"url\");",
@@ -1098,7 +1231,6 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "e2aac4c9-5e17-4596-9549-843a69802453",
 								"type": "text/javascript",
 								"exec": [
 									"pm.globals.get(\"url\");",
@@ -1172,7 +1304,6 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "04c7e900-f277-45dc-948e-1fd2f4519e09",
 								"type": "text/javascript",
 								"exec": [
 									"pm.globals.get(\"url\");",
@@ -1246,7 +1377,6 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "e411666f-31bd-4ed3-acac-2b43a51407a2",
 								"type": "text/javascript",
 								"exec": [
 									"pm.globals.get(\"url\");",
@@ -1320,7 +1450,6 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "6f3343b3-2fa7-4df2-8cc7-dc4c1cc924f4",
 								"type": "text/javascript",
 								"exec": [
 									"pm.globals.get(\"url\");",
@@ -1359,7 +1488,6 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "e69b8c13-cc16-41a6-8bfb-29834188c5f9",
 								"type": "text/javascript",
 								"exec": [
 									"pm.globals.get(\"url\");",
@@ -1419,7 +1547,6 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "2a1ed4a1-f741-4c6d-83c6-0913c8d0759f",
 								"type": "text/javascript",
 								"exec": [
 									"pm.test(\"Status code is 200\", function () {",
@@ -1474,7 +1601,6 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "b6aa3d55-2f57-41de-8d6c-0612d0945da9",
 								"type": "text/javascript",
 								"exec": [
 									"pm.test(\"Status code is 200\", function () {",
@@ -1529,7 +1655,6 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "8195992a-6cce-42dc-91d7-d236892ebf41",
 								"exec": [
 									"",
 									"AOSversion = pm.environment.get(\"AOSversion\");",
@@ -1601,7 +1726,6 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "b1d0fbf0-a01f-437f-8de4-39805bf6e2b6",
 								"exec": [
 									"pm.test(\"Status code is 200\", function () {",
 									"    pm.response.to.have.status(200);",
@@ -1652,7 +1776,6 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "d4f1c098-8253-469d-8a8c-467c28bc0ebb",
 								"exec": [
 									"pm.test(\"Status code is 200\", function () {",
 									"    pm.response.to.have.status(200);",
@@ -1714,7 +1837,6 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "463cb8b4-469a-42a8-bab9-68dc8b880abd",
 								"exec": [
 									"pm.test(\"Status code is 207\", function () {",
 									"    pm.response.to.have.status(207);",
@@ -1782,7 +1904,6 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "f09a13cd-1676-48a5-ad6e-07ee357cfd41",
 								"exec": [
 									"pm.globals.get(\"url\");",
 									"",
@@ -1859,7 +1980,6 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "542eecce-fa2a-4c50-bc9e-41d6f6bdebda",
 								"exec": [
 									"pm.globals.get(\"url\");",
 									"",
@@ -1930,15 +2050,13 @@
 					},
 					"response": []
 				}
-			],
-			"protocolProfileBehavior": {}
+			]
 		}
 	],
 	"event": [
 		{
 			"listen": "prerequest",
 			"script": {
-				"id": "55966182-f50d-449e-8c14-795184d52f5d",
 				"type": "text/javascript",
 				"exec": [
 					""
@@ -1948,13 +2066,11 @@
 		{
 			"listen": "test",
 			"script": {
-				"id": "54e5fa8b-4253-4f74-8286-a41f91d10519",
 				"type": "text/javascript",
 				"exec": [
 					""
 				]
 			}
 		}
-	],
-	"protocolProfileBehavior": {}
+	]
 }


### PR DESCRIPTION
Updated to new version of alfresco-acs-nginx that now supports Enterprise and Community and includes the required change.

Added additional tests for the extra protected URLs.