### PR TITLE
ACS-3180: Bump MS 365/OneDrive "sample" (helm chart)

### DIFF
--- a/helm/alfresco-content-services/README.md
+++ b/helm/alfresco-content-services/README.md
@@ -174,7 +174,7 @@ Please refer to the [documentation](https://github.com/Alfresco/acs-deployment/b
 | ooiService.image.internalPort | int | `9095` |  |
 | ooiService.image.pullPolicy | string | `"IfNotPresent"` |  |
 | ooiService.image.repository | string | `"quay.io/alfresco/alfresco-ooi-service"` |  |
-| ooiService.image.tag | string | `"1.1.2"` |  |
+| ooiService.image.tag | string | `"1.1.3-A1"` |  |
 | ooiService.ingress.path | string | `"/ooi-service"` |  |
 | ooiService.ingress.tls | list | `[]` |  |
 | ooiService.livenessProbe.initialDelaySeconds | int | `10` |  |

--- a/helm/alfresco-content-services/values.yaml
+++ b/helm/alfresco-content-services/values.yaml
@@ -116,7 +116,7 @@ ooiService:
   nodeSelector: {}
   image:
     repository: quay.io/alfresco/alfresco-ooi-service
-    tag: 1.1.2
+    tag: 1.1.3-A1
     pullPolicy: IfNotPresent
     internalPort: 9095
   service:


### PR DESCRIPTION
- from 1.1.2 to 1.1.3-A1 (ready for code freeze)
- note: once we release final 1.1.3 (GA) then we will bump again