### PR TITLE
ACS-1953: Bump MS Teams Int version (helm chart value)

### DIFF
--- a/helm/alfresco-content-services/README.md
+++ b/helm/alfresco-content-services/README.md
@@ -126,7 +126,7 @@ Hence, setting up explicit Container memory and then assigning a percentage of i
 | msTeamsService.image.internalPort | int | `3978` |  |
 | msTeamsService.image.pullPolicy | string | `"IfNotPresent"` |  |
 | msTeamsService.image.repository | string | `"quay.io/alfresco/alfresco-ms-teams-service"` |  |
-| msTeamsService.image.tag | string | `"0.4.0-A1"` |  |
+| msTeamsService.image.tag | string | `"1.0.0-A2"` |  |
 | msTeamsService.ingress.path | string | `"/ms-teams-service"` |  |
 | msTeamsService.ingress.tls | list | `[]` |  |
 | msTeamsService.livenessProbe.initialDelaySeconds | int | `10` |  |

--- a/helm/alfresco-content-services/values.yaml
+++ b/helm/alfresco-content-services/values.yaml
@@ -134,7 +134,7 @@ msTeamsService:
   replicaCount: 2
   image:
     repository: quay.io/alfresco/alfresco-ms-teams-service
-    tag: "0.4.0-A1"
+    tag: "1.0.0-A2"
     pullPolicy: IfNotPresent
     internalPort: 3978
   service:


### PR DESCRIPTION
- from 0.4.0-A1 to 1.0.0-A2 (inc README for pre-commit hook for Helm Docs)