### PR TITLE
Create ELB for TCP services only if email inbound is enabled

### DIFF
--- a/helm/alfresco-content-services/templates/config-email.yaml
+++ b/helm/alfresco-content-services/templates/config-email.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.email.server.enabled }}
+{{- if and .Values.email.server.enabled .Values.email.inbound.enabled }}
 # Defines the email configmap for the alfresco content repository app
 apiVersion: v1
 kind: ConfigMap

--- a/helm/alfresco-content-services/templates/deployment-repository.yaml
+++ b/helm/alfresco-content-services/templates/deployment-repository.yaml
@@ -61,7 +61,7 @@ spec:
             # internal port and the hazelcast port used for clustering
             - containerPort: {{ .Values.repository.image.internalPort }}
             - containerPort: {{ .Values.repository.image.hazelcastPort }}
-            {{- if .Values.email.server.enabled }}
+            {{- if and .Values.email.server.enabled .Values.email.inbound.enabled }}
             - containerPort: {{ .Values.email.server.port }}
             - containerPort: {{ .Values.imap.server.port }}
             - containerPort: {{ .Values.imap.server.imaps.port }}
@@ -86,7 +86,7 @@ spec:
             mountPath: {{ .Values.persistence.repository.config.transform.renditionsMountPath }}
           - name: custom-mimetype-config-volume
             mountPath: {{ .Values.persistence.repository.config.transform.mimetypesMountPath }}
-          {{- if and .Values.email.server.enabled .Values.email.server.enableTLS }}
+          {{- if and .Values.email.server.enabled .Values.email.inbound.enabled .Values.email.server.enableTLS }}
           - mountPath: /var/run/secrets/java.io/keystores
             name: email-keystore-volume
           - mountPath: /var/run/secrets/certs
@@ -133,7 +133,7 @@ spec:
             - name: data
               mountPath: {{ .Values.persistence.repository.data.mountPath }}
               subPath: {{ .Values.persistence.repository.data.subPath }}
-        {{- if and .Values.email.server.enabled .Values.email.server.enableTLS }}
+        {{- if and .Values.email.server.enabled .Values.email.inbound.enabled .Values.email.server.enableTLS }}
         - name: pem-to-keystore
           image: registry.access.redhat.com/redhat-sso-7/sso71-openshift:1.1-16
           env:
@@ -208,7 +208,7 @@ spec:
         configMap:
           optional: true
           name: custom-queryset-config
-      {{- if and .Values.email.server.enabled .Values.email.server.enableTLS }}
+      {{- if and .Values.email.server.enabled .Values.email.inbound.enabled .Values.email.server.enableTLS }}
       - name: email-keystore-volume
         emptyDir: {}
       - name: email-certs

--- a/helm/alfresco-content-services/templates/svc-email.yaml
+++ b/helm/alfresco-content-services/templates/svc-email.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.email.server.enabled }}
+{{- if and .Values.email.server.enabled .Values.email.inbound.enabled }}
 # Defines the email service for the alfresco content repository app
 apiVersion: v1
 kind: Service

--- a/helm/alfresco-content-services/templates/svc-repository.yaml
+++ b/helm/alfresco-content-services/templates/svc-repository.yaml
@@ -11,7 +11,7 @@ spec:
     - port: {{ .Values.repository.service.externalPort }}
       targetPort: {{ .Values.repository.image.internalPort }}
       name: {{ .Values.repository.service.name }}
-    {{- if .Values.email.server.enabled }}
+    {{- if and .Values.email.server.enabled .Values.email.inbound.enabled }}
     - port: {{ .Values.email.server.port }}
       targetPort: {{ .Values.email.server.port }}
       name: {{ .Values.repository.service.name }}-email-inbound


### PR DESCRIPTION
- It should create TCP ELB only if `email.inbound.enabled` (along with `email.server.enabled`)