### PR TITLE
OPSEXP-1095 csi driver update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -217,6 +217,8 @@ _helm_deploy: &helm_deploy
     --set persistence.enabled=true \
     --set persistence.storageClass.enabled=true \
     --set persistence.storageClass.name="nfs-client" \
+    --set postgresql.persistence.storageClass="gp2" \
+    --set postgresql.persistence.existingClaim="" \
     --set global.alfrescoRegistryPullSecrets=quay-registry-secret \
     --wait \
     --timeout 20m0s \

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,7 @@ branches:
     - master
     - /feature.*/
     - /fix.*/
+    - /OPSEXP-.*/
 
 before_install:
   - |


### PR DESCRIPTION
This PR allow for deploying on EKS 1.21 with the newer aws-efs-csi-driver (deployed as part of the cluster installation instead of the nfs-client-provisionner).
The goal is to:
* Stop using the alfresco-volume-claim for postgresql related services
* using dynamic PVC
* rely on the gp2 storageClass for automatic provisioning that's compatible with the service. 

Ref. OPSEXP-1095