### PR TITLE
Add support for network v1

### DIFF
--- a/helm/alfresco-content-services/charts/alfresco-search/charts/alfresco-insight-zeppelin/templates/ingress.yaml
+++ b/helm/alfresco-content-services/charts/alfresco-search/charts/alfresco-insight-zeppelin/templates/ingress.yaml
@@ -20,7 +20,7 @@ spec:
         pathType: Prefix
         backend:
           service:
-            Name: {{ template "alfresco-insight-zeppelin.fullName" . }}
+            name: {{ template "alfresco-insight-zeppelin.fullName" . }}
             port:
               number: {{ .Values.service.externalPort }}
         {{- else }}

--- a/helm/alfresco-content-services/charts/alfresco-search/charts/alfresco-insight-zeppelin/templates/ingress.yaml
+++ b/helm/alfresco-content-services/charts/alfresco-search/charts/alfresco-insight-zeppelin/templates/ingress.yaml
@@ -1,5 +1,7 @@
 {{- if .Values.insightzeppelin.enabled }}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare ">=1.21-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1beta1
 {{- else -}}
 apiVersion: extensions/v1beta1
@@ -14,7 +16,16 @@ spec:
   - http:
       paths:
       - path: {{ .Values.ingress.path }}
+        {{- if semverCompare ">=1.21-0" .Capabilities.KubeVersion.GitVersion }}
+        pathType: Prefix
+        backend:
+          service:
+            Name: {{ template "alfresco-insight-zeppelin.fullName" . }}
+            port:
+              number: {{ .Values.service.externalPort }}
+        {{- else }}
         backend:
           serviceName: {{ template "alfresco-insight-zeppelin.fullName" . }}
           servicePort: {{ .Values.service.externalPort }}
+        {{- end }}
 {{- end }}

--- a/helm/alfresco-content-services/charts/alfresco-search/templates/ingress.yaml
+++ b/helm/alfresco-content-services/charts/alfresco-search/templates/ingress.yaml
@@ -35,7 +35,7 @@ spec:
         pathType: Prefix
         backend:
           service:
-            Name: {{ template "alfresco-search.fullName" . }}-solr
+            name: {{ template "alfresco-search.fullName" . }}-solr
             port:
               number: {{ .Values.service.externalPort }}
         {{- else }}

--- a/helm/alfresco-content-services/charts/alfresco-search/templates/ingress.yaml
+++ b/helm/alfresco-content-services/charts/alfresco-search/templates/ingress.yaml
@@ -1,5 +1,7 @@
 {{- if .Values.ingress.enabled }}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare ">=1.21-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1beta1
 {{- else -}}
 apiVersion: extensions/v1beta1
@@ -29,7 +31,16 @@ spec:
   - http:
       paths:
       - path: {{ .Values.ingress.path }}
+        {{- if semverCompare ">=1.21-0" .Capabilities.KubeVersion.GitVersion }}
+        pathType: Prefix
+        backend:
+          service:
+            Name: {{ template "alfresco-search.fullName" . }}-solr
+            port:
+              number: {{ .Values.service.externalPort }}
+        {{- else }}
         backend:
           serviceName: {{ template "alfresco-search.fullName" . }}-solr
           servicePort: {{ .Values.service.externalPort }}
+        {{- end }}
 {{- end }}

--- a/helm/alfresco-content-services/charts/alfresco-sync-service/templates/ingress.yaml
+++ b/helm/alfresco-content-services/charts/alfresco-sync-service/templates/ingress.yaml
@@ -1,5 +1,7 @@
 {{- if .Values.syncservice.enabled }}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare ">=1.21-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1beta1
 {{- else -}}
 apiVersion: extensions/v1beta1
@@ -37,7 +39,16 @@ spec:
   {{- end }}
       paths:
       - path: {{ .Values.syncservice.ingress.path }}(/|$)(.*)
+        {{- if semverCompare ">=1.21-0" .Capabilities.KubeVersion.GitVersion }}
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ template "syncservice.fullname" . }}
+            port:
+              number: {{ .Values.syncservice.service.externalPort }}
+        {{- else }}
         backend:
           serviceName: {{ template "syncservice.fullname" . }}
           servicePort: {{ .Values.syncservice.service.externalPort }}
+        {{- end }}
 {{- end }}

--- a/helm/alfresco-content-services/templates/ingress-ms-teams-service.yaml
+++ b/helm/alfresco-content-services/templates/ingress-ms-teams-service.yaml
@@ -41,7 +41,7 @@ spec:
         pathType: Prefix
         backend:
           service:
-            Name: {{ template "content-services.shortname" . }}-ms-teams-service
+            name: {{ template "content-services.shortname" . }}-ms-teams-service
             port:
               number: {{ .Values.msTeamsService.service.externalPort }}
         {{- else }}

--- a/helm/alfresco-content-services/templates/ingress-ms-teams-service.yaml
+++ b/helm/alfresco-content-services/templates/ingress-ms-teams-service.yaml
@@ -1,4 +1,6 @@
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare ">=1.21-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1beta1
 {{- else -}}
 apiVersion: extensions/v1beta1
@@ -35,6 +37,15 @@ spec:
   {{- end }}
       paths:
       - path: {{ .Values.msTeamsService.ingress.path }}
+        {{- if semverCompare ">=1.21-0" .Capabilities.KubeVersion.GitVersion }}
+        pathType: Prefix
+        backend:
+          service:
+            Name: {{ template "content-services.shortname" . }}-ms-teams-service
+            port:
+              number: {{ .Values.msTeamsService.service.externalPort }}
+        {{- else }}
         backend:
           serviceName: {{ template "content-services.shortname" . }}-ms-teams-service
           servicePort: {{ .Values.msTeamsService.service.externalPort }}
+        {{- end }}

--- a/helm/alfresco-content-services/templates/ingress-ooi-service.yaml
+++ b/helm/alfresco-content-services/templates/ingress-ooi-service.yaml
@@ -42,7 +42,7 @@ spec:
         pathType: Prefix
         backend:
           service:
-            Name: {{ template "content-services.shortname" . }}-ooi-service
+            name: {{ template "content-services.shortname" . }}-ooi-service
             port:
               number: {{ .Values.ooiService.service.externalPort }}
         {{- else }}

--- a/helm/alfresco-content-services/templates/ingress-ooi-service.yaml
+++ b/helm/alfresco-content-services/templates/ingress-ooi-service.yaml
@@ -1,5 +1,7 @@
 {{- if .Values.ooi.enabled }}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare ">=1.21-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1beta1
 {{- else -}}
 apiVersion: extensions/v1beta1
@@ -36,7 +38,16 @@ spec:
   {{- end }}
       paths:
       - path: {{ .Values.ooiService.ingress.path }}
+        {{- if semverCompare ">=1.21-0" .Capabilities.KubeVersion.GitVersion }}
+        pathType: Prefix
+        backend:
+          service:
+            Name: {{ template "content-services.shortname" . }}-ooi-service
+            port:
+              number: {{ .Values.ooiService.service.externalPort }}
+        {{- else }}
         backend:
           serviceName: {{ template "content-services.shortname" . }}-ooi-service
           servicePort: {{ .Values.ooiService.service.externalPort }}
+        {{- end }}
 {{- end }}

--- a/helm/alfresco-content-services/templates/ingress-repository.yaml
+++ b/helm/alfresco-content-services/templates/ingress-repository.yaml
@@ -69,7 +69,7 @@ spec:
         pathType: Prefix
         backend:
           service:
-            Name: {{ template "content-services.shortname" . }}-repository
+            name: {{ template "content-services.shortname" . }}-repository
             port:
               number: {{ .Values.repository.service.externalPort }}
         {{- else }}

--- a/helm/alfresco-content-services/templates/ingress-repository.yaml
+++ b/helm/alfresco-content-services/templates/ingress-repository.yaml
@@ -1,4 +1,6 @@
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare ">=1.21-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1beta1
 {{- else -}}
 apiVersion: extensions/v1beta1
@@ -50,10 +52,28 @@ spec:
   {{- end }}
       paths:
       - path: {{ .Values.repository.ingress.path }}
+        {{- if semverCompare ">=1.21-0" .Capabilities.KubeVersion.GitVersion }}
+        pathType: Prefix
+        backend:
+          service:
+            Name: {{ template "content-services.shortname" . }}-repository
+            port:
+              number: {{ .Values.repository.service.externalPort }}
+        {{- else }}
         backend:
           serviceName: {{ template "content-services.shortname" . }}-repository
           servicePort: {{ .Values.repository.service.externalPort }}
+        {{- end }}
       - path: {{ .Values.apiexplorer.ingress.path }}
+        {{- if semverCompare ">=1.21-0" .Capabilities.KubeVersion.GitVersion }}
+        pathType: Prefix
+        backend:
+          service:
+            Name: {{ template "content-services.shortname" . }}-repository
+            port:
+              number: {{ .Values.repository.service.externalPort }}
+        {{- else }}
         backend:
           serviceName: {{ template "content-services.shortname" . }}-repository
           servicePort: {{ .Values.repository.service.externalPort }}
+        {{- end }}

--- a/helm/alfresco-content-services/templates/ingress-share.yaml
+++ b/helm/alfresco-content-services/templates/ingress-share.yaml
@@ -50,7 +50,7 @@ spec:
         pathType: Prefix
         backend:
           service:
-            Name: {{ template "content-services.shortname" . }}-share
+            name: {{ template "content-services.shortname" . }}-share
             port:
               number: {{ .Values.share.service.externalPort }}
         {{- else }}

--- a/helm/alfresco-content-services/templates/ingress-share.yaml
+++ b/helm/alfresco-content-services/templates/ingress-share.yaml
@@ -1,4 +1,6 @@
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare ">=1.21-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1beta1
 {{- else -}}
 apiVersion: extensions/v1beta1
@@ -44,6 +46,15 @@ spec:
   {{- end }}
       paths:
       - path: {{ .Values.share.ingress.path }}
+        {{- if semverCompare ">=1.21-0" .Capabilities.KubeVersion.GitVersion }}
+        pathType: Prefix
+        backend:
+          service:
+            Name: {{ template "content-services.shortname" . }}-share
+            port:
+              number: {{ .Values.share.service.externalPort }}
+        {{- else }}
         backend:
           serviceName: {{ template "content-services.shortname" . }}-share
           servicePort: {{ .Values.share.service.externalPort }}
+        {{- end }}


### PR DESCRIPTION
This pull request fixes #638 
Running on kubernetes >= 1.22 where apiVersion `networking.k8s.io/v1beta1` was removed.

Added this MR because I think #653 according to [documentation](https://kubernetes.io/docs/concepts/services-networking/ingress/#examples) does not work because of `pathType = Exact`. This MR uses `pathType = Prefix`.