### PR TITLE
OPSEXP-1812 Fix for missing trustAnchors in repository deployment

### DIFF
--- a/.github/workflows/helm-community.yml
+++ b/.github/workflows/helm-community.yml
@@ -57,12 +57,18 @@ jobs:
         uses: helm/kind-action@v1.4.0
         with:
           config: test/kind-ingress-enabled-cluster.yaml
-      - name: Install NGINX ingress
+      - name: Install nginx ingress
         env:
           NGINX_MANIFEST: |
             https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/kind/deploy.yaml
         run: |
-          kubectl apply -f ${{ env.NGINX_MANIFEST }}
+          kubectl apply -f $NGINX_MANIFEST
+      - name: Wait for nginx ingress ready
+        run: |
+          kubectl wait --namespace ingress-nginx \
+            --for=condition=ready pod \
+            --selector=app.kubernetes.io/component=controller \
+            --timeout=90s
       - name: Use local dependencies
         uses: ./.github/actions/use-local-deps
         with:

--- a/helm/alfresco-content-services/templates/config-repository.yaml
+++ b/helm/alfresco-content-services/templates/config-repository.yaml
@@ -154,3 +154,4 @@ data:
       -Dmessaging.broker.url=$BROKER_URL
       -Dmessaging.broker.username=$BROKER_USERNAME
       -Dmessaging.broker.password=$BROKER_PASSWORD
+      -Dencryption.ssl.truststore.location=/etc/pki/java/cacerts

--- a/helm/alfresco-content-services/templates/config-repository.yaml
+++ b/helm/alfresco-content-services/templates/config-repository.yaml
@@ -154,4 +154,4 @@ data:
       -Dmessaging.broker.url=$BROKER_URL
       -Dmessaging.broker.username=$BROKER_USERNAME
       -Dmessaging.broker.password=$BROKER_PASSWORD
-      -Dencryption.ssl.truststore.location=/etc/pki/java/cacerts
+      -Dencryption.ssl.truststore.location=$JAVA_HOME/lib/security/cacerts

--- a/helm/alfresco-content-services/tests/repository_test.yaml
+++ b/helm/alfresco-content-services/tests/repository_test.yaml
@@ -14,9 +14,7 @@ tests:
       - equal:
           path: metadata.name
           value: RELEASE-NAME-alfresco-cs-repository
-      - equal:
-          path: spec.template.metadata.annotations.checksum/config
-          value: 65b89491b06b9ccd8146424a8eab9d7a9d109a18db722e1276f1223ee37fd47c
+        template: deployment-repository.yaml
   - it: should have basic metadata in place
     values: *testvalues
     asserts:
@@ -26,5 +24,5 @@ tests:
         template: config-repository.yaml
       - matchRegex:
           path: data.CATALINA_OPTS
-          pattern: -Dencryption.ssl.truststore.location=/.*
+          pattern: -Dencryption.ssl.truststore.location=\$JAVA_HOME/lib/security/cacerts
         template: config-repository.yaml

--- a/helm/alfresco-content-services/tests/repository_test.yaml
+++ b/helm/alfresco-content-services/tests/repository_test.yaml
@@ -18,8 +18,7 @@ tests:
           path: spec.template.metadata.annotations.checksum/config
           value: 65b89491b06b9ccd8146424a8eab9d7a9d109a18db722e1276f1223ee37fd47c
   - it: should have basic metadata in place
-    values: &testvalues
-      - values/test_values.yaml
+    values: *testvalues
     asserts:
       - equal:
           path: metadata.name

--- a/helm/alfresco-content-services/tests/repository_test.yaml
+++ b/helm/alfresco-content-services/tests/repository_test.yaml
@@ -1,0 +1,31 @@
+---
+suite: test repository manifest
+templates:
+  - deployment-repository.yaml
+  - config-repository.yaml
+  - secret-database.yaml
+  - secret-s3.yaml
+  - config-dev-log4j-properties.yaml
+tests:
+  - it: should have basic metadata in place
+    values: &testvalues
+      - values/test_values.yaml
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-alfresco-cs-repository
+      - equal:
+          path: spec.template.metadata.annotations.checksum/config
+          value: 65b89491b06b9ccd8146424a8eab9d7a9d109a18db722e1276f1223ee37fd47c
+  - it: should have basic metadata in place
+    values: &testvalues
+      - values/test_values.yaml
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-alfresco-cs-repository-configmap
+        template: config-repository.yaml
+      - matchRegex:
+          path: data.CATALINA_OPTS
+          pattern: -Dencryption.ssl.truststore.location=/.*
+        template: config-repository.yaml


### PR DESCRIPTION
```
2022-10-14 14:40:09,598 ERROR [org.alfresco.repo.search.impl.elasticsearch.contentmodelsync.ElasticsearchIndexServic
e] [elasticsearch-initializer] Failed to check if basic mapping is loaded on alfresco
java.io.IOException: java.security.InvalidAlgorithmParameterException: the trustAnchors parameter must be non-empty
        at org.elasticsearch.client.RestClient.extractAndWrapCause(RestClient.java:884)
```

OPSEXP-1812