### PR TITLE
OPSEXP 1387: Replace existing setup checkov action with bridgecrewio/checkov-action

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -6,12 +6,10 @@ on:
   push:
     branches:
       - 'master'
-      - 'OPSEXP-1387'
 jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-#      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-checkov@v1.6.0
       - uses: Alfresco/alfresco-build-tools/.github/actions/setup-helm-docs@v1.6.0
       - uses: Alfresco/alfresco-build-tools/.github/actions/pre-commit@v1.6.0
   branch:

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -6,11 +6,12 @@ on:
   push:
     branches:
       - 'master'
+      - 'OPSEXP-1387'
 jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-checkov@v1.6.0
+#      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-checkov@v1.6.0
       - uses: Alfresco/alfresco-build-tools/.github/actions/setup-helm-docs@v1.6.0
       - uses: Alfresco/alfresco-build-tools/.github/actions/pre-commit@v1.6.0
   branch:


### PR DESCRIPTION
I removed Alfresco/alfresco-build-tools/.github/actions/setup-checkov@v1.6.0 from the verify workflow as it is not necessary for the [precommit checkov action](https://www.checkov.io/4.Integrations/pre-commit.html) to run, using the [official checkov action](https://github.com/bridgecrewio/checkov-action) also is not needed. All check have passed in [the prior run](https://github.com/Alfresco/acs-deployment/actions/runs/2669520078) without setup-checkov@v1.6.0.