### PR TITLE
Revert "OPSEXP-827: ACS Helm deployment is still using Postgres 11 despite being configured with 13"

### DIFF
--- a/helm/alfresco-content-services/community_values.yaml
+++ b/helm/alfresco-content-services/community_values.yaml
@@ -347,8 +347,7 @@ postgresql:
   # Note: Set this to false if you use an external database.
   enabled: true
   nameOverride: postgresql-acs
-  image:
-    tag: "13.1.0"
+  imageTag: "13.1"
   postgresqlUsername: alfresco
   postgresqlPassword: alfresco
   postgresqlDatabase: alfresco

--- a/helm/alfresco-content-services/values.yaml
+++ b/helm/alfresco-content-services/values.yaml
@@ -510,8 +510,7 @@ postgresql:
   # Note: Set this to false if you use an external database.
   enabled: true
   nameOverride: postgresql-acs
-  image:
-    tag: "13.1.0"
+  imageTag: "13.1"
   commonAnnotations:
     application: alfresco-content-services
   postgresqlUsername: alfresco
@@ -536,8 +535,7 @@ postgresql-syncservice:
   enabled: true
   replicaCount: 1
   nameOverride: postgresql-syncservice
-  image:
-    tag: "13.1.0"
+  imageTag: "13.1"
   commonAnnotations:
     application: alfresco-content-services
   persistence:


### PR DESCRIPTION
Reverts Alfresco/acs-deployment#520