### PR TITLE
Fix imagePullSecret handling when secret is not set

### DIFF
--- a/helm/alfresco-content-services/charts/alfresco-sync-service/templates/deployment-syncservice.yaml
+++ b/helm/alfresco-content-services/charts/alfresco-sync-service/templates/deployment-syncservice.yaml
@@ -30,8 +30,11 @@ spec:
     {{- if .Values.nodeSelector }}
       nodeSelector: {{- .Values.nodeSelector | toYaml | nindent 8 }}
     {{- end }}
+      {{- if .Values.global.alfrescoRegistryPullSecrets }}
+      # only set this secret if a private docker registry variable is defined
       imagePullSecrets:
         - name: {{ .Values.global.alfrescoRegistryPullSecrets }}
+      {{- end }}
       initContainers:
       {{- if eq .Values.activemq.external false }}
       - name: init-activemq

--- a/helm/alfresco-content-services/templates/deployment-transform-router.yaml
+++ b/helm/alfresco-content-services/templates/deployment-transform-router.yaml
@@ -25,9 +25,11 @@ spec:
     {{- if .Values.transformrouter.nodeSelector }}
       nodeSelector: {{- .Values.transformrouter.nodeSelector | toYaml | nindent 8 }}
     {{- end }}
+      {{- if .Values.global.alfrescoRegistryPullSecrets }}
       # only set this secret if a private docker registry variable is defined
       imagePullSecrets:
         - name: {{ .Values.global.alfrescoRegistryPullSecrets }}
+      {{- end }}
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
When performing a helm upgrade over an existing deployment helm would error with; 

client.go:205: [debug] error updating the resource "alfresco-content-services-alfresco-router":
	 failed to create patch: map: map[] does not contain declared merge key: name
upgrade.go:355: [debug] warning: Upgrade "alfresco-content-services" failed: failed to create patch: map: map[] does not contain declared merge key: name

This is because the original deployment would set the imagePullSecret to "name: " and would try to be re-set at upgrade. Since a blank value is defaulted in the chart values this conditional is needed in all the deployment (and is present in the others).