### PR TITLE
DESKTOPAPP-853: Bump sync-service from 3.5.0-M1 to 3.5.0-A4

### DIFF
--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -161,7 +161,7 @@ services:
       - share
 
   sync-service:
-    image: quay.io/alfresco/service-sync:3.5.0-M1
+    image: quay.io/alfresco/service-sync:3.5.0-A4
     mem_limit: 1g
     environment:
       JAVA_OPTS: "

--- a/helm/alfresco-content-services/README.md
+++ b/helm/alfresco-content-services/README.md
@@ -85,7 +85,7 @@ Hence, setting up explicit Container memory and then assigning a percentage of i
 | alfresco-search.searchServicesImage.tag | string | `"2.0.2"` |  |
 | alfresco-search.type | string | `"search-services"` |  |
 | alfresco-sync-service.image.repository | string | `"quay.io/alfresco/service-sync"` |  |
-| alfresco-sync-service.image.tag | string | `"3.5.0-M1"` |  |
+| alfresco-sync-service.image.tag | string | `"3.5.0-A4"` |  |
 | alfresco-sync-service.syncservice.enabled | bool | `true` |  |
 | apiexplorer | object | `{"ingress":{"path":"/api-explorer"}}` | Declares the api-explorer service used by the content repository |
 | database | object | `{"driver":null,"external":false,"password":null,"url":null,"user":null}` | Defines properties required by alfresco for connecting to the database Note! : If you set database.external to true you will have to setup the driver, user, password and JdbcUrl Also make sure that the container has the db driver in /usr/local/tomcat/lib since the current image only has the postgresql driver |

--- a/helm/alfresco-content-services/charts/alfresco-sync-service/README.md
+++ b/helm/alfresco-content-services/charts/alfresco-sync-service/README.md
@@ -65,7 +65,7 @@ Alfresco Sync Service
 | syncservice.image.internalPort | int | `9090` |  |
 | syncservice.image.pullPolicy | string | `"IfNotPresent"` |  |
 | syncservice.image.repository | string | `"quay.io/alfresco/service-sync"` |  |
-| syncservice.image.tag | string | `"3.5.0-M1"` |  |
+| syncservice.image.tag | string | `"3.5.0-A4"` |  |
 | syncservice.ingress.path | string | `"/syncservice"` |  |
 | syncservice.livenessProbe.initialDelaySeconds | int | `150` |  |
 | syncservice.livenessProbe.periodSeconds | int | `30` |  |

--- a/helm/alfresco-content-services/charts/alfresco-sync-service/values.yaml
+++ b/helm/alfresco-content-services/charts/alfresco-sync-service/values.yaml
@@ -12,7 +12,7 @@ syncservice:
   enabled: true
   image:
     repository: quay.io/alfresco/service-sync
-    tag: 3.5.0-M1
+    tag: 3.5.0-A4
     pullPolicy: IfNotPresent
     internalPort: 9090
   environment:

--- a/helm/alfresco-content-services/values.yaml
+++ b/helm/alfresco-content-services/values.yaml
@@ -797,7 +797,7 @@ alfresco-sync-service:
     enabled : true
   image:
     repository: quay.io/alfresco/service-sync
-    tag: 3.5.0-M1
+    tag: 3.5.0-A4
 
 global:
 


### PR DESCRIPTION
Update sync-service image tag for Maidenhead release train

Ref. DESKTOPAPP-853