### PR TITLE
Feature/update sync service

### DIFF
--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -162,7 +162,7 @@ services:
             - share
 
     sync-service:
-        image: quay.io/alfresco/service-sync:3.4.0-M2
+        image: quay.io/alfresco/service-sync:3.4.0-M5
         mem_limit: 1g
         environment:
             JAVA_OPTS : "

--- a/helm/alfresco-content-services/charts/alfresco-sync-service/Chart.yaml
+++ b/helm/alfresco-content-services/charts/alfresco-sync-service/Chart.yaml
@@ -7,5 +7,5 @@ keywords:
 maintainers:
   - name: Alfresco Apps Repo Team
 name: alfresco-sync-service
-version: 3.0.6
+version: 3.0.7
 icon: https://avatars0.githubusercontent.com/u/391127?s=200&v=4

--- a/helm/alfresco-content-services/charts/alfresco-sync-service/values.yaml
+++ b/helm/alfresco-content-services/charts/alfresco-sync-service/values.yaml
@@ -12,7 +12,7 @@ syncservice:
   enabled: true
   image:
     repository: quay.io/alfresco/service-sync
-    tag: 3.4.0-M2
+    tag: 3.4.0-M5
     pullPolicy: Always
     internalPort: 9090
   environment:

--- a/helm/alfresco-content-services/requirements.yaml
+++ b/helm/alfresco-content-services/requirements.yaml
@@ -18,4 +18,4 @@ dependencies:
   - name: alfresco-search
     version: 1.0.4
   - name: alfresco-sync-service
-    version: 3.0.6
+    version: 3.0.7


### PR DESCRIPTION
Update Sync Service from 3.4.0-M2 to 3.4.0-M5. This update is only for ACS 7.0.0