### PR TITLE
ACS-1870: Add MS Teams option to ACS Helm charts (part 2)

### DIFF
--- a/docs/helm/examples/with-ms-teams.md
+++ b/docs/helm/examples/with-ms-teams.md
@@ -41,10 +41,11 @@ helm install acs alfresco/alfresco-content-services \
 --set messageBroker.user="alfresco" \
 --set messageBroker.password="YOUR-MQ-PASSWORD" \
 --set msTeams.enabled=true \
+--set msTeamsService.alfresco.baseUrl="https://acs.YOUR-DOMAIN-NAME:443"
+--set msTeamsService.alfresco.adw.contextPath="/workspace/" \
 --set msTeamsService.microsoft.app.id="YOUR-MS-APP-ID" \
 --set msTeamsService.microsoft.app.password="YOUR-MS-APP-PWD" \
 --set msTeamsService.microsoft.app.oauth.connectionName="alfresco" \
---set msTeamsService.adw.contextPath="/workspace/" \
 --set msTeamsService.chat.filenameEnabled=true \
 --set msTeamsService.chat.metadataEnabled=true \
 --set msTeamsService.chat.imageEnabled=true \

--- a/helm/alfresco-content-services/README.md
+++ b/helm/alfresco-content-services/README.md
@@ -121,11 +121,12 @@ Hence, setting up explicit Container memory and then assigning a percentage of i
 | metadataKeystore.defaultKeyPassword | string | `"oKIWzVdEdA"` |  |
 | metadataKeystore.defaultKeystorePassword | string | `"mp6yc0UD9e"` |  |
 | msTeams | object | `{"enabled":false}` | Choose if you want Microsoft Teams Integration capabilities (Alfresco Content Connector for Microsoft Teams) |
-| msTeamsService.adw.contextPath | string | `"/workspace/"` |  |
+| msTeamsService.alfresco.adw.contextPath | string | `"/workspace/"` |  |
+| msTeamsService.alfresco.baseUrl | string | `"{protocol}//{hostname}{:port}"` |  |
 | msTeamsService.chat.filenameEnabled | bool | `true` |  |
 | msTeamsService.chat.imageEnabled | bool | `true` |  |
 | msTeamsService.chat.metadataEnabled | bool | `true` |  |
-| msTeamsService.environment.JAVA_OPTS | string | `" -Dalfresco.base-url=http://acs-alfresco-cs-repository:80"` |  |
+| msTeamsService.environment.JAVA_OPTS | string | `" -XX:MinRAMPercentage=50 -XX:MaxRAMPercentage=80"` |  |
 | msTeamsService.image.internalPort | int | `3978` |  |
 | msTeamsService.image.pullPolicy | string | `"IfNotPresent"` |  |
 | msTeamsService.image.repository | string | `"quay.io/alfresco/alfresco-ms-teams-service"` |  |

--- a/helm/alfresco-content-services/templates/config-ms-teams-service.yaml
+++ b/helm/alfresco-content-services/templates/config-ms-teams-service.yaml
@@ -13,10 +13,11 @@ data:
   {{ $key }}: {{ tpl $val $ | quote }}
   {{- end }}
   {{- end }}
+  ALFRESCO_BASE_URL: {{ .Values.msTeamsService.alfresco.baseUrl }}
+  ALFRESCO_DIGITAL_WORKSPACE_CONTEXT_PATH: {{ .Values.msTeamsService.alfresco.adw.contextPath }}
   MICROSOFT_APP_ID: {{ .Values.msTeamsService.microsoft.app.id }}
   MICROSOFT_APP_PASSWORD: {{ .Values.msTeamsService.microsoft.app.password }}
   MICROSOFT_APP_OAUTH_CONNECTION_NAME: {{ .Values.msTeamsService.microsoft.app.oauth.connectionName }}
-  ALFRESCO_DIGITAL_WORKSPACE_CONTEXT_PATH: {{ .Values.msTeamsService.adw.contextPath }}
   TEAMS_CHAT_FILENAME_ENABLED: "{{ .Values.msTeamsService.chat.filenameEnabled }}"
   TEAMS_CHAT_METADATA_ENABLED: "{{ .Values.msTeamsService.chat.metadataEnabled }}"
   TEAMS_CHAT_IMAGE_ENABLED: "{{ .Values.msTeamsService.chat.imageEnabled }}"

--- a/helm/alfresco-content-services/values.yaml
+++ b/helm/alfresco-content-services/values.yaml
@@ -153,7 +153,7 @@ msTeamsService:
     limits:
       memory: "1000Mi"
   environment:
-    JAVA_OPTS: " -Dalfresco.base-url=http://acs-alfresco-cs-repository:80"
+    JAVA_OPTS: " -XX:MinRAMPercentage=50 -XX:MaxRAMPercentage=80"
   readinessProbe:
     initialDelaySeconds: 20
     periodSeconds: 60
@@ -162,15 +162,16 @@ msTeamsService:
     initialDelaySeconds: 10
     periodSeconds: 20
     timeoutSeconds: 10
-  
+  alfresco:
+    baseUrl: "{protocol}//{hostname}{:port}"
+    adw:
+      contextPath: /workspace/
   microsoft:
     app:
       id: change_me
       password: change_me
       oauth:
         connectionName: alfresco
-  adw:
-    contextPath: /workspace/
   chat:
     filenameEnabled: true
     metadataEnabled: true


### PR DESCRIPTION
- make sure alfresco.base-url (eg. https://my-env:443) is also configurable
- used to generate ADW preview links (in addition to Alfresco REST API calls)