### PR TITLE
Update eks-deployment.md

### DIFF
--- a/docs/helm/eks-deployment.md
+++ b/docs/helm/eks-deployment.md
@@ -108,10 +108,16 @@ Now we have an EKS cluster up and running there are a few one time steps we need
    kubectl apply -f external-dns.yaml -n kube-system
    ```
 
-5. Find the name of the role used by the nodes by running the following command (replacing `YOUR-CLUSTER-NAME` with the name you gave your cluster):
+4. Find the name of the nodegroup created by running the following command (replacing `YOUR-CLUSTER-NAME` with the name you gave your cluster):
 
     ```bash
-    aws eks describe-nodegroup --cluster-name YOUR-CLUSTER-NAME --nodegroup-name linux-nodes --query "nodegroup.nodeRole" --output text
+    eksctl get nodegroup --cluster=`YOUR-CLUSTER-NAME` 
+    ```
+
+5. Find the name of the role used by the nodes by running the following command (replacing `YOUR-CLUSTER-NAME` with the name you gave your cluster, and `YOUR-NODE-GROUP` with the nodegroup from the step above):
+
+    ```bash
+    aws eks describe-nodegroup --cluster-name YOUR-CLUSTER-NAME --nodegroup-name YOUR-NODE-GROUP --query "nodegroup.nodeRole" --output text
     ```
 
 6. In the [IAM console](https://console.aws.amazon.com/iam/home) find the role discovered in the previous step and attach the "AmazonRoute53FullAccess" managed policy as shown in the screenshot below:

--- a/docs/helm/eks-deployment.md
+++ b/docs/helm/eks-deployment.md
@@ -44,7 +44,7 @@ Now we have an EKS cluster up and running there are a few one time steps we need
     metadata:
       name: external-dns
     ---
-    apiVersion: rbac.authorization.k8s.io/v1beta1
+    apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
       name: external-dns
@@ -59,7 +59,7 @@ Now we have an EKS cluster up and running there are a few one time steps we need
       resources: ["nodes"]
       verbs: ["list","watch"]
     ---
-    apiVersion: rbac.authorization.k8s.io/v1beta1
+    apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
       name: external-dns-viewer


### PR DESCRIPTION
Suggest update the apiVersion in the sample external-dns.yaml from rbac.authorization.k8s.io/v1beta1 to rbac.authorization.k8s.io/v1

And suggestion for additional step in **Prepare The Cluster For ACS** where the nodegroup name created by following the previous steps is not _linux-nodes_ and causes the command to fail (previously step 4).