### PR TITLE
Feature/search services replication

### DIFF
--- a/.github/workflows/community-compose.yml
+++ b/.github/workflows/community-compose.yml
@@ -1,0 +1,31 @@
+---
+name: Docker Compose (Community)
+on:
+  pull_request:
+    branches:
+      - 'master'
+    paths:
+      - 'docker-compose/community-docker-compose.yml'
+      - 'test/postman/docker-compose/**'
+      - '.github/workflows/community-compose.yml'
+      - '.pre-commit-config.d/compose.yaml'
+  push:
+    branches:
+      - 'master'
+jobs:
+  pre_commit:
+    name: Run pre-commit compose checks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: Alfresco/alfresco-build-tools/.github/actions/pre-commit@master
+        with:
+          pre-commit-all-files: false
+          pre-commit-args: -c .pre-commit-config.d/compose.yaml
+  compose_community:
+    name: docker-compose community
+    runs-on: ubuntu-latest
+    steps:
+      - uses: >-
+          Alfresco/alfresco-build-tools/.github/actions/dbp-charts/verify-compose@master
+        with:
+          compose_file_path: docker-compose/community-docker-compose.yml

--- a/.github/workflows/enterprise-compose.yml
+++ b/.github/workflows/enterprise-compose.yml
@@ -1,0 +1,43 @@
+---
+name: Docker Compose (Enterprise)
+on:
+  pull_request:
+    branches:
+      - 'master'
+    paths:
+      - '! docker-compose/community-docker-compose.yml'
+      - 'docker-compose/**'
+      - 'test/postman/docker-compose/**'
+      - '.github/workflows/enterprise-compose.yml'
+      - '.pre-commit-config.d/compose.yaml'
+  push:
+    branches:
+      - 'master'
+jobs:
+  pre_commit:
+    name: Run pre-commit compose checks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: Alfresco/alfresco-build-tools/.github/actions/pre-commit@master
+        with:
+          pre-commit-all-files: false
+          pre-commit-args: -c .pre-commit-config.d/compose.yaml
+  compose_enterprise:
+    name: docker-compose enterprise
+    strategy:
+      fail-fast: true
+      matrix:
+        compose_file:
+          - docker-compose.yml
+          - 7.2.N-docker-compose.yml
+          - 7.1.N-docker-compose.yml
+          - 7.0.N-docker-compose.yml
+          - 6.2.N-docker-compose.yml
+    runs-on: ubuntu-latest
+    steps:
+      - uses: >-
+          Alfresco/alfresco-build-tools/.github/actions/dbp-charts/verify-compose@master
+        with:
+          compose_file_path: docker-compose/${{ matrix.compose_file }}
+          quay_username: ${{ secrets.QUAY_USERNAME }}
+          quay_password: ${{ secrets.QUAY_PASSWORD }}

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -13,7 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: Alfresco/alfresco-build-tools/.github/actions/setup-helm-docs@v1.14.0
-      - uses: Alfresco/alfresco-build-tools/.github/actions/pre-commit@v1.14.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/pre-commit@master
+        with:
+          pre-commit-args: -c .pre-commit-config.d/helm.yaml
   helm:
     needs:
       - pre-commit
@@ -50,29 +52,6 @@ jobs:
           release_prefix: acs-${{ steps.version.outputs.acs_version }}
           chart_name: 'alfresco-content-services'
           test_newman: 'true'
-  compose:
-    needs: [pre-commit]
-    strategy:
-      fail-fast: true
-      matrix:
-        compose_file:
-          - docker-compose.yml
-          - 7.2.N-docker-compose.yml
-          - 7.1.N-docker-compose.yml
-          - 7.0.N-docker-compose.yml
-          - 6.2.N-docker-compose.yml
-          - community-docker-compose.yml
-    runs-on: ubuntu-latest
-    steps:
-      - name: Run Docker Compose tests
-        if: ${{ ! github.event.pull_request.head.repo.fork || matrix.compose_file == 'community-docker-compose.yml' }}
-        uses: Alfresco/alfresco-build-tools/.github/actions/dbp-charts/verify-compose@master
-        with:
-          compose_file_path: docker-compose/${{ matrix.compose_file }}
-          docker_username: ${{ secrets.DOCKER_USERNAME }}
-          docker_password: ${{ secrets.DOCKER_PASSWORD }}
-          quay_username: ${{ secrets.QUAY_USERNAME }}
-          quay_password: ${{ secrets.QUAY_PASSWORD }}
   publish:
     if: contains(github.event.head_commit.message, '[publish]')
     needs:

--- a/.pre-commit-config.d/compose.yaml
+++ b/.pre-commit-config.d/compose.yaml
@@ -1,0 +1,18 @@
+---
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.3.0
+    hooks:
+      - id: check-merge-conflict
+      - id: check-yaml
+        args: [--allow-multiple-documents]
+        exclude: helm/
+      - id: fix-byte-order-marker
+      - id: mixed-line-ending
+        args: ['--fix=lf']
+      - id: end-of-file-fixer
+  - repo: https://github.com/IamTheFij/docker-pre-commit
+    rev: v2.1.0
+    hooks:
+      - id: docker-compose-check
+        exclude: override-docker-compose.yml

--- a/.pre-commit-config.d/helm.yaml
+++ b/.pre-commit-config.d/helm.yaml
@@ -1,0 +1,32 @@
+repos:
+  - repo: https://github.com/norwoodj/helm-docs
+    rev: v1.10.0
+    hooks:
+      - id: helm-docs
+  - repo: https://github.com/Alfresco/alfresco-build-tools
+    rev: v1.15.0
+    hooks:
+      - id: helm-deps
+      - id: helm-lint
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.3.0
+    hooks:
+      - id: check-merge-conflict
+      - id: check-yaml
+        args: [--allow-multiple-documents]
+        exclude: |
+          (?x)^(
+            docker-compose/.*\.ya?ml|
+            helm/.*/templates/.*\.ya?ml
+          )$
+      - id: check-json
+      - id: fix-byte-order-marker
+      - id: mixed-line-ending
+        args: ['--fix=lf']
+      - id: end-of-file-fixer
+  - repo: https://github.com/bridgecrewio/checkov.git
+    rev: 2.0.1211
+    hooks:
+    - id: checkov
+      args: [--config, .checkov/config.yml]
+      files: \.yaml$

--- a/helm/alfresco-common/templates/_helpers-search.tpl
+++ b/helm/alfresco-common/templates/_helpers-search.tpl
@@ -10,7 +10,11 @@ Alfresco Search2 Host
 */}}
 {{- define "alfresco-search.host" -}}
 {{- if index $.Values "alfresco-search" "enabled" -}}
+  {{- if index $.Values "alfresco-search" "replication" "enabled" -}}
+  {{ printf "%s-solr-slave" (include "alfresco-search.fullName" .) -}}
+  {{- else -}}
   {{ printf "%s-solr" (include "alfresco-search.fullName" .) -}}
+  {{- end -}}
 {{- else -}}
   {{ index $.Values "alfresco-search" "external" "host" | default "localhost" -}}
 {{- end -}}

--- a/helm/alfresco-content-services/charts/alfresco-search/templates/config-slave.yaml
+++ b/helm/alfresco-content-services/charts/alfresco-search/templates/config-slave.yaml
@@ -1,8 +1,9 @@
 # Defines the properties required by the Alfresco Search (Solr) App
+{{ if .Values.replication.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "alfresco-search.fullName" . }}-solr-configmap
+  name: {{ template "alfresco-search.fullName" . }}-solr-slave-configmap
   labels:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
@@ -12,16 +13,15 @@ data:
   ALFRESCO_SECURE_COMMS: {{ .Values.global.tracking.auth | default "secret" }}
   SOLR_ALFRESCO_HOST: "{{ .Release.Name }}-{{ .Values.repository.host }}-repository"
   SOLR_ALFRESCO_PORT: "{{ .Values.repository.port }}"
-  SOLR_SOLR_HOST: "{{ template "alfresco-search.fullName" . }}-solr"
+  SOLR_SOLR_HOST: "{{ template "alfresco-search.fullName" . }}-solr-slave"
   SOLR_SOLR_PORT: "{{ .Values.service.externalPort }}"
-  {{- if .Values.replication.enabled }}
-  REPLICATION_TYPE: "master"
-  REPLICATION_AFTER: "commit,startup"
-  REPLICATION_CONFIG_FILES: "schema.xml,stopwords.txt"
-  {{- end }}
+  REPLICATION_TYPE: "slave"
+  REPLICATION_MASTER_HOST: "{{ template "alfresco-search.fullName" . }}-solr"
+  REPLICATION_MASTER_PORT: "80"
   # The values for SOLR_CREATE_ALFRESCO_DEFAULTS and SOLR_OPTS, defined in the values.yaml for "search" are set next:
   {{- if .Values.environment }}
   {{- range $key, $val := .Values.environment }}
   {{ $key }}: {{ $val | quote }}
   {{- end }}
   {{- end }}
+{{ end }}

--- a/helm/alfresco-content-services/charts/alfresco-search/templates/service-headless-slave.yaml
+++ b/helm/alfresco-content-services/charts/alfresco-search/templates/service-headless-slave.yaml
@@ -1,0 +1,19 @@
+{{ if .Values.replication.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "alfresco-search.fullName" . }}-solr-slave-headless
+  labels:
+    app: {{ template "alfresco-search.fullName" . }}-solr-slave-headless
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  clusterIP: None
+  ports:
+    - port: {{ template "alfresco-search.internalPort" . }}
+      name: {{ .Values.service.name }}
+  selector:
+    app: {{ template "alfresco-search.fullName" . }}-solr-slave
+    release: {{ .Release.Name }}
+{{ end }}

--- a/helm/alfresco-content-services/charts/alfresco-search/templates/service-slave.yaml
+++ b/helm/alfresco-content-services/charts/alfresco-search/templates/service-slave.yaml
@@ -1,0 +1,21 @@
+# Defines the service for the Alfresco Search (Solr) App slaves
+{{ if .Values.replication.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "alfresco-search.fullName" . }}-solr-slave
+  labels:
+    app: {{ template "alfresco-search.fullName" . }}-solr-slave
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.externalPort }}
+      targetPort: {{ template "alfresco-search.internalPort" . }}
+      name: {{ .Values.service.name }}
+  selector:
+    app: {{ template "alfresco-search.fullName" . }}-solr-slave
+    release: {{ .Release.Name }}
+{{ end }}

--- a/helm/alfresco-content-services/charts/alfresco-search/templates/statefulset-slave.yaml
+++ b/helm/alfresco-content-services/charts/alfresco-search/templates/statefulset-slave.yaml
@@ -1,0 +1,114 @@
+{{ if .Values.replication.enabled }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ template "alfresco-search.fullName" . }}-solr-slave
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "alfresco-search.fullName" . }}-solr-slave
+      chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+      release: {{ .Release.Name }}
+      heritage: {{ .Release.Service }}
+      component: search
+  serviceName: {{ template "alfresco-search.fullName" . }}-solr-slave-headless
+  replicas: {{ .Values.replication.replicaCount }}
+  minReadySeconds: 10
+  template:
+    metadata:
+      labels:
+        app: {{ template "alfresco-search.fullName" . }}-solr-slave
+        chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        release: {{ .Release.Name }}
+        heritage: {{ .Release.Service }}
+        component: search
+    spec:
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                topologyKey: kubernetes.io/hostname
+                labelSelector:
+                  matchExpressions:
+                    - key: app
+                      operator: In
+                      values:
+                        - {{ template "alfresco-search.fullName" . }}-solr-slave
+              weight: 100
+      terminationGracePeriodSeconds: 10
+      containers:
+        - name: {{ .Chart.Name }}
+          image: {{ template "alfresco-search.dockerImage" . }}
+          imagePullPolicy: {{ template "alfresco-search.pullPolicy" . }}
+          envFrom:
+            - configMapRef:
+                name: {{ template "alfresco-search.fullName" . }}-solr-slave-configmap
+          {{- if and (eq .Values.global.tracking.auth "secret") (.Values.global.tracking.sharedsecret) }}
+            - secretRef:
+                name: {{ printf "%s-solr-jtoolopts" .Release.Name | quote }}
+          {{- end }}
+          ports:
+            - containerPort: {{ template "alfresco-search.internalPort" . }}
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+          volumeMounts:
+            - name: data
+              mountPath: {{ .Values.persistence.search.data.mountPath }}
+              subPath: {{ .Values.persistence.search.data.subPath }}
+          readinessProbe:
+            httpGet:
+              path: /solr/alfresco/admin/ping
+              port: {{ template "alfresco-search.internalPort" . }}
+              {{- if eq .Values.global.tracking.auth "secret" }}
+              httpHeaders:
+                - name: X-Alfresco-Search-Secret
+                  value: "{{ .Values.global.tracking.sharedsecret }}"
+              {{- end }}
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+          livenessProbe:
+            httpGet:
+              path: /solr/admin/info/system
+              port: {{ template "alfresco-search.internalPort" . }}
+              {{- if eq .Values.global.tracking.auth "secret" }}
+              httpHeaders:
+                - name: X-Alfresco-Search-Secret
+                  value: "{{ .Values.global.tracking.sharedsecret }}"
+              {{- end }}
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            failureThreshold: 1
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+          # sleep to drain any existing connections
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/bash", "-c", "sleep 10"]
+      initContainers:
+        - name: init-fs
+          image: "{{ .Values.initContainer.image.repository }}:{{ .Values.initContainer.image.tag }}"
+          imagePullPolicy: {{ .Values.initContainer.image.pullPolicy }}
+          resources:
+{{ toYaml .Values.initContainer.resources | indent 14 }}
+          # command to allow solr to write to EFS volume. Details: https://issues.alfresco.com/jira/browse/DEPLOY-419
+          command: ["sh", "-c", "chown -R 33007:33007 {{ .Values.persistence.search.data.mountPath }}"]
+          volumeMounts:
+            - name: data
+              mountPath: {{ .Values.persistence.search.data.mountPath }}
+              subPath: {{ .Values.persistence.search.data.subPath }}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: [ "ReadWriteOnce" ]
+        storageClassName: {{ .Values.replication.persistence.storageClassName}}
+        resources:
+          requests:
+            storage: {{ .Values.replication.persistence.volumeSizeRequest }}
+
+{{ end }}

--- a/helm/alfresco-content-services/charts/alfresco-search/values.yaml
+++ b/helm/alfresco-content-services/charts/alfresco-search/values.yaml
@@ -127,3 +127,12 @@ global:
 #         operator: In
 #         values:
 #         - "true"
+
+# -- Define replication settings for User-Managed Index Replication
+# https://solr.apache.org/guide/solr/latest/deployment-guide/user-managed-index-replication.html
+replication:
+  enabled: false
+  replicaCount: 2
+  persistence:
+    volumeSizeRequest: 10Gi
+    storageClassName: "default"


### PR DESCRIPTION
Search services replication

By default Alfresco [already supports](https://docs.alfresco.com/insight-engine/latest/config/replication/) master-slave replication for the search services, however it wasn't available yet within the helm chart. The implementation that I propose is based on the [docker-compose example](https://github.com/Alfresco/SearchServices/tree/master/search-services/packaging/src/docker/6.x) which resides in the search-services repository. There's also a change in the alfresco-common chart because of the function that is used to define the alfresco-search host.

We are running this in our own environment and everything seems to work like it does with the docker-compose example. If there are any suggestions, feel free to submit them. And if anything needs to be changed, please let me know.

Thank you in advance.

I've read the contribution guideline and I accept the Alfresco Contribution Agreement.
