### PR TITLE
ACS-1914: Update helm charts for MS Teams example

### DIFF
--- a/docs/helm/examples/with-ms-teams.md
+++ b/docs/helm/examples/with-ms-teams.md
@@ -41,7 +41,8 @@ helm install acs alfresco/alfresco-content-services \
 --set messageBroker.user="alfresco" \
 --set messageBroker.password="YOUR-MQ-PASSWORD" \
 --set msTeams.enabled=true \
---set msTeamsService.alfresco.baseUrl="https://acs.YOUR-DOMAIN-NAME:443"
+--set msTeamsService.alfresco.baseUrl="https://acs.YOUR-DOMAIN-NAME:443" \
+--set msTeamsService.alfresco.digitalWorkspace.baseUrl="https://acs.YOUR-DOMAIN-NAME:443" \
 --set msTeamsService.alfresco.digitalWorkspace.contextPath="/workspace/" \
 --set msTeamsService.microsoft.app.id="YOUR-MS-APP-ID" \
 --set msTeamsService.microsoft.app.password="YOUR-MS-APP-PWD" \

--- a/helm/alfresco-content-services/README.md
+++ b/helm/alfresco-content-services/README.md
@@ -122,6 +122,7 @@ Hence, setting up explicit Container memory and then assigning a percentage of i
 | metadataKeystore.defaultKeystorePassword | string | `"mp6yc0UD9e"` |  |
 | msTeams | object | `{"enabled":false}` | Choose if you want Microsoft Teams Integration capabilities (Alfresco Content Connector for Microsoft Teams) |
 | msTeamsService.alfresco.baseUrl | string | `"change_me_alf_base_url"` |  |
+| msTeamsService.alfresco.digitalWorkspace.baseUrl | string | `"change_me_adw_base_url"` |  |
 | msTeamsService.alfresco.digitalWorkspace.contextPath | string | `"/workspace/"` |  |
 | msTeamsService.image.internalPort | int | `3978` |  |
 | msTeamsService.image.pullPolicy | string | `"IfNotPresent"` |  |

--- a/helm/alfresco-content-services/templates/config-ms-teams-service.yaml
+++ b/helm/alfresco-content-services/templates/config-ms-teams-service.yaml
@@ -14,6 +14,7 @@ data:
   {{- end }}
   {{- end }}
   ALFRESCO_BASE_URL: "{{ .Values.msTeamsService.alfresco.baseUrl }}"
+  ALFRESCO_DIGITAL_WORKSPACE_BASE_URL: "{{ .Values.msTeamsService.alfresco.digitalWorkspace.baseUrl }}"
   ALFRESCO_DIGITAL_WORKSPACE_CONTEXT_PATH: "{{ .Values.msTeamsService.alfresco.digitalWorkspace.contextPath }}"
   MICROSOFT_APP_ID: "{{ .Values.msTeamsService.microsoft.app.id }}"
   MICROSOFT_APP_PASSWORD: "{{ .Values.msTeamsService.microsoft.app.password }}"

--- a/helm/alfresco-content-services/values.yaml
+++ b/helm/alfresco-content-services/values.yaml
@@ -163,6 +163,7 @@ msTeamsService:
   alfresco:
     baseUrl: change_me_alf_base_url
     digitalWorkspace:
+      baseUrl: change_me_adw_base_url
       contextPath: /workspace/
   microsoft:
     app:


### PR DESCRIPTION
- add new property "alfresco.digital-workspace.base-url" (introduced in 0.5.0-A1)

- see also ACS-1870, ACS-1908