### PR TITLE
Upgrade share for Enterprise deployments

### DIFF
--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -91,7 +91,7 @@ services:
             - shared-file-store-volume:/tmp/Alfresco/sfs
 
     share:
-        image: quay.io/alfresco/alfresco-share:7.0.0-M3
+        image: quay.io/alfresco/alfresco-share:7.0.0-A17
         mem_limit: 1g
         environment:
             REPO_HOST: "alfresco"

--- a/helm/alfresco-content-services/values.yaml
+++ b/helm/alfresco-content-services/values.yaml
@@ -368,7 +368,7 @@ share:
   replicaCount: 1
   image:
     repository: quay.io/alfresco/alfresco-share
-    tag: "7.0.0-M3"
+    tag: "7.0.0-A17"
     pullPolicy: Always
     internalPort: 8080
   service:


### PR DESCRIPTION
NOTE: Community remains at 7.0.0-M3 as only stable Share images are pushed to dockerhub.