### PR TITLE
[ACS-2564] update docker-compose and community-docker-compose to use solr with secureComms=secret

### DIFF
--- a/docker-compose/community-docker-compose.yml
+++ b/docker-compose/community-docker-compose.yml
@@ -96,7 +96,7 @@ services:
       # HTTPS or SECRET
       ALFRESCO_SECURE_COMMS: "secret"
       # SHARED SECRET VALUE
-      SOLR_OPTS: "
+      JAVA_TOOL_OPTIONS: "
           -Dalfresco.secureComms.secret=secret
       "
     ports:

--- a/docker-compose/community-docker-compose.yml
+++ b/docker-compose/community-docker-compose.yml
@@ -10,8 +10,8 @@ version: "2"
 
 services:
   alfresco:
-    image: alfresco/alfresco-content-repository-community:7.2.0-M2
-    mem_limit: 1500m
+    image: alfresco/alfresco-content-repository-community:7.1.1.2
+    mem_limit: 1600m
     environment:
       JAVA_TOOL_OPTIONS: "
         -Dencryption.keystore.type=JCEKS
@@ -31,7 +31,8 @@ services:
         -Dsolr.host=solr6
         -Dsolr.port=8983
         -Dsolr.http.connection.timeout=1000
-        -Dsolr.secureComms=none
+        -Dsolr.secureComms=secret
+        -Dsolr.sharedSecret=secret
         -Dsolr.base.url=/solr
         -Dindex.subsystem.name=solr6
         -Dshare.host=127.0.0.1
@@ -81,19 +82,23 @@ services:
       - "5432:5432"
 
   solr6:
-    image: alfresco/alfresco-search-services:2.0.2
+    image: quay.io/alfresco/search-services:2.1.0-SNAPSHOT
     mem_limit: 2g
     environment:
       # Solr needs to know how to register itself with Alfresco
-      - SOLR_ALFRESCO_HOST=alfresco
-      - SOLR_ALFRESCO_PORT=8080
+      SOLR_ALFRESCO_HOST: "alfresco"
+      SOLR_ALFRESCO_PORT: "8080"
       # Alfresco needs to know how to call solr
-      - SOLR_SOLR_HOST=solr6
-      - SOLR_SOLR_PORT=8983
+      SOLR_SOLR_HOST: "solr6"
+      SOLR_SOLR_PORT: "8983"
       # Create the default alfresco and archive cores
-      - SOLR_CREATE_ALFRESCO_DEFAULTS=alfresco,archive
-      # HTTP by default
-      - ALFRESCO_SECURE_COMMS=none
+      SOLR_CREATE_ALFRESCO_DEFAULTS: "alfresco,archive"
+      # HTTPS or SECRET
+      ALFRESCO_SECURE_COMMS: "secret"
+      # SHARED SECRET VALUE
+      SOLR_OPTS: "
+          -Dalfresco.secureComms.secret=secret
+      "
     ports:
       - "8083:8983" # Browser port
 

--- a/docker-compose/community-docker-compose.yml
+++ b/docker-compose/community-docker-compose.yml
@@ -10,7 +10,7 @@ version: "2"
 
 services:
   alfresco:
-    image: alfresco/alfresco-content-repository-community:7.1.1.2
+    image: alfresco/alfresco-content-repository-community:7.2.0-M2
     mem_limit: 1600m
     environment:
       JAVA_TOOL_OPTIONS: "

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -12,7 +12,7 @@ version: "2"
 
 services:
   alfresco:
-    image: quay.io/alfresco/alfresco-content-repository:7.2.0-M2
+    image: quay.io/alfresco/alfresco-content-repository:7.1.1.2
     mem_limit: 1700m
     environment:
       JAVA_TOOL_OPTIONS: "
@@ -32,7 +32,8 @@ services:
         -Ddb.url=jdbc:postgresql://postgres:5432/alfresco
         -Dsolr.host=solr6
         -Dsolr.port=8983
-        -Dsolr.secureComms=none
+        -Dsolr.secureComms=secret
+        -Dsolr.sharedSecret=secret
         -Dsolr.base.url=/solr
         -Dindex.subsystem.name=solr6
         -Dshare.host=127.0.0.1
@@ -115,19 +116,23 @@ services:
       - "5432:5432"
 
   solr6:
-    image: alfresco/alfresco-search-services:2.0.2
+    image: quay.io/alfresco/search-services:2.1.0-SNAPSHOT
     mem_limit: 2g
     environment:
       # Solr needs to know how to register itself with Alfresco
-      - SOLR_ALFRESCO_HOST=alfresco
-      - SOLR_ALFRESCO_PORT=8080
+      SOLR_ALFRESCO_HOST: "alfresco"
+      SOLR_ALFRESCO_PORT: "8080"
       # Alfresco needs to know how to call solr
-      - SOLR_SOLR_HOST=solr6
-      - SOLR_SOLR_PORT=8983
+      SOLR_SOLR_HOST: "solr6"
+      SOLR_SOLR_PORT: "8983"
       # Create the default alfresco and archive cores
-      - SOLR_CREATE_ALFRESCO_DEFAULTS=alfresco,archive
-      # HTTP by default
-      - ALFRESCO_SECURE_COMMS=none
+      SOLR_CREATE_ALFRESCO_DEFAULTS: "alfresco,archive"
+      # HTTPS or SECRET
+      ALFRESCO_SECURE_COMMS: "secret"
+      # SHARED SECRET VALUE
+      SOLR_OPTS: "
+          -Dalfresco.secureComms.secret=secret
+      "
     ports:
       - "8083:8983" # Browser port
 

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -130,7 +130,7 @@ services:
       # HTTPS or SECRET
       ALFRESCO_SECURE_COMMS: "secret"
       # SHARED SECRET VALUE
-      SOLR_OPTS: "
+      JAVA_TOOL_OPTIONS: "
           -Dalfresco.secureComms.secret=secret
       "
     ports:

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -12,7 +12,7 @@ version: "2"
 
 services:
   alfresco:
-    image: quay.io/alfresco/alfresco-content-repository:7.1.1.2
+    image: quay.io/alfresco/alfresco-content-repository:7.2.0-M2
     mem_limit: 1700m
     environment:
       JAVA_TOOL_OPTIONS: "


### PR DESCRIPTION
Changed default solr **SECURE COMMS** from **NONE** to **SECRET**. We need to set the shared secret value for both alfresco `-Dsolr.sharedSecret` and solr `-Dalfresco.secureComms.secret` (default value is “secret”).