### PR TITLE
wait for nginx-ingress during community workflow

### DIFF
--- a/.github/workflows/helm-community.yml
+++ b/.github/workflows/helm-community.yml
@@ -57,12 +57,18 @@ jobs:
         uses: helm/kind-action@v1.4.0
         with:
           config: test/kind-ingress-enabled-cluster.yaml
-      - name: Install NGINX ingress
+      - name: Install nginx ingress
         env:
           NGINX_MANIFEST: |
             https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/kind/deploy.yaml
         run: |
-          kubectl apply -f ${{ env.NGINX_MANIFEST }}
+          kubectl apply -f $NGINX_MANIFEST
+      - name: Wait for nginx ingress ready
+        run: |
+          kubectl wait --namespace ingress-nginx \
+            --for=condition=ready pod \
+            --selector=app.kubernetes.io/component=controller \
+            --timeout=90s
       - name: Use local dependencies
         uses: ./.github/actions/use-local-deps
         with:


### PR DESCRIPTION
Fix for random:

```
Error: INSTALLATION FAILED: Internal error occurred: failed calling webhook "validate.nginx.ingress.kubernetes.io": failed to call webhook: Post "[https://ingress-nginx-controller-admission.ingress-nginx.svc:443/networking/v1/ingresses?timeout=10s](https://ingress-nginx-controller-admission.ingress-nginx.svc/networking/v1/ingresses?timeout=10s)": dial tcp 10.96.190.34:443: connect: connection refused
```

https://github.com/Alfresco/acs-deployment/actions/runs/3330378271/jobs/5508815454#step:6:26