### PR TITLE
OPSEXP-1574 Fixup for broken ai-transformer config

### DIFF
--- a/helm/alfresco-content-services/templates/config-ai-transformer.yaml
+++ b/helm/alfresco-content-services/templates/config-ai-transformer.yaml
@@ -13,7 +13,7 @@ data:
   {{ $key }}: {{ $val | quote }}
   {{- end }}
   {{- end }}
-  {{- include "activemq.config" . | nindent 2 }}
+  {{ template "activemq.config" . }}
   FILE_STORE_URL: http://{{ template "alfresco.shortname" . }}-filestore:80/alfresco/api/-default-/private/sfs/versions/1/file
   AWS_ACCESS_KEY: {{ .Values.ai.aws.accessKey }}
   AWS_SECRET_ACCESS_KEY: {{ .Values.ai.aws.secretAccessKey }}


### PR DESCRIPTION
pipeline failing with:

```
Synchronization of release 'acs' in namespace 'acs' failed: installation failed: YAML parse error on alfresco-content-services/templates/config-ai-transformer.yaml: error converting YAML to JSON: yaml: line 16: mapping values are not allowed in this context
```