### PR TITLE
ACA-3221: Reverting "/content-app" to "/aca" change for ACA

### DIFF
--- a/docker-compose/community-docker-compose.yml
+++ b/docker-compose/community-docker-compose.yml
@@ -118,7 +118,7 @@ services:
       APP_BASE_SHARE_URL: "http://localhost:8080/aca/#/preview/s"
 
   proxy:
-    image: alfresco/alfresco-acs-nginx:3.4.1
+    image: alfresco/alfresco-acs-nginx:3.4.2
     mem_limit: 128m
     environment:
       DISABLE_PROMETHEUS: "true"

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -162,7 +162,7 @@ services:
       BASE_PATH: ./
 
   proxy:
-    image: alfresco/alfresco-acs-nginx:3.4.1
+    image: alfresco/alfresco-acs-nginx:3.4.2
     mem_limit: 128m
     depends_on:
       - alfresco


### PR DESCRIPTION
in docker-compose files by updating Proxy to 3.4.2