### PR TITLE
Add apiVersion in Ingresses for K8s > 1.22.x

### DIFF
--- a/helm/alfresco-content-services/charts/alfresco-search/charts/alfresco-insight-zeppelin/templates/ingress.yaml
+++ b/helm/alfresco-content-services/charts/alfresco-search/charts/alfresco-insight-zeppelin/templates/ingress.yaml
@@ -1,5 +1,7 @@
 {{- if .Values.insightzeppelin.enabled }}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare ">=1.20-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1beta1
 {{- else -}}
 apiVersion: extensions/v1beta1
@@ -12,9 +14,20 @@ metadata:
 spec:
   rules:
   - http:
+{{- if semverCompare ">=1.20-0" .Capabilities.KubeVersion.GitVersion -}}
+      paths:
+      - path: {{ .Values.ingress.path }}
+        pathType: Exact
+        backend:
+          service:
+            name: {{ template "alfresco-insight-zeppelin.fullName" . }}
+            port:
+              number: {{ .Values.service.externalPort }}
+{{- else -}}
       paths:
       - path: {{ .Values.ingress.path }}
         backend:
           serviceName: {{ template "alfresco-insight-zeppelin.fullName" . }}
           servicePort: {{ .Values.service.externalPort }}
+{{- end }}
 {{- end }}

--- a/helm/alfresco-content-services/charts/alfresco-search/templates/ingress.yaml
+++ b/helm/alfresco-content-services/charts/alfresco-search/templates/ingress.yaml
@@ -1,5 +1,7 @@
 {{- if .Values.ingress.enabled }}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare ">=1.20-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1beta1
 {{- else -}}
 apiVersion: extensions/v1beta1
@@ -29,7 +31,11 @@ spec:
   - http:
       paths:
       - path: {{ .Values.ingress.path }}
+        pathType: Exact
         backend:
-          serviceName: {{ template "alfresco-search.fullName" . }}-solr
-          servicePort: {{ .Values.service.externalPort }}
+          service:
+            name: {{ template "alfresco-search.fullName" . }}-solr
+            port:
+              number: {{ .Values.service.externalPort }}
+
 {{- end }}

--- a/helm/alfresco-content-services/charts/alfresco-sync-service/templates/ingress.yaml
+++ b/helm/alfresco-content-services/charts/alfresco-sync-service/templates/ingress.yaml
@@ -1,5 +1,7 @@
 {{- if .Values.syncservice.enabled }}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare ">=1.20-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1beta1
 {{- else -}}
 apiVersion: extensions/v1beta1
@@ -37,7 +39,13 @@ spec:
   {{- end }}
       paths:
       - path: {{ .Values.syncservice.ingress.path }}(/|$)(.*)
+        pathType: Exact
         backend:
-          serviceName: {{ template "syncservice.fullname" . }}
-          servicePort: {{ .Values.syncservice.service.externalPort }}
+          service:
+            name: {{ template "syncservice.fullname" . }}
+            port:
+              number: {{ .Values.syncservice.service.externalPort }}
+
 {{- end }}
+
+

--- a/helm/alfresco-content-services/templates/ingress-ms-teams-service.yaml
+++ b/helm/alfresco-content-services/templates/ingress-ms-teams-service.yaml
@@ -1,4 +1,6 @@
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare ">=1.20-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1beta1
 {{- else -}}
 apiVersion: extensions/v1beta1
@@ -35,6 +37,10 @@ spec:
   {{- end }}
       paths:
       - path: {{ .Values.msTeamsService.ingress.path }}
+        pathType: Exact
         backend:
-          serviceName: {{ template "content-services.shortname" . }}-ms-teams-service
-          servicePort: {{ .Values.msTeamsService.service.externalPort }}
+          service:
+            name: {{ template "content-services.shortname" . }}-ms-teams-service
+            port:
+              number: {{ .Values.msTeamsService.service.externalPort }}
+   

--- a/helm/alfresco-content-services/templates/ingress-ooi-service.yaml
+++ b/helm/alfresco-content-services/templates/ingress-ooi-service.yaml
@@ -1,5 +1,7 @@
 {{- if .Values.ooi.enabled }}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare ">=1.20-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1beta1
 {{- else -}}
 apiVersion: extensions/v1beta1
@@ -36,7 +38,11 @@ spec:
   {{- end }}
       paths:
       - path: {{ .Values.ooiService.ingress.path }}
+        pathType: Exact
         backend:
-          serviceName: {{ template "content-services.shortname" . }}-ooi-service
-          servicePort: {{ .Values.ooiService.service.externalPort }}
+          service:
+            name: {{ template "content-services.shortname" . }}-ooi-service
+            port:
+              number: {{ .Values.ooiService.service.externalPort }}
+    
 {{- end }}

--- a/helm/alfresco-content-services/templates/ingress-repository.yaml
+++ b/helm/alfresco-content-services/templates/ingress-repository.yaml
@@ -1,4 +1,6 @@
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare ">=1.20-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1beta1
 {{- else -}}
 apiVersion: extensions/v1beta1
@@ -50,10 +52,17 @@ spec:
   {{- end }}
       paths:
       - path: {{ .Values.repository.ingress.path }}
+        pathType: Exact
         backend:
-          serviceName: {{ template "content-services.shortname" . }}-repository
-          servicePort: {{ .Values.repository.service.externalPort }}
+          service:
+            name: {{ template "content-services.shortname" . }}-repository
+            port: 
+              number: {{ .Values.repository.service.externalPort }}
       - path: {{ .Values.apiexplorer.ingress.path }}
+        pathType: Exact
         backend:
-          serviceName: {{ template "content-services.shortname" . }}-repository
-          servicePort: {{ .Values.repository.service.externalPort }}
+          service:
+            name: {{ template "content-services.shortname" . }}-repository
+            port: 
+              number: {{ .Values.repository.service.externalPort }}
+   

--- a/helm/alfresco-content-services/templates/ingress-share.yaml
+++ b/helm/alfresco-content-services/templates/ingress-share.yaml
@@ -1,4 +1,6 @@
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare ">=1.20-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1beta1
 {{- else -}}
 apiVersion: extensions/v1beta1
@@ -44,6 +46,10 @@ spec:
   {{- end }}
       paths:
       - path: {{ .Values.share.ingress.path }}
+        pathType: Exact
         backend:
-          serviceName: {{ template "content-services.shortname" . }}-share
-          servicePort: {{ .Values.share.service.externalPort }}
+          service:
+            name: {{ template "content-services.shortname" . }}-share
+            port: 
+              number: {{ .Values.share.service.externalPort }}
+      


### PR DESCRIPTION
Kubernetes Version 1.22 has removed  `apiVersion: networking.k8s.io/v1beta1`
The only change was to add a validation if Version > 1.20 and use `networking.k8s.io/v1` instead.