### PR TITLE
OPSEXP-1766 Fixup helm deployment error

### DIFF
--- a/helm/alfresco-content-services/templates/config-repository.yaml
+++ b/helm/alfresco-content-services/templates/config-repository.yaml
@@ -39,11 +39,7 @@ data:
       -Dshare.host={{ tpl (.Values.externalHost | default (printf "%s-share" (include "content-services.shortname" .))) $ }}
       -Dshare.port={{ tpl (.Values.externalPort | default .Values.share.service.externalPort | toString) $ }}
       -Dalfresco_user_store.adminpassword={{ .Values.repository.adminPassword | default "209c6174da490caeb422f3fa5a7ae634" }}
-      {{- if and 
-        (not (index .Values "alfresco-search" "enabled"))
-        (not (index .Values "alfresco-elasticsearch-connector" "enabled"))
-        (not (index .Values "alfresco-search" "external" "host"))
-      }}
+      {{- if and (not (index .Values "alfresco-search" "enabled")) (not (index .Values "alfresco-elasticsearch-connector" "enabled")) (not (index .Values "alfresco-search" "external" "host")) }}
       -Dindex.subsystem.name=none
       {{- else if or (index .Values "alfresco-search" "enabled") (index .Values "alfresco-search" "external" "host") }}
       -Dindex.subsystem.name=solr6


### PR DESCRIPTION
previous change seem to break fluxcd helm-operator for whatever reason.

```
Warning  FailedReleaseSync  25m (x4 over 21h)    helm-operator  synchronization of release 'acs' in namespace 'acs' failed: failed to prepare chart for release: no cached repository for helm-manager-73205d3bb7f8cb7f05718c543008b393734fbfa7f524827aa27edb8da704707e found. (try 'helm repo update'): error loading /root/.cache/helm/repository/helm-manager-73205d3bb7f8cb7f05718c543008b393734fbfa7f524827aa27edb8da704707e-index.yaml: no API version specified
  Warning  FailedReleaseSync  92s (x303 over 15h)  helm-operator  synchronization of release 'acs' in namespace 'acs' failed: dry-run upgrade failed: dry-run upgrade for comparison failed: parse error at (alfresco-content-services/templates/config-repository.yaml:42): unclosed action
```

Tested on @kavitshah-gl  branch https://github.com/Alfresco/terraform-alfresco-pipeline/tree/OPSEXP-1767-env