### PR TITLE
OPSEXP-827: ACS Helm deployment is still using Postgres 11 despite being configured with 13

### DIFF
--- a/helm/alfresco-content-services/community_values.yaml
+++ b/helm/alfresco-content-services/community_values.yaml
@@ -347,7 +347,8 @@ postgresql:
   # Note: Set this to false if you use an external database.
   enabled: true
   nameOverride: postgresql-acs
-  imageTag: "13.1"
+  image:
+    tag: "13.1"
   postgresqlUsername: alfresco
   postgresqlPassword: alfresco
   postgresqlDatabase: alfresco

--- a/helm/alfresco-content-services/community_values.yaml
+++ b/helm/alfresco-content-services/community_values.yaml
@@ -348,7 +348,7 @@ postgresql:
   enabled: true
   nameOverride: postgresql-acs
   image:
-    tag: "13.1"
+    tag: "13.1.0"
   postgresqlUsername: alfresco
   postgresqlPassword: alfresco
   postgresqlDatabase: alfresco

--- a/helm/alfresco-content-services/values.yaml
+++ b/helm/alfresco-content-services/values.yaml
@@ -510,7 +510,8 @@ postgresql:
   # Note: Set this to false if you use an external database.
   enabled: true
   nameOverride: postgresql-acs
-  image.tag: "13.1"
+  image:
+    tag: "13.1"
   commonAnnotations:
     application: alfresco-content-services
   postgresqlUsername: alfresco
@@ -535,7 +536,8 @@ postgresql-syncservice:
   enabled: true
   replicaCount: 1
   nameOverride: postgresql-syncservice
-  imageTag: "13.1"
+  image:
+    tag: "13.1"
   commonAnnotations:
     application: alfresco-content-services
   persistence:

--- a/helm/alfresco-content-services/values.yaml
+++ b/helm/alfresco-content-services/values.yaml
@@ -511,7 +511,7 @@ postgresql:
   enabled: true
   nameOverride: postgresql-acs
   image:
-    tag: "13.1"
+    tag: "13.1.0"
   commonAnnotations:
     application: alfresco-content-services
   postgresqlUsername: alfresco
@@ -537,7 +537,7 @@ postgresql-syncservice:
   replicaCount: 1
   nameOverride: postgresql-syncservice
   image:
-    tag: "13.1"
+    tag: "13.1.0"
   commonAnnotations:
     application: alfresco-content-services
   persistence:

--- a/helm/alfresco-content-services/values.yaml
+++ b/helm/alfresco-content-services/values.yaml
@@ -510,7 +510,7 @@ postgresql:
   # Note: Set this to false if you use an external database.
   enabled: true
   nameOverride: postgresql-acs
-  imageTag: "13.1"
+  image.tag: "13.1"
   commonAnnotations:
     application: alfresco-content-services
   postgresqlUsername: alfresco


### PR DESCRIPTION
Replaced _imageTag_ with image.tag as referred in bitnami charts. Also, 13.1 tag doesn't exists in bitnami's docker repository, but they do have 13.1.0