### PR TITLE
Add ability to configure TLS section

### DIFF
--- a/helm/alfresco-content-services/6.1.N_values.yaml
+++ b/helm/alfresco-content-services/6.1.N_values.yaml
@@ -50,6 +50,10 @@ repository:
     maxUploadSize: "5g"
     annotations: {}
       # nginx.ingress.kubernetes.io/enable-cors: "true"
+    tls: []
+    #  - secretName: chart-example-tls
+    #    hosts:
+    #      - chart-example.local
   environment:
     JAVA_OPTS: " -Dsolr.base.url=/solr
       -Dsolr.secureComms=none
@@ -338,6 +342,10 @@ share:
   ingress:
     path: /share
     annotations: {}
+    tls: []
+    #  - secretName: chart-example-tls
+    #    hosts:
+    #      - chart-example.local
   resources:
     requests:
       memory: "2000Mi"
@@ -417,6 +425,10 @@ alfresco-search:
   # Example: `echo -n "$(htpasswd -nbm admin admin)" | base64` # i.e. admin / admin
   # basicAuth: YWRtaW46JGFwcjEkVVJqb29uS00kSEMuS1EwVkRScFpwSHB2a3JwTDd1Lg==
     basicAuth:
+    tls: []
+    #  - secretName: chart-example-tls
+    #    hosts:
+    #      - chart-example.local
 
 alfresco-digital-workspace:
   enabled: true
@@ -427,6 +439,10 @@ alfresco-digital-workspace:
     path: /workspace
     annotations:
       nginx.ingress.kubernetes.io/proxy-body-size: "5g"
+    tls: []
+    #  - secretName: chart-example-tls
+    #    hosts:
+    #      - chart-example.local
   image:
     repository: quay.io/alfresco/alfresco-digital-workspace
     tag: 1.4.0

--- a/helm/alfresco-content-services/6.2.N_values.yaml
+++ b/helm/alfresco-content-services/6.2.N_values.yaml
@@ -50,6 +50,10 @@ repository:
     maxUploadSize: "5g"
     annotations: {}
       # nginx.ingress.kubernetes.io/enable-cors: "true"
+    tls: []
+    #  - secretName: chart-example-tls
+    #    hosts:
+    #      - chart-example.local
   environment:
     JAVA_OPTS: " -Dsolr.base.url=/solr
       -Dsolr.secureComms=none
@@ -369,6 +373,10 @@ share:
   ingress:
     path: /share
     annotations: {}
+    tls: []
+    #  - secretName: chart-example-tls
+    #    hosts:
+    #      - chart-example.local
   resources:
     requests:
       memory: "2000Mi"
@@ -448,6 +456,10 @@ alfresco-search:
   # Example: `echo -n "$(htpasswd -nbm admin admin)" | base64` # i.e. admin / admin
   # basicAuth: YWRtaW46JGFwcjEkVVJqb29uS00kSEMuS1EwVkRScFpwSHB2a3JwTDd1Lg==
     basicAuth:
+    tls: []
+    #  - secretName: chart-example-tls
+    #    hosts:
+    #      - chart-example.local
 
 alfresco-digital-workspace:
   enabled: true
@@ -458,6 +470,10 @@ alfresco-digital-workspace:
     path: /workspace
     annotations:
       nginx.ingress.kubernetes.io/proxy-body-size: "5g"
+    tls: []
+    #  - secretName: chart-example-tls
+    #    hosts:
+    #      - chart-example.local
   image:
     repository: quay.io/alfresco/alfresco-digital-workspace
     tag: 2.1.0-adw

--- a/helm/alfresco-content-services/charts/alfresco-search/templates/ingress.yaml
+++ b/helm/alfresco-content-services/charts/alfresco-search/templates/ingress.yaml
@@ -15,6 +15,16 @@ metadata:
     nginx.ingress.kubernetes.io/whitelist-source-range: {{ .Values.ingress.whitelist_ips }}
 
 spec:
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
   rules:
   - http:
       paths:

--- a/helm/alfresco-content-services/charts/alfresco-search/values.yaml
+++ b/helm/alfresco-content-services/charts/alfresco-search/values.yaml
@@ -27,6 +27,10 @@ service:
 ingress:
   enabled: true
   path: /solr
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
   # -- Default solr basic auth user/password: admin / admin
   # You can create your own with htpasswd utilility & encode it with base640.
   # Example: `echo -n "$(htpasswd -nbm admin admin)" | base64` # i.e. admin / admin

--- a/helm/alfresco-content-services/charts/alfresco-sync-service/templates/ingress.yaml
+++ b/helm/alfresco-content-services/charts/alfresco-sync-service/templates/ingress.yaml
@@ -18,6 +18,16 @@ metadata:
 {{- end }}
 
 spec:
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
   rules:
   {{- if .Values.ingress.hostName }}
   - host: {{ tpl .Values.ingress.hostName $ }}

--- a/helm/alfresco-content-services/charts/alfresco-sync-service/values.yaml
+++ b/helm/alfresco-content-services/charts/alfresco-sync-service/values.yaml
@@ -142,3 +142,7 @@ ingress:
   extraAnnotations:
     # -- useful when running Sync service without SSL termination done by a load balancer, e.g. when ran on Minikube for testing purposes
     #nginx.ingress.kubernetes.io/ssl-redirect: "false"
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local

--- a/helm/alfresco-content-services/community_values.yaml
+++ b/helm/alfresco-content-services/community_values.yaml
@@ -46,6 +46,10 @@ repository:
     type: ClusterIP
     externalPort: &repositoryExternalPort 80
   ingress:
+    tls: []
+    #  - secretName: chart-example-tls
+    #    hosts:
+    #      - chart-example.local
     path: /
     maxUploadSize: "5g"
     annotations: {}
@@ -82,6 +86,10 @@ repository:
 # Declares the api-explorer service used by the content repository
 apiexplorer:
   ingress:
+    tls: []
+    #  - secretName: chart-example-tls
+    #    hosts:
+    #      - chart-example.local
     path: /api-explorer
 
 # Declares the alfresco-pdf-renderer service used by the content repository
@@ -266,6 +274,10 @@ share:
   ingress:
     path: /share
     annotations: {}
+    tls: []
+    #  - secretName: chart-example-tls
+    #    hosts:
+    #      - chart-example.local
   resources:
     requests:
       memory: "2000Mi"
@@ -345,6 +357,10 @@ alfresco-search:
   # Example: `echo -n "$(htpasswd -nbm admin admin)" | base64` # i.e. admin / admin
   # basicAuth: YWRtaW46JGFwcjEkVVJqb29uS00kSEMuS1EwVkRScFpwSHB2a3JwTDd1Lg==
     basicAuth:
+    tls: []
+    #  - secretName: chart-example-tls
+    #    hosts:
+    #      - chart-example.local
 
 # Defines properties required by alfresco for connecting to the database
 # Note! : If you set database.external to true you will have to setup the driver, user, password and JdbcUrl

--- a/helm/alfresco-content-services/community_values.yaml
+++ b/helm/alfresco-content-services/community_values.yaml
@@ -46,14 +46,14 @@ repository:
     type: ClusterIP
     externalPort: &repositoryExternalPort 80
   ingress:
-    tls: []
-    #  - secretName: chart-example-tls
-    #    hosts:
-    #      - chart-example.local
     path: /
     maxUploadSize: "5g"
     annotations: {}
       # nginx.ingress.kubernetes.io/enable-cors: "true"
+    tls: []
+    #  - secretName: chart-example-tls
+    #    hosts:
+    #      - chart-example.local
   environment:
     JAVA_OPTS: " -Dsolr.base.url=/solr
       -Dsolr.secureComms=none
@@ -86,11 +86,11 @@ repository:
 # Declares the api-explorer service used by the content repository
 apiexplorer:
   ingress:
+    path: /api-explorer
     tls: []
     #  - secretName: chart-example-tls
     #    hosts:
     #      - chart-example.local
-    path: /api-explorer
 
 # Declares the alfresco-pdf-renderer service used by the content repository
 # to transform pdf files

--- a/helm/alfresco-content-services/templates/ingress-ooi-service.yaml
+++ b/helm/alfresco-content-services/templates/ingress-ooi-service.yaml
@@ -16,6 +16,16 @@ metadata:
 {{- end }}
 
 spec:
+  {{- if .Values.ooiService.ingress.tls }}
+  tls:
+    {{- range .Values.ooiService.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
   rules:
   {{- if .Values.ooiService.ingress.hostName }}
   - host: {{ tpl .Values.ooiService.ingress.hostName $ }}

--- a/helm/alfresco-content-services/templates/ingress-repository.yaml
+++ b/helm/alfresco-content-services/templates/ingress-repository.yaml
@@ -31,6 +31,16 @@ metadata:
 {{- end }}
 
 spec:
+  {{- if .Values.repository.ingress.tls }}
+  tls:
+    {{- range .Values.repository.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
   rules:
   {{- if .Values.repository.ingress.hostName }}
   - host: {{ tpl .Values.repository.ingress.hostName . }}

--- a/helm/alfresco-content-services/templates/ingress-share.yaml
+++ b/helm/alfresco-content-services/templates/ingress-share.yaml
@@ -25,6 +25,16 @@ metadata:
 {{- end }}
 
 spec:
+  {{- if .Values.share.ingress.tls }}
+  tls:
+    {{- range .Values.share.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
   rules:
   {{- if .Values.share.ingress.hostName }}
   - host: {{ tpl .Values.share.ingress.hostName . }}

--- a/helm/alfresco-content-services/values.yaml
+++ b/helm/alfresco-content-services/values.yaml
@@ -39,6 +39,10 @@ repository:
     type: ClusterIP
     externalPort: &repositoryExternalPort 80
   ingress:
+    tls: []
+    #  - secretName: chart-example-tls
+    #    hosts:
+    #      - chart-example.local
     path: /
     maxUploadSize: "5g"
     annotations: {}
@@ -101,6 +105,10 @@ ooiService:
     type: ClusterIP
     externalPort: 80
   ingress:
+    tls: []
+    #  - secretName: chart-example-tls
+    #    hosts:
+    #      - chart-example.local
     path: /ooi-service
   resources:
     requests:
@@ -401,6 +409,10 @@ share:
   ingress:
     path: /share
     annotations: {}
+    tls: []
+    #  - secretName: chart-example-tls
+    #    hosts:
+    #      - chart-example.local
   resources:
     requests:
       memory: "2000Mi"
@@ -487,6 +499,10 @@ alfresco-search:
   # Example: `echo -n "$(htpasswd -nbm admin admin)" | base64` # i.e. admin / admin
   # basicAuth: YWRtaW46JGFwcjEkVVJqb29uS00kSEMuS1EwVkRScFpwSHB2a3JwTDd1Lg==
     basicAuth:
+    tls: []
+    #  - secretName: chart-example-tls
+    #    hosts:
+    #      - chart-example.local
 
 alfresco-digital-workspace:
   enabled: true
@@ -497,6 +513,10 @@ alfresco-digital-workspace:
     path: /workspace
     annotations:
       nginx.ingress.kubernetes.io/proxy-body-size: "5g"
+    tls: []
+    #  - secretName: chart-example-tls
+    #    hosts:
+    #      - chart-example.local
   image:
     repository: quay.io/alfresco/alfresco-digital-workspace
     tag: 2.1.0-adw

--- a/helm/alfresco-content-services/values.yaml
+++ b/helm/alfresco-content-services/values.yaml
@@ -39,14 +39,14 @@ repository:
     type: ClusterIP
     externalPort: &repositoryExternalPort 80
   ingress:
-    tls: []
-    #  - secretName: chart-example-tls
-    #    hosts:
-    #      - chart-example.local
     path: /
     maxUploadSize: "5g"
     annotations: {}
       # nginx.ingress.kubernetes.io/enable-cors: "true"
+    tls: []
+    #  - secretName: chart-example-tls
+    #    hosts:
+    #      - chart-example.local
   environment:
     JAVA_OPTS: " -Dsolr.base.url=/solr
       -Dsolr.secureComms=none
@@ -105,11 +105,11 @@ ooiService:
     type: ClusterIP
     externalPort: 80
   ingress:
+    path: /ooi-service
     tls: []
     #  - secretName: chart-example-tls
     #    hosts:
     #      - chart-example.local
-    path: /ooi-service
   resources:
     requests:
       memory: "1000Mi"


### PR DESCRIPTION
This PR makes it possible to configure the TLS section of the Ingress for the following components:

- apiexplorer
- repository
- search
- share
- sync-service

The configuration follows the structure in the default Helm templates (`helm create <name>`):

```yaml
ingress:
  tls: []
  #  - secretName: chart-example-tls
  #    hosts:
  #      - chart-example.local
```

I added an example configuration in values.yaml and community_values.yaml
