### PR TITLE
OPSEXP-1339 Update ingress-nginx to 4.x for k8s 1.22

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -185,7 +185,7 @@ _helm_deploy: &helm_deploy
     kubectl create secret generic quay-registry-secret --from-file=.dockerconfigjson=/home/travis/.docker/config.json --type=kubernetes.io/dockerconfigjson -n $namespace
 
     # install ingress
-    helm upgrade --install $release_name_ingress --repo https://kubernetes.github.io/ingress-nginx ingress-nginx --version=3.7.1 \
+    helm upgrade --install $release_name_ingress --repo https://kubernetes.github.io/ingress-nginx ingress-nginx --version=4.0.18 \
     --set controller.scope.enabled=true \
     --set controller.scope.namespace=$namespace \
     --set rbac.create=true \

--- a/.travis.yml
+++ b/.travis.yml
@@ -199,6 +199,7 @@ _helm_deploy: &helm_deploy
     --set controller.service.annotations."service\.beta\.kubernetes\.io/aws-load-balancer-security-groups"="${AWS_SG}" \
     --set controller.publishService.enabled=true \
     --set controller.admissionWebhooks.enabled=false \
+    --set controller.ingressClassResource.enabled=false \
     --wait \
     --namespace $namespace
 

--- a/docs/helm/docker-desktop-deployment.md
+++ b/docs/helm/docker-desktop-deployment.md
@@ -46,7 +46,7 @@ helm repo update
 Deploy an ingress controller into the alfresco namespace using the command below:
 
 ```bash
-helm install acs-ingress ingress-nginx/ingress-nginx --version=3.7.1 \
+helm install acs-ingress ingress-nginx/ingress-nginx --version=4.0.18 \
 --set controller.scope.enabled=true \
 --set controller.scope.namespace=alfresco \
 --set rbac.create=true \

--- a/docs/helm/eks-deployment.md
+++ b/docs/helm/eks-deployment.md
@@ -243,7 +243,7 @@ kubectl create namespace alfresco
     helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
     helm repo update
 
-    helm install acs-ingress ingress-nginx/ingress-nginx --version=3.7.1 \
+    helm install acs-ingress ingress-nginx/ingress-nginx --version=4.0.18 \
     --set controller.scope.enabled=true \
     --set controller.scope.namespace=alfresco \
     --set rbac.create=true \

--- a/helm/alfresco-content-services/Chart.yaml
+++ b/helm/alfresco-content-services/Chart.yaml
@@ -26,7 +26,7 @@ dependencies:
   - name: common
     alias: alfresco-digital-workspace
     repository: https://activiti.github.io/activiti-cloud-helm-charts
-    version: 7.1.0-M17
+    version: 7.2.0
     condition: alfresco-content-services.alfresco-digital-workspace.enabled,alfresco-digital-workspace.enabled
   - name: activemq
     version: 2.1.0

--- a/helm/alfresco-content-services/README.md
+++ b/helm/alfresco-content-services/README.md
@@ -17,7 +17,7 @@ A Helm chart for deploying Alfresco Content Services
 |  | activemq | 2.1.0 |
 |  | alfresco-search | 1.0.4 |
 |  | alfresco-sync-service | 3.0.9 |
-| https://activiti.github.io/activiti-cloud-helm-charts | alfresco-digital-workspace(common) | 7.1.0-M17 |
+| https://activiti.github.io/activiti-cloud-helm-charts | alfresco-digital-workspace(common) | 7.2.0 |
 | https://charts.bitnami.com/bitnami | postgresql | 10.16.2 |
 | https://charts.bitnami.com/bitnami | postgresql-syncservice(postgresql) | 10.16.2 |
 

--- a/helm/alfresco-content-services/README.md
+++ b/helm/alfresco-content-services/README.md
@@ -65,6 +65,7 @@ Hence, setting up explicit Container memory and then assigning a percentage of i
 | alfresco-digital-workspace.image.pullPolicy | string | `"IfNotPresent"` |  |
 | alfresco-digital-workspace.image.repository | string | `"quay.io/alfresco/alfresco-digital-workspace"` |  |
 | alfresco-digital-workspace.image.tag | string | `"2.6.0"` |  |
+| alfresco-digital-workspace.ingress.annotations."kubernetes.io/ingress.class" | string | `"nginx"` |  |
 | alfresco-digital-workspace.ingress.annotations."nginx.ingress.kubernetes.io/proxy-body-size" | string | `"5g"` |  |
 | alfresco-digital-workspace.ingress.path | string | `"/workspace"` |  |
 | alfresco-digital-workspace.ingress.tls | list | `[]` |  |

--- a/helm/alfresco-content-services/templates/ingress-repository.yaml
+++ b/helm/alfresco-content-services/templates/ingress-repository.yaml
@@ -14,14 +14,14 @@ metadata:
     # Default file limit (1m) check, document(s) above this size will throw 413 (Request Entity Too Large) error
     nginx.ingress.kubernetes.io/proxy-body-size: {{ .Values.repository.ingress.maxUploadSize }}
     {{- if index .Values "alfresco-search" "enabled" }}
-    nginx.ingress.kubernetes.io/configuration-snippet: |
+    nginx.ingress.kubernetes.io/server-snippet: |
       location ~ ^(/.*/service/api/solr/.*)$ {return 403;}
       location ~ ^(/.*/s/api/solr/.*)$ {return 403;}
       location ~ ^(/.*/wcservice/api/solr/.*)$ {return 403;}
       location ~ ^(/.*/wcs/api/solr/.*)$ {return 403;}
       location ~ ^(/.*/s/prometheus)$ {return 403;}
     {{- else }}
-    nginx.ingress.kubernetes.io/configuration-snippet: |
+    nginx.ingress.kubernetes.io/server-snippet: |
       location ~ ^(/.*/s/prometheus)$ {return 403;}
     {{- end }}
 {{- if .Values.repository.ingress.annotations }}

--- a/helm/alfresco-content-services/templates/ingress-repository.yaml
+++ b/helm/alfresco-content-services/templates/ingress-repository.yaml
@@ -13,17 +13,16 @@ metadata:
     nginx.ingress.kubernetes.io/session-cookie-hash: "sha1"
     # Default file limit (1m) check, document(s) above this size will throw 413 (Request Entity Too Large) error
     nginx.ingress.kubernetes.io/proxy-body-size: {{ .Values.repository.ingress.maxUploadSize }}
+    nginx.ingress.kubernetes.io/server-snippet: |
     {{- if index .Values "alfresco-search" "enabled" }}
-    nginx.ingress.kubernetes.io/server-snippet: |
-      location ~ ^(/.*/service/api/solr/.*)$ {return 403;}
-      location ~ ^(/.*/s/api/solr/.*)$ {return 403;}
-      location ~ ^(/.*/wcservice/api/solr/.*)$ {return 403;}
-      location ~ ^(/.*/wcs/api/solr/.*)$ {return 403;}
-      location ~ ^(/.*/s/prometheus)$ {return 403;}
-    {{- else }}
-    nginx.ingress.kubernetes.io/server-snippet: |
-      location ~ ^(/.*/s/prometheus)$ {return 403;}
+      location ~ ^(/.*/service/api/solr/.*)$ { deny all; return 403; }
+      location ~ ^(/.*/s/api/solr/.*)$ { deny all; return 403; }
+      location ~ ^(/.*/wcservice/api/solr/.*)$ { deny all; return 403; }
+      location ~ ^(/.*/wcs/api/solr/.*)$ { deny all; return 403; }
     {{- end }}
+      location ~ ^(/.*/s/prometheus)$ { deny all; return 403; }
+      location ~ ^(/.*/proxy/.*/api/solr/.*)$ {return 403 ;}
+      location ~ ^(/.*/-default-/proxy/.*/api/.*)$ { deny all; return 403; }
 {{- if .Values.repository.ingress.annotations }}
 {{ toYaml .Values.repository.ingress.annotations | indent 4 }}
 {{- end }}

--- a/helm/alfresco-content-services/templates/ingress-repository.yaml
+++ b/helm/alfresco-content-services/templates/ingress-repository.yaml
@@ -13,16 +13,14 @@ metadata:
     nginx.ingress.kubernetes.io/session-cookie-hash: "sha1"
     # Default file limit (1m) check, document(s) above this size will throw 413 (Request Entity Too Large) error
     nginx.ingress.kubernetes.io/proxy-body-size: {{ .Values.repository.ingress.maxUploadSize }}
-    nginx.ingress.kubernetes.io/server-snippet: |
+    nginx.ingress.kubernetes.io/configuration-snippet: |
     {{- if index .Values "alfresco-search" "enabled" }}
-      location ~ ^(/.*/service/api/solr/.*)$ { deny all; return 403; }
-      location ~ ^(/.*/s/api/solr/.*)$ { deny all; return 403; }
-      location ~ ^(/.*/wcservice/api/solr/.*)$ { deny all; return 403; }
-      location ~ ^(/.*/wcs/api/solr/.*)$ { deny all; return 403; }
+      location ~ ^(/.*/service/api/solr/.*)$ {return 403;}
+      location ~ ^(/.*/s/api/solr/.*)$ {return 403;}
+      location ~ ^(/.*/wcservice/api/solr/.*)$ {return 403;}
+      location ~ ^(/.*/wcs/api/solr/.*)$ {return 403;}
     {{- end }}
-      location ~ ^(/.*/s/prometheus)$ { deny all; return 403; }
-      location ~ ^(/.*/proxy/.*/api/solr/.*)$ {return 403 ;}
-      location ~ ^(/.*/-default-/proxy/.*/api/.*)$ { deny all; return 403; }
+      location ~ ^(/.*/s/prometheus)$ {return 403;}
 {{- if .Values.repository.ingress.annotations }}
 {{ toYaml .Values.repository.ingress.annotations | indent 4 }}
 {{- end }}

--- a/helm/alfresco-content-services/templates/ingress-share.yaml
+++ b/helm/alfresco-content-services/templates/ingress-share.yaml
@@ -15,9 +15,6 @@ metadata:
     nginx.ingress.kubernetes.io/session-cookie-path: "/share"
     nginx.ingress.kubernetes.io/session-cookie-max-age: "604800"
     nginx.ingress.kubernetes.io/session-cookie-expires: "604800"
-    nginx.ingress.kubernetes.io/server-snippet: |
-      location ~ ^(/.*/proxy/.*/api/solr/.*)$ {return 403 ;}
-      location ~ ^(/.*/-default-/proxy/.*/api/.*)$ {return 403;}
 {{- if .Values.share.ingress.annotations }}
 {{ toYaml .Values.share.ingress.annotations | indent 4 }}
 {{- end }}

--- a/helm/alfresco-content-services/templates/ingress-share.yaml
+++ b/helm/alfresco-content-services/templates/ingress-share.yaml
@@ -15,6 +15,9 @@ metadata:
     nginx.ingress.kubernetes.io/session-cookie-path: "/share"
     nginx.ingress.kubernetes.io/session-cookie-max-age: "604800"
     nginx.ingress.kubernetes.io/session-cookie-expires: "604800"
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      location ~ ^(/.*/proxy/.*/api/solr/.*)$ {return 403;}
+      location ~ ^(/.*/-default-/proxy/.*/api/.*)$ {return 403;}
 {{- if .Values.share.ingress.annotations }}
 {{ toYaml .Values.share.ingress.annotations | indent 4 }}
 {{- end }}

--- a/helm/alfresco-content-services/templates/ingress-share.yaml
+++ b/helm/alfresco-content-services/templates/ingress-share.yaml
@@ -15,7 +15,7 @@ metadata:
     nginx.ingress.kubernetes.io/session-cookie-path: "/share"
     nginx.ingress.kubernetes.io/session-cookie-max-age: "604800"
     nginx.ingress.kubernetes.io/session-cookie-expires: "604800"
-    nginx.ingress.kubernetes.io/configuration-snippet: |
+    nginx.ingress.kubernetes.io/server-snippet: |
       location ~ ^(/.*/proxy/.*/api/solr/.*)$ {return 403 ;}
       location ~ ^(/.*/-default-/proxy/.*/api/.*)$ {return 403;}
 {{- if .Values.share.ingress.annotations }}

--- a/helm/alfresco-content-services/values.yaml
+++ b/helm/alfresco-content-services/values.yaml
@@ -595,6 +595,7 @@ alfresco-digital-workspace:
   ingress:
     path: /workspace
     annotations:
+      kubernetes.io/ingress.class: nginx
       nginx.ingress.kubernetes.io/proxy-body-size: "5g"
     tls: []
     #  - secretName: chart-example-tls


### PR DESCRIPTION
Updates `ingress-nginx` to 4.x in order to support k8s 1.22 so that the build will work also when EKS 1.22 is released.
Applies missing `kubernetes.io/ingress.class: nginx` on ADW that with `ingress-nginx` 3.x was working anyway but not 4.x.
Disable the creation of an IngressClass resource with `--set controller.ingressClassResource.enabled=false` which is new in 4.x and breaks multiple installations per namespace as the IngressClass resource itself is not namespaced and not needed for our configuration.
Update activiti-common to 7.2.0 which includes the ingress API changes for 1.22 for ADW

Ref. OPSEXP-1339 OPSEXP-1348