### PR TITLE
OPSEXP-958: Fix 2.3.0-adw to 2.4.0-adw (for docker-compose) on master

### DIFF
--- a/docker-compose/6.2.N-docker-compose.yml
+++ b/docker-compose/6.2.N-docker-compose.yml
@@ -143,6 +143,8 @@ services:
         environment:
             APP_CONFIG_AUTH_TYPE: "BASIC"
             BASE_PATH: ./
+            APP_CONFIG_ECM_HOST: "http://localhost:8080"
+            APP_CONFIG_PROVIDER: "ECM"
 
     proxy:
         image: alfresco/alfresco-acs-nginx:3.1.1

--- a/docker-compose/7.0.N-docker-compose.yml
+++ b/docker-compose/7.0.N-docker-compose.yml
@@ -148,6 +148,8 @@ services:
         environment:
             APP_CONFIG_AUTH_TYPE: "BASIC"
             BASE_PATH: ./
+            APP_CONFIG_ECM_HOST: "http://localhost:8080"
+            APP_CONFIG_PROVIDER: "ECM"           
 
     proxy:
         image: alfresco/alfresco-acs-nginx:3.1.1

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -148,6 +148,8 @@ services:
         environment:
             APP_CONFIG_AUTH_TYPE: "BASIC"
             BASE_PATH: ./
+            APP_CONFIG_ECM_HOST: "http://localhost:8080"
+            APP_CONFIG_PROVIDER: "ECM"
 
     proxy:
         image: alfresco/alfresco-acs-nginx:3.1.1


### PR DESCRIPTION
- follow-on to https://github.com/Alfresco/acs-deployment/pull/609
- see comments on OPSEXP-958 (and link to slack)

- apparently requires two additional env variables (presumably had defaults for 2.3.0-adw), eg.

            APP_CONFIG_ECM_HOST: "http://localhost:8080"
            APP_CONFIG_PROVIDER: "ECM"

- please verify and test (I've only sanity checked). I'm not sure if this could also affect helm charts (or not) ?

- I assume we will also need a new release tag, eg. 5.1.1 (since it affects 5.1.0)

- note: this would also impact [ECM Download Trial ](https://www.alfresco.com/platform/content-services-ecm/trial/download) if it were switched from 5.0.1 (ACS 7.0) to 5.1.0 (ACS 7.1) without this fix.