### PR TITLE
Opsexp 922 chown for volumes

### DIFF
--- a/helm/alfresco-content-services/6.1.N_values.yaml
+++ b/helm/alfresco-content-services/6.1.N_values.yaml
@@ -490,8 +490,7 @@ postgresql:
     max_connections: 300
     log_min_messages: LOG
   persistence:
-    existingClaim: "alfresco-volume-claim"
-    subPath: "alfresco-content-services/database-data"
+    storageClass: gp2
   resources:
     requests:
       memory: "1500Mi"
@@ -509,8 +508,7 @@ postgresql-syncservice:
     tag: "11.4.0"
     pullPolicy: Always
   persistence:
-    existingClaim: "alfresco-volume-claim"
-    subPath: "alfresco-sync-services/database-data"
+    storageClass: gp2
     #subPath: "ent-featureappsrepo470-9/alfresco-sync-services/database-data"
   postgresqlUsername: alfresco
   postgresqlPassword: admin

--- a/helm/alfresco-content-services/6.2.N_values.yaml
+++ b/helm/alfresco-content-services/6.2.N_values.yaml
@@ -520,8 +520,7 @@ postgresql:
     max_connections: 300
     log_min_messages: LOG
   persistence:
-    existingClaim: "alfresco-volume-claim"
-    subPath: "alfresco-content-services/database-data"
+    storageClass: gp2
   resources:
     requests:
       memory: "1500Mi"
@@ -539,8 +538,7 @@ postgresql-syncservice:
     tag: "11.4.0"
     pullPolicy: Always
   persistence:
-    existingClaim: "alfresco-volume-claim"
-    subPath: "alfresco-sync-services/database-data"
+    storageClass: gp2
     #subPath: "ent-featureappsrepo470-9/alfresco-sync-services/database-data"
   postgresqlUsername: alfresco
   postgresqlPassword: admin

--- a/helm/alfresco-content-services/charts/activemq/templates/deployment-activemq.yaml
+++ b/helm/alfresco-content-services/charts/activemq/templates/deployment-activemq.yaml
@@ -64,6 +64,7 @@ spec:
           subPath: {{ .Values.persistence.subPath }}
         resources:
 {{ toYaml .Values.resources | indent 12 }}
+      {{- if .Values.persistence.dynamicProvisioning }}
       initContainers:
         - name: init-fs
           image: "{{ .Values.initContainer.image.repository }}:{{ .Values.initContainer.image.tag }}"
@@ -80,4 +81,5 @@ spec:
       - name: data
         persistentVolumeClaim:
           claimName: {{ .Values.persistence.existingClaim }}
+      {{- end }}
 {{- end }}

--- a/helm/alfresco-content-services/charts/activemq/templates/deployment-activemq.yaml
+++ b/helm/alfresco-content-services/charts/activemq/templates/deployment-activemq.yaml
@@ -58,13 +58,13 @@ spec:
           periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
           failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
           timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+        resources:
+{{ toYaml .Values.resources | indent 12 }}
+       {{- if .Values.persistence.dynamicProvisioning }}
         volumeMounts:
         - name: data
           mountPath: {{ .Values.persistence.mountPath }}
           subPath: {{ .Values.persistence.subPath }}
-        resources:
-{{ toYaml .Values.resources | indent 12 }}
-      {{- if .Values.persistence.dynamicProvisioning }}
       initContainers:
         - name: init-fs
           image: "{{ .Values.initContainer.image.repository }}:{{ .Values.initContainer.image.tag }}"

--- a/helm/alfresco-content-services/charts/activemq/values.yaml
+++ b/helm/alfresco-content-services/charts/activemq/values.yaml
@@ -60,3 +60,4 @@ persistence:
   existingClaim: "alfresco-volume-claim"
   mountPath: "/opt/activemq/data"
   subPath: "alfresco-infrastructure/activemq-data"
+  dynamicProvisioning: false

--- a/helm/alfresco-content-services/charts/alfresco-search/templates/deployment.yaml
+++ b/helm/alfresco-content-services/charts/alfresco-search/templates/deployment.yaml
@@ -51,10 +51,12 @@ spec:
             - containerPort: {{ template "alfresco-search.internalPort" . }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
+          {{- if .Values.persistence.dynamicProvisioning }}
           volumeMounts:
           - name: data
             mountPath: {{ .Values.persistence.search.data.mountPath }}
             subPath: {{ .Values.persistence.search.data.subPath }}
+          {{- end }}
           readinessProbe:
             httpGet:
               path: /solr
@@ -75,6 +77,7 @@ spec:
             preStop:
               exec:
                 command: ["/bin/bash", "-c", "sleep 10"]
+      {{- if .Values.persistence.dynamicProvisioning }}
       initContainers:
         - name: init-db
           image: "{{ .Values.initContainer.image.repository }}:{{ .Values.initContainer.image.tag }}"
@@ -91,3 +94,4 @@ spec:
       - name: data
         persistentVolumeClaim:
           claimName: "{{ .Values.persistence.existingClaim | default (printf "%s-solr-claim" (include "alfresco-search.fullName" .)) }}"
+      {{- end }}

--- a/helm/alfresco-content-services/charts/alfresco-search/values.yaml
+++ b/helm/alfresco-content-services/charts/alfresco-search/values.yaml
@@ -54,8 +54,9 @@ resources:
 # the solr data folder containing the indexes for the alfresco-search-services is mapped to alfresco-content-services/solr-data
 persistence:
   enabled: true
+  dynamicProvisioning: false
   # -- Only define if you have a specific claim already created
-  # existingClaim: "search-master-claim" 
+  # existingClaim: "search-master-claim"
   VolumeSizeRequest: 10Gi
   search:
     data:

--- a/helm/alfresco-content-services/charts/alfresco-sync-service/values.yaml
+++ b/helm/alfresco-content-services/charts/alfresco-sync-service/values.yaml
@@ -96,11 +96,10 @@ postgresql-syncservice:
   replicaCount: 1
   nameOverride: postgresql-syncservice
   image:
-    tag: "11.7.0"    
+    tag: "11.7.0"
     pullPolicy: Always
   persistence:
-    existingClaim: "alfresco-volume-claim"
-    subPath: "alfresco-sync-services/database-data"
+    storageClass: gp2
     #subPath: "ent-featureappsrepo470-9/alfresco-sync-services/database-data"
   postgresqlUsername: alfresco
   postgresqlPassword: admin

--- a/helm/alfresco-content-services/templates/deployment-filestore.yaml
+++ b/helm/alfresco-content-services/templates/deployment-filestore.yaml
@@ -77,12 +77,12 @@ spec:
             failureThreshold: 1
             timeoutSeconds: {{ .Values.filestore.livenessProbe.timeoutSeconds }}
           {{- if .Values.persistence.filestore.enabled }}
+      {{- if and .Values.persistence.filestore.enabled .Values.persistence.dynamicProvisioning }}
           volumeMounts:
           - name: data
             mountPath: {{ .Values.persistence.filestore.data.mountPath }}
             subPath: {{ .Values.persistence.filestore.data.subPath }}
           {{- end }}
-      {{- if and .Values.persistence.filestore.enabled .Values.persistence.dynamicProvisioning }}
       initContainers:
         - name: init-fs
           image: "{{ .Values.filestore.initContainer.image.repository }}:{{ .Values.filestore.initContainer.image.tag }}"

--- a/helm/alfresco-content-services/templates/deployment-filestore.yaml
+++ b/helm/alfresco-content-services/templates/deployment-filestore.yaml
@@ -82,7 +82,7 @@ spec:
             mountPath: {{ .Values.persistence.filestore.data.mountPath }}
             subPath: {{ .Values.persistence.filestore.data.subPath }}
           {{- end }}
-      {{- if .Values.persistence.filestore.enabled }}
+      {{- if and .Values.persistence.filestore.enabled .Values.persistence.dynamicProvisioning }}
       initContainers:
         - name: init-fs
           image: "{{ .Values.filestore.initContainer.image.repository }}:{{ .Values.filestore.initContainer.image.tag }}"

--- a/helm/alfresco-content-services/templates/deployment-filestore.yaml
+++ b/helm/alfresco-content-services/templates/deployment-filestore.yaml
@@ -76,13 +76,11 @@ spec:
             periodSeconds: {{ .Values.filestore.livenessProbe.periodSeconds }}
             failureThreshold: 1
             timeoutSeconds: {{ .Values.filestore.livenessProbe.timeoutSeconds }}
-          {{- if .Values.persistence.filestore.enabled }}
       {{- if and .Values.persistence.filestore.enabled .Values.persistence.dynamicProvisioning }}
           volumeMounts:
           - name: data
             mountPath: {{ .Values.persistence.filestore.data.mountPath }}
             subPath: {{ .Values.persistence.filestore.data.subPath }}
-          {{- end }}
       initContainers:
         - name: init-fs
           image: "{{ .Values.filestore.initContainer.image.repository }}:{{ .Values.filestore.initContainer.image.tag }}"

--- a/helm/alfresco-content-services/templates/deployment-repository.yaml
+++ b/helm/alfresco-content-services/templates/deployment-repository.yaml
@@ -82,9 +82,11 @@ spec:
             mountPath: /usr/local/tomcat/shared/classes/alfresco/extension/dev-log4j.properties
             subPath: dev-log4j.properties
           {{- end }}
+          {{- if .Values.persistence.dynamicProvisioning }}
           - name: data
             mountPath: {{ .Values.persistence.repository.data.mountPath }}
             subPath: {{ .Values.persistence.repository.data.subPath }}
+          {{- end }}
           - name: custom-queryset-config-volume
             mountPath: {{ .Values.persistence.repository.config.querysetsMountPath }}
           - name: custom-pipeline-config-volume

--- a/helm/alfresco-content-services/templates/deployment-repository.yaml
+++ b/helm/alfresco-content-services/templates/deployment-repository.yaml
@@ -138,6 +138,7 @@ spec:
           command: ['sh', '-c', 'until nc -w1 {{ printf "%s-%s" .Release.Name .Values.postgresql.nameOverride }} {{ .Values.postgresql.service.port }}; do echo "waiting for {{ printf "%s-%s" .Release.Name .Values.postgresql.nameOverride }}"; sleep 2; done;']
       {{- end }}
       {{- if .Values.persistence.repository.enabled }}
+        {{- if .Values.persistence.dynamicProvisioning }}
         - name: init-fs
           image: "{{ .Values.repository.initContainers.fs.image.repository }}:{{ .Values.repository.initContainers.fs.image.tag }}"
           imagePullPolicy: {{ .Values.repository.initContainers.fs.image.pullPolicy }}
@@ -149,6 +150,7 @@ spec:
             - name: data
               mountPath: {{ .Values.persistence.repository.data.mountPath }}
               subPath: {{ .Values.persistence.repository.data.subPath }}
+        {{- end }}
         {{- if and .Values.email.server.enabled .Values.email.inbound.enabled .Values.email.server.enableTLS }}
         - name: pem-to-keystore
           image: "{{ .Values.email.initContainers.pemToKeystore.image.repository }}:{{ .Values.email.initContainers.pemToKeystore.image.tag }}"

--- a/helm/alfresco-content-services/values.yaml
+++ b/helm/alfresco-content-services/values.yaml
@@ -605,8 +605,7 @@ postgresql-syncservice:
   commonAnnotations:
     application: alfresco-content-services
   persistence:
-    existingClaim: "alfresco-volume-claim"
-    subPath: "alfresco-sync-services/database-data"
+    storageClass: gp2
     #subPath: "ent-featureappsrepo470-9/alfresco-sync-services/database-data"
   postgresqlUsername: alfresco
   postgresqlPassword: admin

--- a/helm/alfresco-content-services/values.yaml
+++ b/helm/alfresco-content-services/values.yaml
@@ -438,6 +438,7 @@ share:
 # cluster the alf_data folder from alfresco-content-repository app is mapped to
 # alfresco-content-services/repository-data
 persistence:
+  dynamicProvisioning: false
   enabled: true
   baseSize: 20Gi
   # -- Enable and define if you already have a custom storage class defined


### PR DESCRIPTION
Ref: [OPSEXP-922](https://alfresco.atlassian.net/browse/OPSEXP-922)

Got rid of init-fs containers, because we can't run `chown` command with  EFS CSI dynamic provisioning ([bug](https://github.com/kubernetes-sigs/aws-efs-csi-driver/issues/300) is already created for provider). 