### PR TITLE
OPSEXP-1587: sync service to use activeMQ URL instead of single host

### DIFF
--- a/helm/alfresco-content-services/README.md
+++ b/helm/alfresco-content-services/README.md
@@ -97,6 +97,9 @@ Please refer to the [documentation](https://github.com/Alfresco/acs-deployment/b
 | alfresco-search.type | string | `"search-services"` |  |
 | alfresco-sync-service.image.repository | string | `"quay.io/alfresco/service-sync"` |  |
 | alfresco-sync-service.image.tag | string | `"4.0.0-M1"` |  |
+| alfresco-sync-service.messageBroker.password | string | `nil` |  |
+| alfresco-sync-service.messageBroker.url | string | `nil` |  |
+| alfresco-sync-service.messageBroker.user | string | `nil` |  |
 | alfresco-sync-service.nodeSelector | object | `{}` |  |
 | alfresco-sync-service.syncservice.enabled | bool | `true` |  |
 | apiexplorer | object | `{"ingress":{"path":"/api-explorer"}}` | Declares the api-explorer service used by the content repository |

--- a/helm/alfresco-content-services/charts/alfresco-content-common/templates/_helpers-activemq.tpl
+++ b/helm/alfresco-content-services/charts/alfresco-content-common/templates/_helpers-activemq.tpl
@@ -12,7 +12,7 @@
 
 {{- define "spring.activemq.config" -}}
   SPRING_ACTIVEMQ_BROKERURL: |-
-    {{ .Values.messageBroker.url | default (printf "nio://%s-activemq-broker:61616" .Release.Name) }}
+    {{ .Values.messageBroker.url | default (printf "failover(nio://%s-activemq-broker:61616)?timeout=3000&jms.useCompression=true" .Release.Name) }}
   {{- if .Values.messageBroker.user }}
   SPRING_ACTIVEMQ_USER: {{ .Values.messageBroker.user | quote }}
   {{- end }}

--- a/helm/alfresco-content-services/charts/alfresco-elasticsearch-connector/README.md
+++ b/helm/alfresco-content-services/charts/alfresco-elasticsearch-connector/README.md
@@ -41,7 +41,7 @@ Please refer to the [documentation](https://github.com/Alfresco/acs-deployment/b
 | liveIndexing.path.image.tag | string | `"3.1.1"` |  |
 | liveIndexing.path.replicaCount | int | `1` |  |
 | messageBroker.password | string | `nil` | Broker password |
-| messageBroker.url | string | `nil` | Broker URL formated as per https://activemq.apache.org/activemq-connection-uris |
+| messageBroker.url | string | `nil` | Broker URL formatted as per https://activemq.apache.org/activemq-connection-uris |
 | messageBroker.user | string | `nil` | Broker username |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |

--- a/helm/alfresco-content-services/charts/alfresco-sync-service/Chart.yaml
+++ b/helm/alfresco-content-services/charts/alfresco-sync-service/Chart.yaml
@@ -10,6 +10,9 @@ sources:
 version: 3.0.9
 icon: https://avatars0.githubusercontent.com/u/391127?s=200&v=4
 dependencies:
+  - name: alfresco-content-common
+    version: 0.1.0
+    repository: "file://../alfresco-content-common"
   - name: common
     repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami/
     version: 1.x.x

--- a/helm/alfresco-content-services/charts/alfresco-sync-service/README.md
+++ b/helm/alfresco-content-services/charts/alfresco-sync-service/README.md
@@ -18,20 +18,14 @@ Alfresco Sync Service
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| activemq.broker.host | string | `"activemq-broker"` |  |
-| activemq.broker.password | string | `nil` |  |
-| activemq.broker.port | int | `61616` |  |
-| activemq.broker.protocol | string | `"tcp"` |  |
-| activemq.broker.username | string | `nil` |  |
-| activemq.external | bool | `false` |  |
 | contentServices.installationName | string | `nil` | Specify when installing as a standalone chart, not as a subchart of ACS. This variable will be used to construct the correct hostname for ACS and ActiveMQ |
-| database | object | `{"external":false}` | Defines properties required by sync service for connecting to the database Note! : If you set database.external to true you will have to setup the driver, user, password and JdbcUrl Also make sure that the container has the db driver in TODO - add container path |
+| database | object | `{"external":false}` | Defines properties required by sync service for connecting to the database Note! : If you set database.external to true you will have to setup the JDBC driver, user, password and JdbcUrl as `driver`, `user`, `password` & `url` subelements of `database`. Also make sure that the container has the db driver in TODO - add container path |
 | global | object | `{"alfrescoRegistryPullSecrets":"quay-registry-secret","strategy":{"rollingUpdate":{"maxSurge":1,"maxUnavailable":0}}}` | Global definition of Docker registry pull secret which can be overridden from parent ACS Helm chart(s) |
 | ingress.extraAnnotations | string | `nil` |  |
 | ingress.tls | list | `[]` | useful when running Sync service without SSL termination done by a load balancer, e.g. when ran on Minikube for testing purposes nginx.ingress.kubernetes.io/ssl-redirect: "false" |
 | initContainers.activemq.image.pullPolicy | string | `"IfNotPresent"` |  |
-| initContainers.activemq.image.repository | string | `"busybox"` |  |
-| initContainers.activemq.image.tag | string | `"1.35.0"` |  |
+| initContainers.activemq.image.repository | string | `"bash"` |  |
+| initContainers.activemq.image.tag | string | `"5.1.16"` |  |
 | initContainers.activemq.resources.limits.memory | string | `"10Mi"` |  |
 | initContainers.activemq.resources.requests.memory | string | `"5Mi"` |  |
 | initContainers.postgres.image.pullPolicy | string | `"IfNotPresent"` |  |
@@ -65,7 +59,7 @@ Alfresco Sync Service
 | syncservice.horizontalPodAutoscaling.enabled | bool | `true` |  |
 | syncservice.horizontalPodAutoscaling.maxReplicas | int | `3` |  |
 | syncservice.horizontalPodAutoscaling.memory.enabled | bool | `true` |  |
-| syncservice.horizontalPodAutoscaling.memory.targetAverageUtilization | int | `60` |  |
+| syncservice.horizontalPodAutoscaling.memory.targetAverageUtilization | int | `60` | For the memory a lower threshold(60) for the targetAverageUtilization is needed. We need to allow the resource metrics to be queried by the metrics-server, before the pod is killed # by Kubernetes due to reaching memory limits(the infamous message one might see  in the pod events history. "Terminated: OOMKilled"). The metrics are checked every 15 seconds by #    # default,  configured by the global cluster flag --horizontal-pod-autoscaler-sync-period |
 | syncservice.horizontalPodAutoscaling.minReplicas | int | `1` |  |
 | syncservice.image.internalPort | int | `9090` |  |
 | syncservice.image.pullPolicy | string | `"IfNotPresent"` |  |
@@ -105,20 +99,14 @@ Alfresco Sync Service
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| activemq.broker.host | string | `"activemq-broker"` |  |
-| activemq.broker.password | string | `nil` |  |
-| activemq.broker.port | int | `61616` |  |
-| activemq.broker.protocol | string | `"tcp"` |  |
-| activemq.broker.username | string | `nil` |  |
-| activemq.external | bool | `false` |  |
 | contentServices.installationName | string | `nil` | Specify when installing as a standalone chart, not as a subchart of ACS. This variable will be used to construct the correct hostname for ACS and ActiveMQ |
-| database | object | `{"external":false}` | Defines properties required by sync service for connecting to the database Note! : If you set database.external to true you will have to setup the driver, user, password and JdbcUrl Also make sure that the container has the db driver in TODO - add container path |
+| database | object | `{"external":false}` | Defines properties required by sync service for connecting to the database Note! : If you set database.external to true you will have to setup the JDBC driver, user, password and JdbcUrl as `driver`, `user`, `password` & `url` subelements of `database`. Also make sure that the container has the db driver in TODO - add container path |
 | global | object | `{"alfrescoRegistryPullSecrets":"quay-registry-secret","strategy":{"rollingUpdate":{"maxSurge":1,"maxUnavailable":0}}}` | Global definition of Docker registry pull secret which can be overridden from parent ACS Helm chart(s) |
 | ingress.extraAnnotations | string | `nil` |  |
 | ingress.tls | list | `[]` | useful when running Sync service without SSL termination done by a load balancer, e.g. when ran on Minikube for testing purposes nginx.ingress.kubernetes.io/ssl-redirect: "false" |
 | initContainers.activemq.image.pullPolicy | string | `"IfNotPresent"` |  |
-| initContainers.activemq.image.repository | string | `"busybox"` |  |
-| initContainers.activemq.image.tag | string | `"1.35.0"` |  |
+| initContainers.activemq.image.repository | string | `"bash"` |  |
+| initContainers.activemq.image.tag | string | `"5.1.16"` |  |
 | initContainers.activemq.resources.limits.memory | string | `"10Mi"` |  |
 | initContainers.activemq.resources.requests.memory | string | `"5Mi"` |  |
 | initContainers.postgres.image.pullPolicy | string | `"IfNotPresent"` |  |
@@ -152,7 +140,7 @@ Alfresco Sync Service
 | syncservice.horizontalPodAutoscaling.enabled | bool | `true` |  |
 | syncservice.horizontalPodAutoscaling.maxReplicas | int | `3` |  |
 | syncservice.horizontalPodAutoscaling.memory.enabled | bool | `true` |  |
-| syncservice.horizontalPodAutoscaling.memory.targetAverageUtilization | int | `60` |  |
+| syncservice.horizontalPodAutoscaling.memory.targetAverageUtilization | int | `60` | For the memory a lower threshold(60) for the targetAverageUtilization is needed. We need to allow the resource metrics to be queried by the metrics-server, before the pod is killed # by Kubernetes due to reaching memory limits(the infamous message one might see  in the pod events history. "Terminated: OOMKilled"). The metrics are checked every 15 seconds by #    # default,  configured by the global cluster flag --horizontal-pod-autoscaler-sync-period |
 | syncservice.horizontalPodAutoscaling.minReplicas | int | `1` |  |
 | syncservice.image.internalPort | int | `9090` |  |
 | syncservice.image.pullPolicy | string | `"IfNotPresent"` |  |

--- a/helm/alfresco-content-services/charts/alfresco-sync-service/README.md
+++ b/helm/alfresco-content-services/charts/alfresco-sync-service/README.md
@@ -12,6 +12,7 @@ Alfresco Sync Service
 
 | Repository | Name | Version |
 |------------|------|---------|
+| file://../alfresco-content-common | alfresco-content-common | 0.1.0 |
 | https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami/ | common | 1.x.x |
 
 ## Values
@@ -21,8 +22,8 @@ Alfresco Sync Service
 | contentServices.installationName | string | `nil` | Specify when installing as a standalone chart, not as a subchart of ACS. This variable will be used to construct the correct hostname for ACS and ActiveMQ |
 | database | object | `{"external":false}` | Defines properties required by sync service for connecting to the database Note! : If you set database.external to true you will have to setup the JDBC driver, user, password and JdbcUrl as `driver`, `user`, `password` & `url` subelements of `database`. Also make sure that the container has the db driver in TODO - add container path |
 | global | object | `{"alfrescoRegistryPullSecrets":"quay-registry-secret","strategy":{"rollingUpdate":{"maxSurge":1,"maxUnavailable":0}}}` | Global definition of Docker registry pull secret which can be overridden from parent ACS Helm chart(s) |
-| ingress.extraAnnotations | string | `nil` |  |
-| ingress.tls | list | `[]` | useful when running Sync service without SSL termination done by a load balancer, e.g. when ran on Minikube for testing purposes nginx.ingress.kubernetes.io/ssl-redirect: "false" |
+| ingress.extraAnnotations | string | `nil` | useful when running Sync service without SSL termination done by a load balancer, e.g. when ran on Minikube for testing purposes nginx.ingress.kubernetes.io/ssl-redirect: "false" |
+| ingress.tls | list | `[]` |  |
 | initContainers.activemq.image.pullPolicy | string | `"IfNotPresent"` |  |
 | initContainers.activemq.image.repository | string | `"bash"` |  |
 | initContainers.activemq.image.tag | string | `"5.1.16"` |  |
@@ -33,11 +34,12 @@ Alfresco Sync Service
 | initContainers.postgres.image.tag | string | `"1.35.0"` |  |
 | initContainers.postgres.resources.limits.memory | string | `"10Mi"` |  |
 | initContainers.postgres.resources.requests.memory | string | `"5Mi"` |  |
+| messageBroker.url | string | `nil` |  |
 | nodeSelector | object | `{}` |  |
-| postgresql-syncservice.enabled | bool | `true` |  |
+| postgresql-syncservice.enabled | bool | `true` | If true, install the postgresql chart alongside Alfresco Sync service. Note: Set this to false if you use an external database. |
 | postgresql-syncservice.image.pullPolicy | string | `"IfNotPresent"` |  |
 | postgresql-syncservice.image.tag | string | `"11.7.0"` |  |
-| postgresql-syncservice.name | string | `"postgresql-syncservice"` | If true, install the postgresql chart alongside Alfresco Sync service. Note: Set this to false if you use an external database. |
+| postgresql-syncservice.name | string | `"postgresql-syncservice"` |  |
 | postgresql-syncservice.nameOverride | string | `"postgresql-syncservice"` |  |
 | postgresql-syncservice.postgresConfig.log_min_messages | string | `"LOG"` |  |
 | postgresql-syncservice.postgresConfig.max_connections | int | `450` |  |
@@ -93,6 +95,7 @@ Alfresco Sync Service
 
 | Repository | Name | Version |
 |------------|------|---------|
+| file://../alfresco-content-common | alfresco-content-common | 0.1.0 |
 | https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami/ | common | 1.x.x |
 
 ## Values
@@ -102,8 +105,8 @@ Alfresco Sync Service
 | contentServices.installationName | string | `nil` | Specify when installing as a standalone chart, not as a subchart of ACS. This variable will be used to construct the correct hostname for ACS and ActiveMQ |
 | database | object | `{"external":false}` | Defines properties required by sync service for connecting to the database Note! : If you set database.external to true you will have to setup the JDBC driver, user, password and JdbcUrl as `driver`, `user`, `password` & `url` subelements of `database`. Also make sure that the container has the db driver in TODO - add container path |
 | global | object | `{"alfrescoRegistryPullSecrets":"quay-registry-secret","strategy":{"rollingUpdate":{"maxSurge":1,"maxUnavailable":0}}}` | Global definition of Docker registry pull secret which can be overridden from parent ACS Helm chart(s) |
-| ingress.extraAnnotations | string | `nil` |  |
-| ingress.tls | list | `[]` | useful when running Sync service without SSL termination done by a load balancer, e.g. when ran on Minikube for testing purposes nginx.ingress.kubernetes.io/ssl-redirect: "false" |
+| ingress.extraAnnotations | string | `nil` | useful when running Sync service without SSL termination done by a load balancer, e.g. when ran on Minikube for testing purposes nginx.ingress.kubernetes.io/ssl-redirect: "false" |
+| ingress.tls | list | `[]` |  |
 | initContainers.activemq.image.pullPolicy | string | `"IfNotPresent"` |  |
 | initContainers.activemq.image.repository | string | `"bash"` |  |
 | initContainers.activemq.image.tag | string | `"5.1.16"` |  |
@@ -114,11 +117,12 @@ Alfresco Sync Service
 | initContainers.postgres.image.tag | string | `"1.35.0"` |  |
 | initContainers.postgres.resources.limits.memory | string | `"10Mi"` |  |
 | initContainers.postgres.resources.requests.memory | string | `"5Mi"` |  |
+| messageBroker.url | string | `nil` |  |
 | nodeSelector | object | `{}` |  |
-| postgresql-syncservice.enabled | bool | `true` |  |
+| postgresql-syncservice.enabled | bool | `true` | If true, install the postgresql chart alongside Alfresco Sync service. Note: Set this to false if you use an external database. |
 | postgresql-syncservice.image.pullPolicy | string | `"IfNotPresent"` |  |
 | postgresql-syncservice.image.tag | string | `"11.7.0"` |  |
-| postgresql-syncservice.name | string | `"postgresql-syncservice"` | If true, install the postgresql chart alongside Alfresco Sync service. Note: Set this to false if you use an external database. |
+| postgresql-syncservice.name | string | `"postgresql-syncservice"` |  |
 | postgresql-syncservice.nameOverride | string | `"postgresql-syncservice"` |  |
 | postgresql-syncservice.postgresConfig.log_min_messages | string | `"LOG"` |  |
 | postgresql-syncservice.postgresConfig.max_connections | int | `450` |  |

--- a/helm/alfresco-content-services/charts/alfresco-sync-service/templates/config-syncservice.yaml
+++ b/helm/alfresco-content-services/charts/alfresco-sync-service/templates/config-syncservice.yaml
@@ -10,7 +10,7 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     component: syncservice
 data:
-  {{ template "activemq.config" . }}
+  {{ template "spring.activemq.config" . }}
   JAVA_OPTS: >-
       {{- if eq .Values.database.external false }}
       -Dsql.db.driver="org.postgresql.Driver"
@@ -23,9 +23,9 @@ data:
       -Dsql.db.password=$DATABASE_PASSWORD
       -Drepo.hostname={{ printf "%s-%s" (include "acs.release.name" .) .Values.repository.host }}
       -Drepo.port={{ .Values.repository.port }}
-      -Dmessaging.broker.host=$ACTIVEMQ_URL
-      -Dmessaging.username=$ACTIVEMQ_USERNAME
-      -Dmessaging.password=$ACTIVEMQ_PASSWORD
+      -Dmessaging.broker.url=$SPRING_ACTIVEMQ_BROKERURL
+      -Dmessaging.username=$SPRING_ACTIVEMQ_USER
+      -Dmessaging.password=$SPRING_ACTIVEMQ_PASSWORD
       -Ddw.server.applicationConnectors[0].type=http
       {{ .Values.syncservice.environment.JAVA_OPTS }}
       {{ .Values.syncservice.environment.EXTRA_JAVA_OPTS }}

--- a/helm/alfresco-content-services/charts/alfresco-sync-service/templates/config-syncservice.yaml
+++ b/helm/alfresco-content-services/charts/alfresco-sync-service/templates/config-syncservice.yaml
@@ -10,6 +10,7 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     component: syncservice
 data:
+  {{ template "activemq.config" . }}
   JAVA_OPTS: >-
       {{- if eq .Values.database.external false }}
       -Dsql.db.driver="org.postgresql.Driver"
@@ -22,15 +23,9 @@ data:
       -Dsql.db.password=$DATABASE_PASSWORD
       -Drepo.hostname={{ printf "%s-%s" (include "acs.release.name" .) .Values.repository.host }}
       -Drepo.port={{ .Values.repository.port }}
-      {{- if eq .Values.activemq.external false }}
-      -Dmessaging.broker.host={{ printf "%s-%s" (include "acs.release.name" .) .Values.activemq.broker.host}}
-      {{- else }}
-      -Dmessaging.broker.host={{ .Values.activemq.broker.host }}
-      {{- end }}
-      -Dmessaging.username={{ .Values.activemq.broker.username }}
-      -Dmessaging.password={{ .Values.activemq.broker.password }}
-      -Dmessaging.broker.port={{ .Values.activemq.broker.port }}
-      -Dmessaging.broker.protocol={{ .Values.activemq.broker.protocol }}
+      -Dmessaging.broker.host=$ACTIVEMQ_URL
+      -Dmessaging.username=$ACTIVEMQ_USERNAME
+      -Dmessaging.password=$ACTIVEMQ_PASSWORD
       -Ddw.server.applicationConnectors[0].type=http
       {{ .Values.syncservice.environment.JAVA_OPTS }}
       {{ .Values.syncservice.environment.EXTRA_JAVA_OPTS }}

--- a/helm/alfresco-content-services/charts/alfresco-sync-service/templates/deployment-syncservice.yaml
+++ b/helm/alfresco-content-services/charts/alfresco-sync-service/templates/deployment-syncservice.yaml
@@ -36,20 +36,31 @@ spec:
       {{- if .Values.activemq }}
       {{ fail "Using activemq.[host|port|user|password|external] in subcharts is not supported anymore. Use messageBroker.* instead" }}
       {{- end }}
-      {{/*
-       - name: init-activemq
+      - name: init-activemq
         image: "{{ .Values.initContainers.activemq.image.repository }}:{{ .Values.initContainers.activemq.image.tag }}"
         imagePullPolicy: {{ .Values.initContainers.activemq.image.pullPolicy }}
         resources:
 {{ toYaml .Values.initContainers.activemq.resources | indent 10 }}
-        env:
-        - name: ACTIVEMQ_HOST
-          value: {{ printf "%s-%s" (include "acs.release.name" .) .Values.activemq.broker.host}}
-        - name: ACTIVEMQ_PORT
-          value: {{ .Values.activemq.broker.ports | default 61616 | quote }}
-        command: ['sh', '-c', 'until nc -w1 $ACTIVEMQ_HOST $ACTIVEMQ_PORT; do echo "waiting for activemq"; sleep 5; done;']
-      {{- end }}
-      */}}
+        envFrom:
+        - configMapRef:
+            name: {{ template "syncservice.fullname" . }}-configmap
+        args:
+          - -c
+          - echo "Checking for ActiveMQ broker availability";
+            IFS=, read -r -a array < <(echo "${SPRING_ACTIVEMQ_BROKERURL}" | sed -r 's/([a-z]+:\()*([^\)]*)(\)?.*)*/\2/');
+            while [ -z $MQREADY ]; do
+              for broker in "${array[@]}"; do broker_socket=${broker%%\?*};
+                [[ "${broker_socket#*://}" == *":"* ]] || NCPORT=61616;
+                echo "Trying ${broker_socket#*://} $NCPORT";
+                nc -w1 ${broker_socket#*://} $NCPORT;
+                if [ $? -eq 0 ]; then echo "ok";
+                  MQREADY=1;
+                  break;
+                else echo "not ok";
+                  sleep 5;
+                fi;
+              done;
+            done
       {{- if eq .Values.database.external false }}
       - name: init-postgres
         image: "{{ .Values.initContainers.postgres.image.repository }}:{{ .Values.initContainers.postgres.image.tag }}"

--- a/helm/alfresco-content-services/charts/alfresco-sync-service/templates/deployment-syncservice.yaml
+++ b/helm/alfresco-content-services/charts/alfresco-sync-service/templates/deployment-syncservice.yaml
@@ -33,8 +33,11 @@ spec:
       imagePullSecrets:
         - name: {{ .Values.global.alfrescoRegistryPullSecrets }}
       initContainers:
-      {{- if eq .Values.activemq.external false }}
-      - name: init-activemq
+      {{- if .Values.activemq }}
+      {{ fail "Using activemq.[host|port|user|password|external] in subcharts is not supported anymore. Use messageBroker.* instead" }}
+      {{- end }}
+      {{/*
+       - name: init-activemq
         image: "{{ .Values.initContainers.activemq.image.repository }}:{{ .Values.initContainers.activemq.image.tag }}"
         imagePullPolicy: {{ .Values.initContainers.activemq.image.pullPolicy }}
         resources:
@@ -46,6 +49,7 @@ spec:
           value: {{ .Values.activemq.broker.ports | default 61616 | quote }}
         command: ['sh', '-c', 'until nc -w1 $ACTIVEMQ_HOST $ACTIVEMQ_PORT; do echo "waiting for activemq"; sleep 5; done;']
       {{- end }}
+      */}}
       {{- if eq .Values.database.external false }}
       - name: init-postgres
         image: "{{ .Values.initContainers.postgres.image.repository }}:{{ .Values.initContainers.postgres.image.tag }}"

--- a/helm/alfresco-content-services/charts/alfresco-sync-service/values.yaml
+++ b/helm/alfresco-content-services/charts/alfresco-sync-service/values.yaml
@@ -57,17 +57,24 @@ syncservice:
       targetAverageUtilization: 80
     memory:
       enabled: true
-       # -- For the memory a lower threshold(60) for the targetAverageUtilization is needed.
-       # We need to allow the resource metrics to be queried by the metrics-server,
-       # before the pod is killed # by Kubernetes due to reaching memory limits(the infamous
-       # message one might see  in the pod events history. "Terminated: OOMKilled").
-       # The metrics are checked every 15 seconds by #    # default,  configured by the
-       # global cluster flag --horizontal-pod-autoscaler-sync-period
+      # -- For the memory a lower threshold(60) for the targetAverageUtilization is needed.
+      # We need to allow the resource metrics to be queried by the metrics-server,
+      # before the pod is killed # by Kubernetes due to reaching memory limits(the infamous
+      # message one might see  in the pod events history. "Terminated: OOMKilled").
+      # The metrics are checked every 15 seconds by #    # default,  configured by the
+      # global cluster flag --horizontal-pod-autoscaler-sync-period
       targetAverageUtilization: 60
 
 repository:
   host: alfresco-cs-repository
   port: 80
+
+    # -- `messageBroker` object allow to pass ActiveMQ connection details.
+# `url`: provides URI formatted string (see https://activemq.apache.org/activemq-connection-uris).
+# `user`: username to authenticate as.
+# `password`: credential to use to authenticate to the broker.
+messageBroker:
+  url: null
 
 contentServices:
   # -- Specify when installing as a standalone chart, not as a subchart of ACS.
@@ -82,9 +89,9 @@ database:
   external: false
 
 postgresql-syncservice:
+  name: postgresql-syncservice
   # -- If true, install the postgresql chart alongside Alfresco Sync service.
   # Note: Set this to false if you use an external database.
-  name: postgresql-syncservice
   enabled: true
   replicaCount: 1
   nameOverride: postgresql-syncservice
@@ -128,10 +135,10 @@ initContainers:
         memory: "10Mi"
 
 ingress:
+  # -- useful when running Sync service without SSL termination done by a load balancer, e.g. when ran on Minikube for testing purposes
+  #nginx.ingress.kubernetes.io/ssl-redirect: "false"
   extraAnnotations:
-    # -- useful when running Sync service without SSL termination done by a load balancer, e.g. when ran on Minikube for testing purposes
-    #nginx.ingress.kubernetes.io/ssl-redirect: "false"
-  tls: []
   #  - secretName: chart-example-tls
   #    hosts:
   #      - chart-example.local
+  tls: []

--- a/helm/alfresco-content-services/charts/alfresco-sync-service/values.yaml
+++ b/helm/alfresco-content-services/charts/alfresco-sync-service/values.yaml
@@ -57,37 +57,29 @@ syncservice:
       targetAverageUtilization: 80
     memory:
       enabled: true
-
-# -- For the memory a lower threshold(60) for the targetAverageUtilization is needed. We need to allow the resource metrics to be queried by the metrics-server, before the pod is killed # by Kubernetes due to reaching memory limits(the infamous message one might see  in the pod events history. "Terminated: OOMKilled"). The metrics are checked every 15 seconds by #    # default,  configured by the global cluster flag --horizontal-pod-autoscaler-sync-period
+       # -- For the memory a lower threshold(60) for the targetAverageUtilization is needed.
+       # We need to allow the resource metrics to be queried by the metrics-server,
+       # before the pod is killed # by Kubernetes due to reaching memory limits(the infamous
+       # message one might see  in the pod events history. "Terminated: OOMKilled").
+       # The metrics are checked every 15 seconds by #    # default,  configured by the
+       # global cluster flag --horizontal-pod-autoscaler-sync-period
       targetAverageUtilization: 60
-
-activemq:
-  external: false
-  broker:
-      host: activemq-broker
-      port: 61616
-      username:
-      password:
-      protocol: tcp
 
 repository:
   host: alfresco-cs-repository
   port: 80
 
 contentServices:
-# -- Specify when installing as a standalone chart, not as a subchart of ACS.
-# This variable will be used to construct the correct hostname for ACS and ActiveMQ
+  # -- Specify when installing as a standalone chart, not as a subchart of ACS.
+  # This variable will be used to construct the correct hostname for ACS and ActiveMQ
   installationName:
 
 # -- Defines properties required by sync service for connecting to the database
-# Note! : If you set database.external to true you will have to setup the driver, user, password and JdbcUrl
+# Note! : If you set database.external to true you will have to setup the JDBC driver,
+# user, password and JdbcUrl as `driver`, `user`, `password` & `url` subelements of `database`.
 # Also make sure that the container has the db driver in TODO - add container path
 database:
   external: false
-  # driver:     #ex: org.postgresql.Driver
-  # user:     #ex: alfresco
-  # password:     #ex: alfresco
-  # url:    # ex: jdbc:postgresql://oldfashioned-mule-postgresql-acs:5432/alfresco
 
 postgresql-syncservice:
   # -- If true, install the postgresql chart alongside Alfresco Sync service.

--- a/helm/alfresco-content-services/charts/alfresco-sync-service/values.yaml
+++ b/helm/alfresco-content-services/charts/alfresco-sync-service/values.yaml
@@ -108,8 +108,8 @@ postgresql-syncservice:
 initContainers:
   activemq:
     image:
-      repository: busybox
-      tag: 1.35.0
+      repository: bash
+      tag: 5.1.16
       pullPolicy: IfNotPresent
     resources:
       requests:

--- a/helm/alfresco-content-services/values.yaml
+++ b/helm/alfresco-content-services/values.yaml
@@ -844,6 +844,7 @@ metadataKeystore:
   defaultKeyPassword: "oKIWzVdEdA"
 
 alfresco-sync-service:
+  messageBroker: *acs_messageBroker
   nodeSelector: {}
   syncservice:
     enabled : true


### PR DESCRIPTION
Current sync subchart expect a single host/port/protocol to be passed to sync serivce so it cannot benefit from high-availability provided by external instances.