### PR TITLE
ACS-2719: Fix ADW shared links for reference d-c deployment

### DIFF
--- a/docker-compose/7.1.N-docker-compose.yml
+++ b/docker-compose/7.1.N-docker-compose.yml
@@ -1,4 +1,4 @@
-# This docker-compose file will spin up an ACS cluster on a local host or on a server and it requires a minimum of 13GB Memory to distribute among containers.
+# This docker-compose file will spin up an ACS cluster on a local host or on a server and it requires a minimum of 14GB Memory to distribute among containers.
 #
 # For performance tuning, assign the container memory and give a percentage of it to the JVM.
 # Use either the -Xms,-Xmx flags or the newly added flags in java 10+: -XX:MaxRAMPercentage and -XX:MinRAMPercentage. More details here: https://www.oracle.com/technetwork/java/javase/10-relnote-issues-4108729.html
@@ -13,7 +13,7 @@ version: "2"
 services:
   alfresco:
     image: quay.io/alfresco/alfresco-content-repository:7.1.1
-    mem_limit: 1700m
+    mem_limit: 1900m
     environment:
       JAVA_TOOL_OPTIONS: "
         -Dencryption.keystore.type=JCEKS
@@ -146,6 +146,7 @@ services:
     environment:
       APP_CONFIG_AUTH_TYPE: "BASIC"
       BASE_PATH: ./
+      APP_BASE_SHARE_URL: "http://localhost:8080/workspace/#/preview/s"
 
   proxy:
     image: alfresco/alfresco-acs-nginx:3.2.0

--- a/docker-compose/community-docker-compose.yml
+++ b/docker-compose/community-docker-compose.yml
@@ -1,4 +1,4 @@
-# This docker-compose file will spin up an ACS cluster on a local host or on a server and it requires a minimum of 12GB Memory to distribute among containers.
+# This docker-compose file will spin up an ACS cluster on a local host or on a server and it requires a minimum of 13GB Memory to distribute among containers.
 # Limit container memory and assign X percentage to JVM.  There are couple of ways to allocate JVM Memory for ACS Containers
 # For example: 'JAVA_OPTS: "$JAVA_OPTS -XX:+PrintFlagsFinal -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap"'
 # See Oracle docs (https://docs.oracle.com/javase/9/gctuning/parallel-collector1.htm#JSGCT-GUID-CAB83393-3438-44ED-98F0-D15641B43C7D).
@@ -11,7 +11,7 @@ version: "2"
 services:
   alfresco:
     image: alfresco/alfresco-content-repository-community:7.2.0-A28
-    mem_limit: 1600m
+    mem_limit: 1900m
     environment:
       JAVA_TOOL_OPTIONS: "
         -Dencryption.keystore.type=JCEKS

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -1,4 +1,4 @@
-# This docker-compose file will spin up an ACS cluster on a local host or on a server and it requires a minimum of 13GB Memory to distribute among containers.
+# This docker-compose file will spin up an ACS cluster on a local host or on a server and it requires a minimum of 14GB Memory to distribute among containers.
 #
 # For performance tuning, assign the container memory and give a percentage of it to the JVM.
 # Use either the -Xms,-Xmx flags or the newly added flags in java 10+: -XX:MaxRAMPercentage and -XX:MinRAMPercentage. More details here: https://www.oracle.com/technetwork/java/javase/10-relnote-issues-4108729.html
@@ -13,7 +13,7 @@ version: "2"
 services:
   alfresco:
     image: quay.io/alfresco/alfresco-content-repository:7.2.0-A28
-    mem_limit: 1700m
+    mem_limit: 1900m
     environment:
       JAVA_TOOL_OPTIONS: "
         -Dencryption.keystore.type=JCEKS
@@ -151,6 +151,7 @@ services:
     environment:
       APP_CONFIG_AUTH_TYPE: "BASIC"
       BASE_PATH: ./
+      APP_BASE_SHARE_URL: "http://localhost:8080/workspace/#/preview/s"
 
   proxy:
     image: alfresco/alfresco-acs-nginx:3.2.0


### PR DESCRIPTION
- fix Alfresco Digital Workspace shared links in docker-compose (missing /workspace context)

- also take opportunity to bump up min mem for Content Repo (see also ACS-509)
  - at least for master (7.2.N & community) and 7.1.N (see ACS-509)
  - otherwise sometimes "alfresco" container will unexpectedly exit with 137 either on startup &/or overnight