### PR TITLE
OPSEXP-1378: USe server-snippet to avoid nested location within exact matches

### DIFF
--- a/helm/alfresco-content-services/templates/_helpers-ingress.tpl
+++ b/helm/alfresco-content-services/templates/_helpers-ingress.tpl
@@ -1,17 +1,26 @@
 {{/*
-Define required annotations for secure nginx ingress
+Define annotations as provided in values
 */}}
 {{- define "ingress_annotations" }}
 {{- range $annotation, $value := .ingress.annotations }}
   {{- if ne $annotation "nginx.ingress.kubernetes.io/server-snippet" }}
   {{- $annotation | nindent 4 }}: |
     {{- $value | nindent 6 }}
-  {{- else -}}
-    nginx.ingress.kubernetes.io/server-snippet: |
-    {{- $value | nindent 6 }}
   {{- end }}
 {{- end }}
-{{- if not (index .ingress.annotations "nginx.ingress.kubernetes.io/server-snippet") }}
+{{- end }}
+{{/*
+Define required annotations for secure nginx ingress
+*/}}
+{{- define "ingress_vhost_annotations" }}
+{{- if index .ingress.annotations "nginx.ingress.kubernetes.io/server-snippet" }}
+  {{- range $annotation, $value := .ingress.annotations }}
+    {{- if eq $annotation "nginx.ingress.kubernetes.io/server-snippet" }}
+    nginx.ingress.kubernetes.io/server-snippet: |
+      {{- $value | nindent 6 }}
+    {{- end }}
+  {{- end }}
+{{- else }}
     nginx.ingress.kubernetes.io/server-snippet: |
 {{- end }}
       location ~ ^(/.*/((default/)?proxy/)?(wc)?s(ervice)?/api/solr/.*)$ {return 403;}

--- a/helm/alfresco-content-services/templates/_helpers-ingress.tpl
+++ b/helm/alfresco-content-services/templates/_helpers-ingress.tpl
@@ -23,6 +23,7 @@ Define required annotations for secure nginx ingress
 {{- else }}
     nginx.ingress.kubernetes.io/server-snippet: |
 {{- end }}
-      location ~ ^(/.*/((default/)?proxy/)?(wc)?s(ervice)?/api/solr/.*)$ {return 403;}
+      location ~ ^(/.*/(wc)?s(ervice)?/api/solr/.*)$ {return 403;}
+      location ~ ^(/.*/(-default-/)?proxy/.*/api/solr/.*)$ {return 403;}
       location ~ ^(/.*/s/prometheus)$ {return 403;}
 {{- end }}

--- a/helm/alfresco-content-services/templates/_helpers-ingress.tpl
+++ b/helm/alfresco-content-services/templates/_helpers-ingress.tpl
@@ -1,0 +1,19 @@
+{{/*
+Define required annotations for secure nginx ingress
+*/}}
+{{- define "ingress_annotations" }}
+{{- range $annotation, $value := .ingress.annotations }}
+  {{- if ne $annotation "nginx.ingress.kubernetes.io/server-snippet" }}
+  {{- $annotation | nindent 4 }}: |
+    {{- $value | nindent 6 }}
+  {{- else -}}
+    nginx.ingress.kubernetes.io/server-snippet: |
+    {{- $value | nindent 6 }}
+  {{- end }}
+{{- end }}
+{{- if not (index .ingress.annotations "nginx.ingress.kubernetes.io/server-snippet") }}
+    nginx.ingress.kubernetes.io/server-snippet: |
+{{- end }}
+      location ~ ^(/.*/((default/)?proxy/)?(wc)?s(ervice)?/api/solr/.*)$ {return 403;}
+      location ~ ^(/.*/s/prometheus)$ {return 403;}
+{{- end }}

--- a/helm/alfresco-content-services/templates/ingress-repository.yaml
+++ b/helm/alfresco-content-services/templates/ingress-repository.yaml
@@ -14,6 +14,7 @@ metadata:
     # Default file limit (1m) check, document(s) above this size will throw 413 (Request Entity Too Large) error
     nginx.ingress.kubernetes.io/proxy-body-size: {{ .Values.repository.ingress.maxUploadSize }}
     {{- include "ingress_annotations" .Values.repository }}
+    {{- include "ingress_vhost_annotations" .Values.repository }}
 spec:
   {{- if .Values.repository.ingress.tls }}
   tls:

--- a/helm/alfresco-content-services/templates/ingress-repository.yaml
+++ b/helm/alfresco-content-services/templates/ingress-repository.yaml
@@ -13,18 +13,7 @@ metadata:
     nginx.ingress.kubernetes.io/session-cookie-hash: "sha1"
     # Default file limit (1m) check, document(s) above this size will throw 413 (Request Entity Too Large) error
     nginx.ingress.kubernetes.io/proxy-body-size: {{ .Values.repository.ingress.maxUploadSize }}
-    nginx.ingress.kubernetes.io/configuration-snippet: |
-    {{- if index .Values "alfresco-search" "enabled" }}
-      location ~ ^(/.*/service/api/solr/.*)$ {return 403;}
-      location ~ ^(/.*/s/api/solr/.*)$ {return 403;}
-      location ~ ^(/.*/wcservice/api/solr/.*)$ {return 403;}
-      location ~ ^(/.*/wcs/api/solr/.*)$ {return 403;}
-    {{- end }}
-      location ~ ^(/.*/s/prometheus)$ {return 403;}
-{{- if .Values.repository.ingress.annotations }}
-{{ toYaml .Values.repository.ingress.annotations | indent 4 }}
-{{- end }}
-
+    {{- include "ingress_annotations" .Values.repository }}
 spec:
   {{- if .Values.repository.ingress.tls }}
   tls:

--- a/helm/alfresco-content-services/templates/ingress-share.yaml
+++ b/helm/alfresco-content-services/templates/ingress-share.yaml
@@ -15,13 +15,7 @@ metadata:
     nginx.ingress.kubernetes.io/session-cookie-path: "/share"
     nginx.ingress.kubernetes.io/session-cookie-max-age: "604800"
     nginx.ingress.kubernetes.io/session-cookie-expires: "604800"
-    nginx.ingress.kubernetes.io/configuration-snippet: |
-      location ~ ^(/.*/proxy/.*/api/solr/.*)$ {return 403;}
-      location ~ ^(/.*/-default-/proxy/.*/api/.*)$ {return 403;}
-{{- if .Values.share.ingress.annotations }}
-{{ toYaml .Values.share.ingress.annotations | indent 4 }}
-{{- end }}
-
+    {{- include "ingress_annotations" .Values.share }}
 spec:
   {{- if .Values.share.ingress.tls }}
   tls:

--- a/helm/alfresco-content-services/templates/ingress-share.yaml
+++ b/helm/alfresco-content-services/templates/ingress-share.yaml
@@ -16,6 +16,9 @@ metadata:
     nginx.ingress.kubernetes.io/session-cookie-max-age: "604800"
     nginx.ingress.kubernetes.io/session-cookie-expires: "604800"
     {{- include "ingress_annotations" .Values.share }}
+    {{- if ne .Values.share.ingress.hostName .Values.repository.ingress.hostName }}
+    {{- include "ingress_vhost_annotations" .Values.share }}
+    {{- end }}
 spec:
   {{- if .Values.share.ingress.tls }}
   tls:
@@ -28,11 +31,9 @@ spec:
     {{- end }}
   {{- end }}
   rules:
+  - http: 
   {{- if .Values.share.ingress.hostName }}
-  - host: {{ tpl .Values.share.ingress.hostName . }}
-    http:
-  {{- else }}
-  - http:
+    host: {{ tpl .Values.share.ingress.hostName . }}
   {{- end }}
       paths:
       - path: {{ .Values.share.ingress.path }}


### PR DESCRIPTION
In some circumstances the nginx ingress annotations generated broken configuration preventing ingress controller from working. This seem to happen even more often with ingress-nginx v4
This PR prevents that by moving the configuration-snippet to server-snippet and making sure it can't be overridden by annotations from values.