### PR TITLE
OPSEXP-1875: exclude actual go templates

### DIFF
--- a/.github/workflows/bumpVersions.yml
+++ b/.github/workflows/bumpVersions.yml
@@ -1,0 +1,53 @@
+---
+name: Bump component versions
+
+on:
+  workflow_dispatch:
+    inputs:
+      ticket:
+        description: ticket reference for the requested update
+        required: true
+
+permissions:
+  contents: "write"
+  pull-requests: "write"
+
+jobs:
+  updatecli:
+    runs-on: "ubuntu-latest"
+    strategy:
+      matrix:
+        version:
+          - latest
+          - 7.3.N
+          - 7.2.N
+          - 7.1.N
+          - 7.0.N
+          - community
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install Updatecli
+        uses: updatecli/updatecli-action@v2
+
+      - name: Run Updatecli in apply mode
+        env:
+          QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
+          QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
+          UPDATECLI_MANIFEST: ${{ matrix.version }}-manifest.yaml
+          MATRIX_FILE: /tmp/${{ matrix.version }}-matrix.yaml
+          UPDATECLI_GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          yq e '.matrix["${{ matrix.version }}"]' supported-matrix.yaml \
+          | tee > "$MATRIX_FILE"
+          updatecli apply -c "$UPDATECLI_MANIFEST" -v "$MATRIX_FILE"
+
+      - name: commit changes & open PR
+        shell:  bash
+        run: |
+          git checkout -b ${{ inputs.ticket }}-$GITHUB_RUN_ID
+          git commit -m "bumped" -- docker-compose/ helm/
+          git push
+          gh pr create -d -t "updatecli version bump" \
+            -b "${{ inputs.ticket }}" -l component-versions

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
     hooks:
       - id: check-yaml
         args: [--allow-multiple-documents]
-        exclude: helm/.*/templates
+        exclude: (helm/.*/templates)|(updatecli.d/.*-manifest.ya?ml)
       - id: check-json
       - id: check-merge-conflict
       - id: fix-byte-order-marker

--- a/updatecli.d/7.0.N-manifest.yaml
+++ b/updatecli.d/7.0.N-manifest.yaml
@@ -1,0 +1,137 @@
+---
+name: Images updates for ACS 7.0.N
+
+{{- define "quay_auth" }}
+      username: {{ requiredEnv "QUAY_USERNAME" }}
+      password: {{ requiredEnv "QUAY_PASSWORD" }}
+{{- end }}
+
+{{- define "wip_pattern" -}}
+  (-[AM]\.?[0-9]+)?
+{{- end }}
+
+{{- define "hf_pattern" -}}
+  (\.[0-9]+){1,3}
+{{- end }}
+
+{{- define "ga_pattern" -}}
+  (\.[0-9]+){1,2}
+{{- end }}
+
+scms:
+
+sources:
+  syncTag:
+    name: Sync Service image tag
+    kind: dockerimage
+    spec:
+      image: quay.io/alfresco/service-sync
+      {{ template "quay_auth" }}
+      versionFilter:
+        kind: regex
+        pattern: >-
+          ^{{ index . "sync" "version" }}{{ template "hf_pattern" }}$
+  adwTag:
+    name: Alfresco Digital Workspace tag
+    kind: dockerimage
+    spec:
+      image: quay.io/alfresco/alfresco-digital-workspace
+      {{ template "quay_auth" }}
+      versionFilter:
+        kind: regex
+        pattern: >-
+          ^{{ index . "adw" "version" }}{{ template "ga_pattern" }}$
+  repositoryTag:
+    name: ACS repository tag
+    kind: dockerimage
+    spec:
+      image: quay.io/alfresco/alfresco-content-repository
+      {{ template "quay_auth" }}
+      versionFilter:
+        kind: regex
+        pattern: >-
+          ^{{ index . "acs" "version" }}{{ template "hf_pattern" }}$
+  shareTag:
+    name: Share repository tag
+    kind: dockerimage
+    spec:
+      image: quay.io/alfresco/alfresco-share
+      {{ template "quay_auth" }}
+      versionFilter:
+        kind: regex
+        pattern: >-
+          ^{{ index . "share" "version" }}{{ template "hf_pattern" }}$
+
+targets:
+  repositoryCompose:
+    name: Repo image tag
+    kind: yaml
+    sourceid: repositoryTag
+    transformers:
+      - addprefix: "quay.io/alfresco/alfresco-content-repository:"
+    spec:
+      file: {{ .acs.compose_target }}
+      key: >-
+        {{ .acs.compose_key }}
+  repositoryValues:
+    name: Repo image tag
+    kind: yaml
+    sourceid: repositoryTag
+    spec:
+      file: {{ .acs.helm_target }}
+      key: >-
+        {{ .acs.helm_key }}
+  shareCompose:
+    name: Share image tag
+    kind: yaml
+    sourceid: shareTag
+    transformers:
+      - addprefix: "quay.io/alfresco/alfresco-share:"
+    spec:
+      file: {{ .share.compose_target }}
+      key: >-
+        {{ .share.compose_key }}
+  shareValues:
+    name: Share image tag
+    kind: yaml
+    sourceid: shareTag
+    spec:
+      file: {{ .share.helm_target }}
+      key: >-
+        {{ .share.helm_key }}
+  syncCompose:
+    name: Sync image tag
+    kind: yaml
+    sourceid: syncTag
+    transformers:
+      - addprefix: "quay.io/alfresco/service-sync:"
+    spec:
+      file: {{ .sync.compose_target }}
+      key: >-
+        {{ .sync.compose_key }}
+  syncValues:
+    name: Sync image tag
+    kind: yaml
+    sourceid: syncTag
+    spec:
+      file: {{ .sync.helm_target }}
+      key: >-
+        {{ .sync.helm_key }}
+  adwCompose:
+    name: ADW image tag
+    kind: yaml
+    sourceid: adwTag
+    transformers:
+      - addprefix: "quay.io/alfresco/alfresco-digital-workspace:"
+    spec:
+      file: {{ .adw.compose_target }}
+      key: >-
+        {{ .adw.compose_key }}
+  adwValues:
+    name: ADW image tag
+    kind: yaml
+    sourceid: adwTag
+    spec:
+      file: {{ .adw.helm_target }}
+      key: >-
+        {{ .adw.helm_key }}

--- a/updatecli.d/7.1.N-manifest.yaml
+++ b/updatecli.d/7.1.N-manifest.yaml
@@ -1,0 +1,173 @@
+---
+name: Images updates for ACS 7.1.N
+
+{{- define "quay_auth" }}
+      username: {{ requiredEnv "QUAY_USERNAME" }}
+      password: {{ requiredEnv "QUAY_PASSWORD" }}
+{{- end }}
+
+{{- define "wip_pattern" -}}
+  (-[AM]\.?[0-9]+)?
+{{- end }}
+
+{{- define "hf_pattern" -}}
+  (\.[0-9]+){1,3}
+{{- end }}
+
+{{- define "ga_pattern" -}}
+  (\.[0-9]+){1,2}
+{{- end }}
+
+scms:
+  searchEnterprise:
+    name: Alfresco Elasticsearch connector
+    kind: github
+    spec:
+      owner: Alfresco
+      repository: alfresco-elasticsearch-connector
+      branch: master
+      username: alfresco-build
+      token: {{ requiredEnv "GITHUB_TOKEN" }}
+      directory: /tmp/updatecli/searchEnterprise
+
+sources:
+  syncTag:
+    name: Sync Service image tag
+    kind: dockerimage
+    spec:
+      image: quay.io/alfresco/service-sync
+      {{ template "quay_auth" }}
+      versionFilter:
+        kind: regex
+        pattern: >-
+          ^{{ index . "sync" "version" }}{{ template "hf_pattern" }}$
+  adwTag:
+    name: Alfresco Digital Workspace tag
+    kind: dockerimage
+    spec:
+      image: quay.io/alfresco/alfresco-digital-workspace
+      {{ template "quay_auth" }}
+      versionFilter:
+        kind: regex
+        pattern: >-
+          ^{{ index . "adw" "version" }}{{ template "ga_pattern" }}$
+  searchEnterpriseTag:
+    name: Search Enterprise tag
+    kind: gittag
+    scmid: searchEnterprise
+    spec:
+      versionFilter:
+        kind: regex
+        pattern: >-
+          ^{{ index . "search-enterprise" "version" }}{{ template "hf_pattern" }}$
+  repositoryTag:
+    name: ACS repository tag
+    kind: dockerimage
+    spec:
+      image: quay.io/alfresco/alfresco-content-repository
+      {{ template "quay_auth" }}
+      versionFilter:
+        kind: regex
+        pattern: >-
+          ^{{ index . "acs" "version" }}{{ template "hf_pattern" }}$
+  shareTag:
+    name: Share repository tag
+    kind: dockerimage
+    spec:
+      image: quay.io/alfresco/alfresco-share
+      {{ template "quay_auth" }}
+      versionFilter:
+        kind: regex
+        pattern: >-
+          ^{{ index . "share" "version" }}{{ template "hf_pattern" }}$
+
+targets:
+  repositoryCompose:
+    name: Repo image tag
+    kind: yaml
+    sourceid: repositoryTag
+    transformers:
+      - addprefix: "quay.io/alfresco/alfresco-content-repository:"
+    spec:
+      file: {{ .acs.compose_target }}
+      key: >-
+        {{ .acs.compose_key }}
+  repositoryValues:
+    name: Repo image tag
+    kind: yaml
+    sourceid: repositoryTag
+    spec:
+      file: {{ .acs.helm_target }}
+      key: >-
+        {{ .acs.helm_key }}
+  shareCompose:
+    name: Share image tag
+    kind: yaml
+    sourceid: shareTag
+    transformers:
+      - addprefix: "quay.io/alfresco/alfresco-share:"
+    spec:
+      file: {{ .share.compose_target }}
+      key: >-
+        {{ .share.compose_key }}
+  shareValues:
+    name: Share image tag
+    kind: yaml
+    sourceid: shareTag
+    spec:
+      file: {{ .share.helm_target }}
+      key: >-
+        {{ .share.helm_key }}
+  syncCompose:
+    name: Sync image tag
+    kind: yaml
+    sourceid: syncTag
+    transformers:
+      - addprefix: "quay.io/alfresco/service-sync:"
+    spec:
+      file: {{ .sync.compose_target }}
+      key: >-
+        {{ .sync.compose_key }}
+  syncValues:
+    name: Sync image tag
+    kind: yaml
+    sourceid: syncTag
+    spec:
+      file: {{ .sync.helm_target }}
+      key: >-
+        {{ .sync.helm_key }}
+  {{- $target_searchEnt := index . "search-enterprise" "helm_target" }}
+  searchEnterpriseReindexingValues:
+    name: Search Enterprise image tag
+    kind: yaml
+    sourceid: searchEnterpriseTag
+    spec:
+      file: {{ $target_searchEnt }}
+      key: {{ index . "search-enterprise" "helm_keys" "Reindexing" }}
+  {{- range $key, $value := index . "search-enterprise" "helm_keys" "Liveindexing" }}
+  searchEnterprise{{ $key }}Values:
+    name: Search Enterprise image tag
+    kind: yaml
+    sourceid: searchEnterpriseTag
+    spec:
+      file: {{ $target_searchEnt }}
+      key: {{ $value }}
+  {{- end }}
+  adwCompose:
+    name: ADW image tag
+    kind: yaml
+    sourceid: adwTag
+    transformers:
+      - addprefix: "quay.io/alfresco/alfresco-digital-workspace:"
+    spec:
+      file: {{ .adw.compose_target }}
+      key: >-
+        {{ .adw.compose_key }}
+  adwValues:
+    name: ADW image tag
+    kind: yaml
+    sourceid: adwTag
+    spec:
+      file: {{ .adw.helm_target }}
+      key: >-
+        {{ .adw.helm_key }}

--- a/updatecli.d/7.2.N-manifest.yaml
+++ b/updatecli.d/7.2.N-manifest.yaml
@@ -1,0 +1,201 @@
+---
+name: Images updates for ACS 7.2.N
+
+{{- define "quay_auth" }}
+      username: {{ requiredEnv "QUAY_USERNAME" }}
+      password: {{ requiredEnv "QUAY_PASSWORD" }}
+{{- end }}
+
+{{- define "wip_pattern" -}}
+  (-[AM]\.?[0-9]+)?
+{{- end }}
+
+{{- define "hf_pattern" -}}
+  (\.[0-9]+){1,3}
+{{- end }}
+
+{{- define "ga_pattern" -}}
+  (\.[0-9]+){1,2}
+{{- end }}
+
+scms:
+  searchEnterprise:
+    name: Alfresco Elasticsearch connector
+    kind: github
+    spec:
+      owner: Alfresco
+      repository: alfresco-elasticsearch-connector
+      branch: master
+      username: alfresco-build
+      token: {{ requiredEnv "GITHUB_TOKEN" }}
+      directory: /tmp/updatecli/searchEnterprise
+
+sources:
+  syncTag:
+    name: Sync Service image tag
+    kind: dockerimage
+    spec:
+      image: quay.io/alfresco/service-sync
+      {{ template "quay_auth" }}
+      versionFilter:
+        kind: regex
+        pattern: >-
+          ^{{ index . "sync" "version" }}{{ template "hf_pattern" }}$
+  adwTag:
+    name: Alfresco Digital Workspace tag
+    kind: dockerimage
+    spec:
+      image: quay.io/alfresco/alfresco-digital-workspace
+      {{ template "quay_auth" }}
+      versionFilter:
+        kind: regex
+        pattern: >-
+          ^{{ index . "adw" "version" }}{{ template "ga_pattern" }}$
+  searchEnterpriseTag:
+    name: Search Enterprise tag
+    kind: gittag
+    scmid: searchEnterprise
+    spec:
+      versionFilter:
+        kind: regex
+        pattern: >-
+          ^{{ index . "search-enterprise" "version" }}{{ template "hf_pattern" }}$
+  repositoryTag:
+    name: ACS repository tag
+    kind: dockerimage
+    spec:
+      image: quay.io/alfresco/alfresco-content-repository
+      {{ template "quay_auth" }}
+      versionFilter:
+        kind: regex
+        pattern: >-
+          ^{{ index . "acs" "version" }}{{ template "hf_pattern" }}$
+  shareTag:
+    name: Share repository tag
+    kind: dockerimage
+    spec:
+      image: quay.io/alfresco/alfresco-share
+      {{ template "quay_auth" }}
+      versionFilter:
+        kind: regex
+        pattern: >-
+          ^{{ index . "share" "version" }}{{ template "hf_pattern" }}$
+  adminAppTag:
+    name: Alfresco admin application tag
+    kind: dockerimage
+    spec:
+      image: quay.io/alfresco/alfresco-admin-app
+      {{ template "quay_auth" }}
+      versionFilter:
+        kind: regex
+        pattern: >-
+          ^{{ index . "adminApp" "version" }}{{ template "ga_pattern" }}$
+
+targets:
+  repositoryCompose:
+    name: Repo image tag
+    kind: yaml
+    sourceid: repositoryTag
+    transformers:
+      - addprefix: "quay.io/alfresco/alfresco-content-repository:"
+    spec:
+      file: {{ .acs.compose_target }}
+      key: >-
+        {{ .acs.compose_key }}
+  repositoryValues:
+    name: Repo image tag
+    kind: yaml
+    sourceid: repositoryTag
+    spec:
+      file: {{ .acs.helm_target }}
+      key: >-
+        {{ .acs.helm_key }}
+  shareCompose:
+    name: Share image tag
+    kind: yaml
+    sourceid: shareTag
+    transformers:
+      - addprefix: "quay.io/alfresco/alfresco-share:"
+    spec:
+      file: {{ .share.compose_target }}
+      key: >-
+        {{ .share.compose_key }}
+  shareValues:
+    name: Share image tag
+    kind: yaml
+    sourceid: shareTag
+    spec:
+      file: {{ .share.helm_target }}
+      key: >-
+        {{ .share.helm_key }}
+  syncCompose:
+    name: Sync image tag
+    kind: yaml
+    sourceid: syncTag
+    transformers:
+      - addprefix: "quay.io/alfresco/service-sync:"
+    spec:
+      file: {{ .sync.compose_target }}
+      key: >-
+        {{ .sync.compose_key }}
+  syncValues:
+    name: Sync image tag
+    kind: yaml
+    sourceid: syncTag
+    spec:
+      file: {{ .sync.helm_target }}
+      key: >-
+        {{ .sync.helm_key }}
+  {{- $target_searchEnt := index . "search-enterprise" "helm_target" }}
+  searchEnterpriseReindexingValues:
+    name: Search Enterprise image tag
+    kind: yaml
+    sourceid: searchEnterpriseTag
+    spec:
+      file: {{ $target_searchEnt }}
+      key: {{ index . "search-enterprise" "helm_keys" "Reindexing" }}
+  {{- range $key, $value := index . "search-enterprise" "helm_keys" "Liveindexing" }}
+  searchEnterprise{{ $key }}Values:
+    name: Search Enterprise image tag
+    kind: yaml
+    sourceid: searchEnterpriseTag
+    spec:
+      file: {{ $target_searchEnt }}
+      key: {{ $value }}
+  {{- end }}
+  adwCompose:
+    name: ADW image tag
+    kind: yaml
+    sourceid: adwTag
+    transformers:
+      - addprefix: "quay.io/alfresco/alfresco-digital-workspace:"
+    spec:
+      file: {{ .adw.compose_target }}
+      key: >-
+        {{ .adw.compose_key }}
+  adwValues:
+    name: ADW image tag
+    kind: yaml
+    sourceid: adwTag
+    spec:
+      file: {{ .adw.helm_target }}
+      key: >-
+        {{ .adw.helm_key }}
+  adminAppCompose:
+    name: Alfresco Control Center
+    kind: yaml
+    sourceid: adminAppTag
+    transformers:
+      - addprefix: "quay.io/alfresco/alfresco-admin-app:"
+    spec:
+      file: {{ .adminApp.compose_target }}
+      key: >-
+        {{ .adminApp.compose_key }}
+  adminAppValues:
+    name: Helm chart default values file
+    kind: yaml
+    sourceid: adminAppTag
+    spec:
+      file: {{ .adminApp.helm_target }}
+      key: >-
+        {{ .adminApp.helm_key }}

--- a/updatecli.d/7.3.N-manifest.yaml
+++ b/updatecli.d/7.3.N-manifest.yaml
@@ -1,0 +1,201 @@
+---
+name: Images updates for ACS 7.3.N
+
+{{- define "quay_auth" }}
+      username: {{ requiredEnv "QUAY_USERNAME" }}
+      password: {{ requiredEnv "QUAY_PASSWORD" }}
+{{- end }}
+
+{{- define "wip_pattern" -}}
+  (-[AM]\.?[0-9]+)?
+{{- end }}
+
+{{- define "hf_pattern" -}}
+  (\.[0-9]+){1,3}
+{{- end }}
+
+{{- define "ga_pattern" -}}
+  (\.[0-9]+){1,2}
+{{- end }}
+
+scms:
+  searchEnterprise:
+    name: Alfresco Elasticsearch connector
+    kind: github
+    spec:
+      owner: Alfresco
+      repository: alfresco-elasticsearch-connector
+      branch: master
+      username: alfresco-build
+      token: {{ requiredEnv "GITHUB_TOKEN" }}
+      directory: /tmp/updatecli/searchEnterprise
+
+sources:
+  syncTag:
+    name: Sync Service image tag
+    kind: dockerimage
+    spec:
+      image: quay.io/alfresco/service-sync
+      {{ template "quay_auth" }}
+      versionFilter:
+        kind: regex
+        pattern: >-
+          ^{{ index . "sync" "version" }}{{ template "hf_pattern" }}$
+  adwTag:
+    name: Alfresco Digital Workspace tag
+    kind: dockerimage
+    spec:
+      image: quay.io/alfresco/alfresco-digital-workspace
+      {{ template "quay_auth" }}
+      versionFilter:
+        kind: regex
+        pattern: >-
+          ^{{ index . "adw" "version" }}{{ template "ga_pattern" }}$
+  searchEnterpriseTag:
+    name: Search Enterprise tag
+    kind: gittag
+    scmid: searchEnterprise
+    spec:
+      versionFilter:
+        kind: regex
+        pattern: >-
+          ^{{ index . "search-enterprise" "version" }}{{ template "hf_pattern" }}$
+  repositoryTag:
+    name: ACS repository tag
+    kind: dockerimage
+    spec:
+      image: quay.io/alfresco/alfresco-content-repository
+      {{ template "quay_auth" }}
+      versionFilter:
+        kind: regex
+        pattern: >-
+          ^{{ index . "acs" "version" }}{{ template "hf_pattern" }}$
+  shareTag:
+    name: Share repository tag
+    kind: dockerimage
+    spec:
+      image: quay.io/alfresco/alfresco-share
+      {{ template "quay_auth" }}
+      versionFilter:
+        kind: regex
+        pattern: >-
+          ^{{ index . "share" "version" }}{{ template "hf_pattern" }}$
+  adminAppTag:
+    name: Alfresco admin application tag
+    kind: dockerimage
+    spec:
+      image: quay.io/alfresco/alfresco-admin-app
+      {{ template "quay_auth" }}
+      versionFilter:
+        kind: regex
+        pattern: >-
+          ^{{ index . "adminApp" "version" }}{{ template "ga_pattern" }}$
+
+targets:
+  repositoryCompose:
+    name: Repo image tag
+    kind: yaml
+    sourceid: repositoryTag
+    transformers:
+      - addprefix: "quay.io/alfresco/alfresco-content-repository:"
+    spec:
+      file: {{ .acs.compose_target }}
+      key: >-
+        {{ .acs.compose_key }}
+  repositoryValues:
+    name: Repo image tag
+    kind: yaml
+    sourceid: repositoryTag
+    spec:
+      file: {{ .acs.helm_target }}
+      key: >-
+        {{ .acs.helm_key }}
+  shareCompose:
+    name: Share image tag
+    kind: yaml
+    sourceid: shareTag
+    transformers:
+      - addprefix: "quay.io/alfresco/alfresco-share:"
+    spec:
+      file: {{ .share.compose_target }}
+      key: >-
+        {{ .share.compose_key }}
+  shareValues:
+    name: Share image tag
+    kind: yaml
+    sourceid: shareTag
+    spec:
+      file: {{ .share.helm_target }}
+      key: >-
+        {{ .share.helm_key }}
+  syncCompose:
+    name: Sync image tag
+    kind: yaml
+    sourceid: syncTag
+    transformers:
+      - addprefix: "quay.io/alfresco/service-sync:"
+    spec:
+      file: {{ .sync.compose_target }}
+      key: >-
+        {{ .sync.compose_key }}
+  syncValues:
+    name: Sync image tag
+    kind: yaml
+    sourceid: syncTag
+    spec:
+      file: {{ .sync.helm_target }}
+      key: >-
+        {{ .sync.helm_key }}
+  {{- $target_searchEnt := index . "search-enterprise" "helm_target" }}
+  searchEnterpriseReindexingValues:
+    name: Search Enterprise image tag
+    kind: yaml
+    sourceid: searchEnterpriseTag
+    spec:
+      file: {{ $target_searchEnt }}
+      key: {{ index . "search-enterprise" "helm_keys" "Reindexing" }}
+  {{- range $key, $value := index . "search-enterprise" "helm_keys" "Liveindexing" }}
+  searchEnterprise{{ $key }}Values:
+    name: Search Enterprise image tag
+    kind: yaml
+    sourceid: searchEnterpriseTag
+    spec:
+      file: {{ $target_searchEnt }}
+      key: {{ $value }}
+  {{- end }}
+  adwCompose:
+    name: ADW image tag
+    kind: yaml
+    sourceid: adwTag
+    transformers:
+      - addprefix: "quay.io/alfresco/alfresco-digital-workspace:"
+    spec:
+      file: {{ .adw.compose_target }}
+      key: >-
+        {{ .adw.compose_key }}
+  adwValues:
+    name: ADW image tag
+    kind: yaml
+    sourceid: adwTag
+    spec:
+      file: {{ .adw.helm_target }}
+      key: >-
+        {{ .adw.helm_key }}
+  adminAppCompose:
+    name: Alfresco Control Center
+    kind: yaml
+    sourceid: adminAppTag
+    transformers:
+      - addprefix: "quay.io/alfresco/alfresco-admin-app:"
+    spec:
+      file: {{ .adminApp.compose_target }}
+      key: >-
+        {{ .adminApp.compose_key }}
+  adminAppValues:
+    name: Helm chart default values file
+    kind: yaml
+    sourceid: adminAppTag
+    spec:
+      file: {{ .adminApp.helm_target }}
+      key: >-
+        {{ .adminApp.helm_key }}

--- a/updatecli.d/community-manifest.yaml
+++ b/updatecli.d/community-manifest.yaml
@@ -1,0 +1,50 @@
+---
+name: Images updates for ACS community
+
+{{- define "wip_suffix" -}}
+  (\.[0-9]+)*(-[AM]\.?[0-9]+)?
+{{- end }}
+
+scms:
+
+sources:
+  repositoryTag:
+    name: ACS repository tag
+    kind: dockerimage
+    spec:
+      image: alfresco/alfresco-content-repository-community
+      versionFilter:
+        kind: regex
+        pattern: >-
+          ^{{ index . "acs" "version" }}{{ template "wip_suffix" }}$
+  shareTag:
+    name: Share repository tag
+    kind: dockerimage
+    spec:
+      image: alfresco/alfresco-share
+      versionFilter:
+        kind: regex
+        pattern: >-
+          ^{{ index . "share" "version" }}{{ template "wip_suffix" }}$
+
+targets:
+  repositoryCompose:
+    name: Repo image tag
+    kind: yaml
+    sourceid: repositoryTag
+    transformers:
+      - addprefix: "alfresco/alfresco-content-repository-community:"
+    spec:
+      file: {{ .acs.compose_target }}
+      key: >-
+        {{ .acs.compose_key }}
+  shareCompose:
+    name: Share image tag
+    kind: yaml
+    sourceid: shareTag
+    transformers:
+      - addprefix: "alfresco/alfresco-share:"
+    spec:
+      file: {{ .share.compose_target }}
+      key: >-
+        {{ .share.compose_key }}

--- a/updatecli.d/latest-manifest.yaml
+++ b/updatecli.d/latest-manifest.yaml
@@ -1,0 +1,211 @@
+---
+name: Images updates for ACS latest
+
+{{- define "quay_auth" }}
+      username: {{ requiredEnv "QUAY_USERNAME" }}
+      password: {{ requiredEnv "QUAY_PASSWORD" }}
+{{- end }}
+
+{{- define "wip_pattern" -}}
+  (-[AM]\.?[0-9]+)?
+{{- end }}
+
+{{- define "hf_pattern" -}}
+  (\.[0-9]+){1,3}
+{{- end }}
+
+{{- define "ga_pattern" -}}
+  (\.[0-9]+){1,2}
+{{- end }}
+
+scms:
+  searchEnterprise:
+    name: Alfresco Elasticsearch connector
+    kind: github
+    spec:
+      owner: Alfresco
+      repository: alfresco-elasticsearch-connector
+      branch: master
+      username: alfresco-build
+      token: {{ requiredEnv "GITHUB_TOKEN" }}
+      directory: /tmp/updatecli/searchEnterprise
+
+sources:
+  syncTag:
+    name: Sync Service image tag
+    kind: dockerimage
+    spec:
+      image: quay.io/alfresco/service-sync
+      {{ template "quay_auth" }}
+      versionFilter:
+        kind: regex
+        pattern: >-
+          ^{{ index . "sync" "version" }}{{ template "hf_pattern" }}{{ template "wip_pattern" }}$
+  adwTag:
+    name: Alfresco Digital Workspace tag
+    kind: dockerimage
+    spec:
+      image: quay.io/alfresco/alfresco-digital-workspace
+      {{ template "quay_auth" }}
+      versionFilter:
+        kind: regex
+        pattern: >-
+          ^{{ index . "adw" "version" }}{{ template "hf_pattern" }}{{ template "wip_pattern" }}$
+  searchEnterpriseTag:
+    name: Search Enterprise tag
+    kind: gittag
+    scmid: searchEnterprise
+    spec:
+      versionFilter:
+        kind: regex
+        pattern: >-
+          ^{{ index . "search-enterprise" "version" }}{{ template "hf_pattern" }}{{ template "wip_pattern" }}$
+  repositoryTag:
+    name: ACS repository tag
+    kind: dockerimage
+    spec:
+      image: quay.io/alfresco/alfresco-content-repository
+      {{ template "quay_auth" }}
+      versionFilter:
+        kind: regex
+        pattern: >-
+          ^{{ index . "acs" "version" }}{{ template "hf_pattern" }}{{ template "wip_pattern" }}$
+  shareTag:
+    name: Share repository tag
+    kind: dockerimage
+    spec:
+      image: quay.io/alfresco/alfresco-share
+      {{ template "quay_auth" }}
+      versionFilter:
+        kind: regex
+        pattern: >-
+          ^{{ index . "share" "version" }}{{ template "hf_pattern" }}{{ template "wip_pattern" }}$
+  adminAppTag:
+    name: Alfresco admin application tag
+    kind: dockerimage
+    spec:
+      image: quay.io/alfresco/alfresco-admin-app
+      {{ template "quay_auth" }}
+      versionFilter:
+        kind: regex
+        pattern: >-
+          ^{{ index . "adminApp" "version" }}{{ template "hf_pattern" }}{{ template "wip_pattern" }}$
+
+targets:
+  repositoryCompose:
+    name: Repo image tag
+    kind: yaml
+    sourceid: repositoryTag
+    transformers:
+      - addprefix: "quay.io/alfresco/alfresco-content-repository:"
+    spec:
+      file: {{ .acs.compose_target }}
+      key: >-
+        {{ .acs.compose_key }}
+  repositoryValues:
+    name: Repo image tag
+    kind: yaml
+    sourceid: repositoryTag
+    spec:
+      file: {{ .acs.helm_target }}
+      key: >-
+        {{ .acs.helm_key }}
+  shareCompose:
+    name: Share image tag
+    kind: yaml
+    sourceid: shareTag
+    transformers:
+      - addprefix: "quay.io/alfresco/alfresco-share:"
+    spec:
+      file: {{ .share.compose_target }}
+      key: >-
+        {{ .share.compose_key }}
+  shareValues:
+    name: Share image tag
+    kind: yaml
+    sourceid: shareTag
+    spec:
+      file: {{ .share.helm_target }}
+      key: >-
+        {{ .share.helm_key }}
+  syncCompose:
+    name: Sync image tag
+    kind: yaml
+    sourceid: syncTag
+    transformers:
+      - addprefix: "quay.io/alfresco/service-sync:"
+    spec:
+      file: {{ .sync.compose_target }}
+      key: >-
+        {{ .sync.compose_key }}
+  syncValues:
+    name: Sync image tag
+    kind: yaml
+    sourceid: syncTag
+    spec:
+      file: {{ .sync.helm_target }}
+      key: >-
+        {{ .sync.helm_key }}
+  searchEnterpriseCompose:
+    name: Search Enterprise image tag
+    kind: yaml
+    sourceid: searchEnterpriseTag
+    transformers:
+      - addprefix: "quay.io/alfresco/alfresco-elasticsearch-live-indexing:"
+    spec:
+      file: {{ index . "search-enterprise" "compose_target" }}
+      key: >-
+        {{ index . "search-enterprise" "compose_key" }}
+  {{- $target_searchEnt := index . "search-enterprise" "helm_target" }}
+  searchEnterpriseReindexingValues:
+    name: Search Enterprise image tag
+    kind: yaml
+    sourceid: searchEnterpriseTag
+    spec:
+      file: {{ $target_searchEnt }}
+      key: {{ index . "search-enterprise" "helm_keys" "Reindexing" }}
+  {{- range $key, $value := index . "search-enterprise" "helm_keys" "Liveindexing" }}
+  searchEnterprise{{ $key }}Values:
+    name: Search Enterprise image tag
+    kind: yaml
+    sourceid: searchEnterpriseTag
+    spec:
+      file: {{ $target_searchEnt }}
+      key: {{ $value }}
+  {{- end }}
+  adwCompose:
+    name: ADW image tag
+    kind: yaml
+    sourceid: adwTag
+    transformers:
+      - addprefix: "quay.io/alfresco/alfresco-digital-workspace:"
+    spec:
+      file: {{ .adw.compose_target }}
+      key: >-
+        {{ .adw.compose_key }}
+  adwValues:
+    name: ADW image tag
+    kind: yaml
+    sourceid: adwTag
+    spec:
+      file: {{ .adw.helm_target }}
+      key: >-
+        {{ .adw.helm_key }}
+  adminAppCompose:
+    name: Alfresco Control Center
+    kind: yaml
+    sourceid: adminAppTag
+    transformers:
+      - addprefix: "quay.io/alfresco/alfresco-admin-app:"
+    spec:
+      file: {{ .adminApp.compose_target }}
+      key: >-
+        {{ .adminApp.compose_key }}
+  adminAppValues:
+    name: Helm chart default values file
+    kind: yaml
+    sourceid: adminAppTag
+    spec:
+      file: {{ .adminApp.helm_target }}
+      key: >-
+        {{ .adminApp.helm_key }}

--- a/updatecli.d/supported-matrix.yaml
+++ b/updatecli.d/supported-matrix.yaml
@@ -1,0 +1,228 @@
+---
+# Reflection of https://docs.alfresco.com/content-services/latest/support/
+# TO BE ENRICHED AS RELEASES ARE OUT
+matrix:
+  latest:
+    acs:
+      version: "7.4"
+      compose_target: &compose >-
+        docker-compose/docker-compose.yml
+      compose_key: services.alfresco.image
+      helm_target: &helmvalues >-
+        helm/alfresco-content-services/values.yaml
+      helm_key: repository.image.tag
+    share:
+      version: "7.4"
+      compose_target: *compose
+      compose_key: services.share.image
+      helm_target: *helmvalues
+      helm_key: share.image.tag
+    search-enterprise:
+      version: "3"
+      compose_target: >-
+        docker-compose/elasticsearch-override-docker-compose.yml
+      compose_key: services.search.image
+      helm_target: >-
+        helm/alfresco-content-services/charts/alfresco-elasticsearch-connector/values.yaml
+      helm_keys:
+        Reindexing: reindexing.image.tag
+        Liveindexing:
+          Mediation: liveIndexing.mediation.image.tag
+          Content: liveIndexing.content.image.tag
+          Metadata: liveIndexing.metadata.image.tag
+          Path: liveIndexing.path.image.tag
+    sync:
+      version: "4"
+      compose_target: *compose
+      compose_key: services.sync-service.image
+      helm_target: >-
+        helm/alfresco-content-services/charts/alfresco-sync-service/values.yaml
+      helm_key: syncservice.image.tag
+    adw:
+      version: "4"
+      compose_target: *compose
+      compose_key: services.digital-workspace.image
+      helm_target: *helmvalues
+      helm_key: alfresco-digital-workspace.image.tag
+    adminApp:
+      version: "7"
+      compose_target: *compose
+      compose_key: services.control-center.image
+      helm_target: *helmvalues
+      helm_key: alfresco-admin-app.image.tag
+  7.3.N:
+    acs:
+      version: "7.3"
+      compose_target: &compose73 >-
+        docker-compose/7.3.N-docker-compose.yml
+      compose_key: services.alfresco.image
+      helm_target: &helmvalues73 >-
+        helm/alfresco-content-services/7.3.N_values.yaml
+      helm_key: repository.image.tag
+    share:
+      version: "7.3"
+      compose_target: *compose73
+      compose_key: services.share.image
+      helm_target: *helmvalues73
+      helm_key: share.image.tag
+    search-enterprise:
+      version: "3.2"
+      helm_target: *helmvalues73
+      helm_keys:
+        Reindexing: alfresco-elasticsearch-connector.reindexing.image.tag
+        Liveindexing:
+          Mediation: >-
+            alfresco-elasticsearch-connector.liveIndexing.mediation.image.tag
+          Content: >-
+            alfresco-elasticsearch-connector.liveIndexing.content.image.tag
+          Metadata: >-
+            alfresco-elasticsearch-connector.liveIndexing.metadata.image.tag
+          Path: >-
+            alfresco-elasticsearch-connector.liveIndexing.path.image.tag
+    sync:
+      version: "3.8"
+      compose_target: *compose73
+      compose_key: services.sync-service.image
+      helm_target: >-
+        helm/alfresco-content-services/charts/alfresco-sync-service/values.yaml
+      helm_key: syncservice.image.tag
+    adw:
+      version: "3.1"
+      compose_target: *compose73
+      compose_key: services.digital-workspace.image
+      helm_target: *helmvalues73
+      helm_key: alfresco-digital-workspace.image.tag
+    adminApp:
+      version: "7.6"
+      compose_target: *compose73
+      compose_key: services.control-center.image
+      helm_target: *helmvalues73
+      helm_key: alfresco-admin-app.image.tag
+  7.2.N:
+    acs:
+      version: "7.2"
+      compose_target: &compose72 >-
+        docker-compose/7.2.N-docker-compose.yml
+      compose_key: services.alfresco.image
+      helm_target: &helmvalues72 >-
+        helm/alfresco-content-services/7.2.N_values.yaml
+      helm_key: repository.image.tag
+    share:
+      version: "7.2"
+      compose_target: *compose72
+      compose_key: services.share.image
+      helm_target: *helmvalues72
+      helm_key: share.image.tag
+    search-enterprise:
+      version: "3.1"
+      helm_target: *helmvalues72
+      helm_keys:
+        Reindexing: alfresco-elasticsearch-connector.reindexing.image.tag
+        Liveindexing:
+          Mediation: >-
+            alfresco-elasticsearch-connector.liveIndexing.mediation.image.tag
+          Content: >-
+            alfresco-elasticsearch-connector.liveIndexing.content.image.tag
+          Metadata: >-
+            alfresco-elasticsearch-connector.liveIndexing.metadata.image.tag
+          Path: >-
+            alfresco-elasticsearch-connector.liveIndexing.path.image.tag
+    sync:
+      version: "3.7"
+      compose_target: *compose72
+      compose_key: services.sync-service.image
+      helm_target: >-
+        helm/alfresco-content-services/charts/alfresco-sync-service/values.yaml
+      helm_key: syncservice.image.tag
+    adw:
+      version: "3.0"
+      compose_target: *compose72
+      compose_key: services.digital-workspace.image
+      helm_target: *helmvalues72
+      helm_key: alfresco-digital-workspace.image.tag
+    adminApp:
+      version: "7.6"
+      compose_target: *compose72
+      compose_key: services.control-center.image
+      helm_target: *helmvalues72
+      helm_key: alfresco-admin-app.image.tag
+  7.1.N:
+    acs:
+      version: "7.1"
+      compose_target: &compose71 >-
+        docker-compose/7.1.N-docker-compose.yml
+      compose_key: services.alfresco.image
+      helm_target: &helmvalues71 >-
+        helm/alfresco-content-services/7.1.N_values.yaml
+      helm_key: repository.image.tag
+    share:
+      version: "7.1"
+      compose_target: *compose71
+      compose_key: services.share.image
+      helm_target: *helmvalues71
+      helm_key: share.image.tag
+    search-enterprise:
+      version: "3.1"
+      helm_target: *helmvalues71
+      helm_keys:
+        Reindexing: alfresco-elasticsearch-connector.reindexing.image.tag
+        Liveindexing:
+          Mediation: >-
+            alfresco-elasticsearch-connector.liveIndexing.mediation.image.tag
+          Content: >-
+            alfresco-elasticsearch-connector.liveIndexing.content.image.tag
+          Metadata: >-
+            alfresco-elasticsearch-connector.liveIndexing.metadata.image.tag
+          Path: >-
+            alfresco-elasticsearch-connector.liveIndexing.path.image.tag
+    sync:
+      version: "3.7"
+      compose_target: *compose71
+      compose_key: services.sync-service.image
+      helm_target: >-
+        helm/alfresco-content-services/charts/alfresco-sync-service/values.yaml
+      helm_key: syncservice.image.tag
+    adw:
+      version: "2.6"
+      compose_target: *compose71
+      compose_key: services.digital-workspace.image
+      helm_target: *helmvalues71
+      helm_key: alfresco-digital-workspace.image.tag
+  7.0.N:
+    acs:
+      version: "7.0"
+      compose_target: &compose70 >-
+        docker-compose/7.0.N-docker-compose.yml
+      compose_key: services.alfresco.image
+      helm_target: &helmvalues70 >-
+        helm/alfresco-content-services/7.0.N_values.yaml
+      helm_key: repository.image.tag
+    share:
+      version: "7.0"
+      compose_target: *compose70
+      compose_key: services.share.image
+      helm_target: *helmvalues70
+      helm_key: share.image.tag
+    sync:
+      version: "3.7"
+      compose_target: *compose70
+      compose_key: services.sync-service.image
+      helm_target: >-
+        helm/alfresco-content-services/charts/alfresco-sync-service/values.yaml
+      helm_key: syncservice.image.tag
+    adw:
+      version: "2.6"
+      compose_target: *compose70
+      compose_key: services.digital-workspace.image
+      helm_target: *helmvalues70
+      helm_key: alfresco-digital-workspace.image.tag
+  community:
+    acs:
+      version: "7.4"
+      compose_target: &composece >-
+        docker-compose/community-docker-compose.yml
+      compose_key: services.alfresco.image
+    share:
+      version: "7.4"
+      compose_target: *composece
+      compose_key: services.share.image


### PR DESCRIPTION
Ref OPSEXP-1875

Addiotnal PR to introduce updatecli config in acs-deplyment (as beta considering opened updatecli issues (https://github.com/updatecli/updatecli/issues/1028 & https://github.com/updatecli/updatecli/issues/794)