### PR TITLE
OPSEXP-1651 Use existing secret to configure activemq credentials in embedded chart

### DIFF
--- a/helm/alfresco-content-services/README.md
+++ b/helm/alfresco-content-services/README.md
@@ -93,9 +93,9 @@ Please refer to the [documentation](https://github.com/Alfresco/acs-deployment/b
 | alfresco-elasticsearch-connector.elasticsearch | object | `{"host":null,"password":null,"port":null,"protocol":null,"user":null}` | Overrides .Values.global.elasticsearch |
 | alfresco-elasticsearch-connector.enabled | bool | `false` |  |
 | alfresco-elasticsearch-connector.messageBroker.existingSecretName | string | `nil` |  |
-| alfresco-elasticsearch-connector.messageBroker.password | string | `nil` |  |
+| alfresco-elasticsearch-connector.messageBroker.password | string | `"admin"` |  |
 | alfresco-elasticsearch-connector.messageBroker.url | string | `nil` |  |
-| alfresco-elasticsearch-connector.messageBroker.user | string | `nil` |  |
+| alfresco-elasticsearch-connector.messageBroker.user | string | `"admin"` |  |
 | alfresco-elasticsearch-connector.reindexing.enabled | bool | `true` |  |
 | alfresco-elasticsearch-connector.reindexing.postgresql.database | string | `"alfresco"` |  |
 | alfresco-elasticsearch-connector.reindexing.postgresql.hostname | string | `"postgresql-acs"` |  |
@@ -118,9 +118,9 @@ Please refer to the [documentation](https://github.com/Alfresco/acs-deployment/b
 | alfresco-sync-service.image.repository | string | `"quay.io/alfresco/service-sync"` |  |
 | alfresco-sync-service.image.tag | string | `"3.8.0"` |  |
 | alfresco-sync-service.messageBroker.existingSecretName | string | `nil` |  |
-| alfresco-sync-service.messageBroker.password | string | `nil` |  |
+| alfresco-sync-service.messageBroker.password | string | `"admin"` |  |
 | alfresco-sync-service.messageBroker.url | string | `nil` |  |
-| alfresco-sync-service.messageBroker.user | string | `nil` |  |
+| alfresco-sync-service.messageBroker.user | string | `"admin"` |  |
 | alfresco-sync-service.nodeSelector | object | `{}` |  |
 | alfresco-sync-service.syncservice.enabled | bool | `true` |  |
 | apiexplorer | object | `{"ingress":{"path":"/api-explorer"}}` | Declares the api-explorer service used by the content repository |
@@ -154,7 +154,7 @@ Please refer to the [documentation](https://github.com/Alfresco/acs-deployment/b
 | imap | object | `{"mail":{"from":{"default":null},"to":{"default":null}},"server":{"enabled":false,"host":"0.0.0.0","imap":{"enabled":true},"imaps":{"enabled":true,"port":1144},"port":1143}}` | For a full information of configuring the imap subsystem, see https://docs.alfresco.com/content-services/latest/config/email/#enable-imap-protocol-using-alfresco-globalproperties |
 | libreoffice | object | `{"environment":{"JAVA_OPTS":"-XX:MinRAMPercentage=50 -XX:MaxRAMPercentage=80"},"image":{"internalPort":8090,"pullPolicy":"IfNotPresent","repository":"alfresco/alfresco-libreoffice","tag":"3.0.0"},"livenessProbe":{"initialDelaySeconds":10,"livenessPercent":250,"livenessTransformPeriodSeconds":600,"maxTransformSeconds":1800,"maxTransforms":99999,"periodSeconds":20,"timeoutSeconds":10},"nodeSelector":{},"readinessProbe":{"initialDelaySeconds":20,"periodSeconds":60,"timeoutSeconds":10},"replicaCount":2,"resources":{"limits":{"memory":"1000Mi"},"requests":{"memory":"1000Mi"}},"service":{"externalPort":80,"name":"libreoffice","type":"ClusterIP"}}` | Declares the alfresco-libreoffice service used by the content repository to transform office files |
 | mail | object | `{"encoding":"UTF-8","from":{"default":null,"enabled":false},"host":null,"password":null,"port":null,"protocol":"smtps","smtp":{"auth":true,"debug":false,"starttls":{"enable":true},"timeout":30000},"smtps":{"auth":true,"starttls":{"enable":true}},"username":null}` | For a full information of configuring the outbound email ssytem, see https://docs.alfresco.com/content-services/latest/config/email/#manage-outbound-emails |
-| messageBroker | object | `{"existingSecretName":null,"password":null,"url":null,"user":null}` | external activemq connection setting when activemq.enabled=false |
+| messageBroker | object | `{"existingSecretName":null,"password":"admin","url":null,"user":"admin"}` | activemq connection settings |
 | metadataKeystore.defaultKeyPassword | string | `"oKIWzVdEdA"` |  |
 | metadataKeystore.defaultKeystorePassword | string | `"mp6yc0UD9e"` |  |
 | msTeams | object | `{"enabled":false}` | Enable/Disable Alfresco Content Connector for Microsoft Teams |

--- a/helm/alfresco-content-services/README.md
+++ b/helm/alfresco-content-services/README.md
@@ -31,6 +31,8 @@ Please refer to the [documentation](https://github.com/Alfresco/acs-deployment/b
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| activemq.adminUser.password | string | `"admin"` | Default password for the embedded broker admin user |
+| activemq.adminUser.user | string | `"admin"` | Default username for the embedded broker admin user |
 | activemq.enabled | bool | `true` |  |
 | activemq.nodeSelector | object | `{}` | Possibility to choose Node for pod, with a key-value pair label e.g {"kubernetes.io/hostname": multinode-demo-m02} |
 | aiTransformer.environment.JAVA_OPTS | string | `"-XX:MinRAMPercentage=50 -XX:MaxRAMPercentage=80"` |  |
@@ -93,9 +95,9 @@ Please refer to the [documentation](https://github.com/Alfresco/acs-deployment/b
 | alfresco-elasticsearch-connector.elasticsearch | object | `{"host":null,"password":null,"port":null,"protocol":null,"user":null}` | Overrides .Values.global.elasticsearch |
 | alfresco-elasticsearch-connector.enabled | bool | `false` |  |
 | alfresco-elasticsearch-connector.messageBroker.existingSecretName | string | `nil` |  |
-| alfresco-elasticsearch-connector.messageBroker.password | string | `"admin"` |  |
+| alfresco-elasticsearch-connector.messageBroker.password | string | `nil` |  |
 | alfresco-elasticsearch-connector.messageBroker.url | string | `nil` |  |
-| alfresco-elasticsearch-connector.messageBroker.user | string | `"admin"` |  |
+| alfresco-elasticsearch-connector.messageBroker.user | string | `nil` |  |
 | alfresco-elasticsearch-connector.reindexing.enabled | bool | `true` |  |
 | alfresco-elasticsearch-connector.reindexing.postgresql.database | string | `"alfresco"` |  |
 | alfresco-elasticsearch-connector.reindexing.postgresql.hostname | string | `"postgresql-acs"` |  |
@@ -118,9 +120,9 @@ Please refer to the [documentation](https://github.com/Alfresco/acs-deployment/b
 | alfresco-sync-service.image.repository | string | `"quay.io/alfresco/service-sync"` |  |
 | alfresco-sync-service.image.tag | string | `"3.8.0"` |  |
 | alfresco-sync-service.messageBroker.existingSecretName | string | `nil` |  |
-| alfresco-sync-service.messageBroker.password | string | `"admin"` |  |
+| alfresco-sync-service.messageBroker.password | string | `nil` |  |
 | alfresco-sync-service.messageBroker.url | string | `nil` |  |
-| alfresco-sync-service.messageBroker.user | string | `"admin"` |  |
+| alfresco-sync-service.messageBroker.user | string | `nil` |  |
 | alfresco-sync-service.nodeSelector | object | `{}` |  |
 | alfresco-sync-service.syncservice.enabled | bool | `true` |  |
 | apiexplorer | object | `{"ingress":{"path":"/api-explorer"}}` | Declares the api-explorer service used by the content repository |
@@ -154,7 +156,7 @@ Please refer to the [documentation](https://github.com/Alfresco/acs-deployment/b
 | imap | object | `{"mail":{"from":{"default":null},"to":{"default":null}},"server":{"enabled":false,"host":"0.0.0.0","imap":{"enabled":true},"imaps":{"enabled":true,"port":1144},"port":1143}}` | For a full information of configuring the imap subsystem, see https://docs.alfresco.com/content-services/latest/config/email/#enable-imap-protocol-using-alfresco-globalproperties |
 | libreoffice | object | `{"environment":{"JAVA_OPTS":"-XX:MinRAMPercentage=50 -XX:MaxRAMPercentage=80"},"image":{"internalPort":8090,"pullPolicy":"IfNotPresent","repository":"alfresco/alfresco-libreoffice","tag":"3.0.0"},"livenessProbe":{"initialDelaySeconds":10,"livenessPercent":250,"livenessTransformPeriodSeconds":600,"maxTransformSeconds":1800,"maxTransforms":99999,"periodSeconds":20,"timeoutSeconds":10},"nodeSelector":{},"readinessProbe":{"initialDelaySeconds":20,"periodSeconds":60,"timeoutSeconds":10},"replicaCount":2,"resources":{"limits":{"memory":"1000Mi"},"requests":{"memory":"1000Mi"}},"service":{"externalPort":80,"name":"libreoffice","type":"ClusterIP"}}` | Declares the alfresco-libreoffice service used by the content repository to transform office files |
 | mail | object | `{"encoding":"UTF-8","from":{"default":null,"enabled":false},"host":null,"password":null,"port":null,"protocol":"smtps","smtp":{"auth":true,"debug":false,"starttls":{"enable":true},"timeout":30000},"smtps":{"auth":true,"starttls":{"enable":true}},"username":null}` | For a full information of configuring the outbound email ssytem, see https://docs.alfresco.com/content-services/latest/config/email/#manage-outbound-emails |
-| messageBroker | object | `{"existingSecretName":null,"password":"admin","url":null,"user":"admin"}` | activemq connection settings |
+| messageBroker | object | `{"existingSecretName":null,"password":null,"url":null,"user":null}` | external activemq connection setting when activemq.enabled=false |
 | metadataKeystore.defaultKeyPassword | string | `"oKIWzVdEdA"` |  |
 | metadataKeystore.defaultKeystorePassword | string | `"mp6yc0UD9e"` |  |
 | msTeams | object | `{"enabled":false}` | Enable/Disable Alfresco Content Connector for Microsoft Teams |

--- a/helm/alfresco-content-services/charts/activemq/Chart.yaml
+++ b/helm/alfresco-content-services/charts/activemq/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 appVersion: 5.16.4
-description: A Helm chart Providing Apache ActiveMQ.
+description: A Helm chart providing a basic Apache ActiveMQ deployment required to evaluate ACS (do not use in production).
 keywords:
   - activemq
   - message broker

--- a/helm/alfresco-content-services/charts/activemq/Chart.yaml
+++ b/helm/alfresco-content-services/charts/activemq/Chart.yaml
@@ -1,6 +1,5 @@
 ---
 apiVersion: v2
-appVersion: 5.16.4
 appVersion: 5.17.1
 description: A Helm chart providing a basic Apache ActiveMQ deployment required to evaluate ACS (do not use in production).
 keywords:

--- a/helm/alfresco-content-services/charts/activemq/README.md
+++ b/helm/alfresco-content-services/charts/activemq/README.md
@@ -21,8 +21,6 @@ Please refer to the [documentation](https://github.com/Alfresco/acs-deployment/b
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | adminUser.existingSecretName | string | `nil` | An existing kubernetes secret that contains BROKER_USERNAME and BROKER_PASSWORD keys |
-| adminUser.password | string | `"admin"` |  |
-| adminUser.username | string | `"admin"` |  |
 | enabled | bool | `true` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"alfresco/alfresco-activemq"` |  |

--- a/helm/alfresco-content-services/charts/activemq/README.md
+++ b/helm/alfresco-content-services/charts/activemq/README.md
@@ -2,9 +2,14 @@
 
 ![Version: 2.1.0](https://img.shields.io/badge/Version-2.1.0-informational?style=flat-square) ![AppVersion: 5.16.4](https://img.shields.io/badge/AppVersion-5.16.4-informational?style=flat-square)
 
-A Helm chart Providing Apache ActiveMQ.
+A Helm chart providing a basic Apache ActiveMQ deployment required to evaluate ACS (do not use in production).
 
-Please refer to the [documentation](https://github.com/Alfresco/acs-deployment/blob/master/docs/helm/README.md) for information on the Helm charts and deployment instructions.
+Please refer to the [documentation](../../../../docs/helm/README.md) for information on the Helm charts and deployment instructions.
+
+Credentials get injected by the [main chart](../../README.md) and by default are:
+
+* username: admin
+* password: admin
 
 ## Source Code
 

--- a/helm/alfresco-content-services/charts/activemq/README.md
+++ b/helm/alfresco-content-services/charts/activemq/README.md
@@ -20,6 +20,7 @@ Please refer to the [documentation](https://github.com/Alfresco/acs-deployment/b
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| adminUser.existingSecretName | string | `nil` | An existing kubernetes secret that contains BROKER_USERNAME and BROKER_PASSWORD keys |
 | adminUser.password | string | `"admin"` |  |
 | adminUser.username | string | `"admin"` |  |
 | enabled | bool | `true` |  |

--- a/helm/alfresco-content-services/charts/activemq/README.md.gotmpl
+++ b/helm/alfresco-content-services/charts/activemq/README.md.gotmpl
@@ -5,7 +5,12 @@
 
 {{ template "chart.description" . }}
 
-Please refer to the [documentation](https://github.com/Alfresco/acs-deployment/blob/master/docs/helm/README.md) for information on the Helm charts and deployment instructions.
+Please refer to the [documentation](../../../../docs/helm/README.md) for information on the Helm charts and deployment instructions.
+
+Credentials get injected by the [main chart](../../README.md) and by default are:
+
+* username: admin
+* password: admin
 
 {{ template "chart.homepageLine" . }}
 

--- a/helm/alfresco-content-services/charts/activemq/templates/deployment-activemq.yaml
+++ b/helm/alfresco-content-services/charts/activemq/templates/deployment-activemq.yaml
@@ -39,9 +39,15 @@ spec:
         - name: ACTIVEMQ_BROKER_NAME
           value: "{{ template "activemq.fullname" . }}"
         - name: ACTIVEMQ_ADMIN_LOGIN
-          value: "{{ .Values.adminUser.username }}"
+          valueFrom:
+            secretKeyRef:
+              name: {{ default (printf "%s-brokersecret" (include "content-services.shortname" $)) $.Values.adminUser.existingSecretName }}
+              key: BROKER_USERNAME
         - name: ACTIVEMQ_ADMIN_PASSWORD
-          value: "{{ .Values.adminUser.password }}"
+          valueFrom:
+            secretKeyRef:
+              name: {{ default (printf "%s-brokersecret" (include "content-services.shortname" $)) $.Values.adminUser.existingSecretName }}
+              key: BROKER_PASSWORD
         ports:
         - name: stomp
           containerPort: {{ .Values.services.broker.ports.internal.stomp | default 61613 }}

--- a/helm/alfresco-content-services/charts/activemq/tests/deployment-activemq_test.yaml
+++ b/helm/alfresco-content-services/charts/activemq/tests/deployment-activemq_test.yaml
@@ -1,0 +1,26 @@
+---
+suite: test activemq persistence
+templates:
+  - deployment-activemq.yaml
+tests:
+  - it: should reference default secret containing broker default credentials
+    values: &testvalues
+      - ../../../tests/values/test_values.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[3].name
+          value: ACTIVEMQ_ADMIN_LOGIN
+        template: deployment-activemq.yaml
+      - equal:
+          path: spec.template.spec.containers[0].env[3].valueFrom.secretKeyRef.name
+          value: RELEASE-NAME-alfresco-cs-brokersecret
+        template: deployment-activemq.yaml
+  - it: should reference overridden secret when setting existingSecretName
+    values: *testvalues
+    set:
+      adminUser.existingSecretName: existing-secret
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[3].valueFrom.secretKeyRef.name
+          value: existing-secret
+        template: deployment-activemq.yaml

--- a/helm/alfresco-content-services/charts/activemq/values.yaml
+++ b/helm/alfresco-content-services/charts/activemq/values.yaml
@@ -7,8 +7,6 @@ image:
   tag: 5.17.1-jre11-rockylinux8
   pullPolicy: IfNotPresent
 adminUser:
-  username: admin
-  password: admin
   # -- An existing kubernetes secret that contains BROKER_USERNAME and BROKER_PASSWORD keys
   existingSecretName:
 resources:

--- a/helm/alfresco-content-services/charts/activemq/values.yaml
+++ b/helm/alfresco-content-services/charts/activemq/values.yaml
@@ -9,6 +9,8 @@ image:
 adminUser:
   username: admin
   password: admin
+  # -- An existing kubernetes secret that contains BROKER_USERNAME and BROKER_PASSWORD keys
+  existingSecretName:
 resources:
   requests:
     memory: "512Mi"

--- a/helm/alfresco-content-services/templates/secret-message-broker.yaml
+++ b/helm/alfresco-content-services/templates/secret-message-broker.yaml
@@ -9,11 +9,9 @@ type: Opaque
 data:
   {{- if .Values.activemq.enabled }}
   BROKER_URL: {{ printf "failover:(nio://%s-broker:61616)?timeout=3000&jms.useCompression=true" (include "activemq.fullname" .) | b64enc | quote }}
-  BROKER_USERNAME: {{ .Values.activemq.adminUser.username | b64enc | quote }}
-  BROKER_PASSWORD: {{ .Values.activemq.adminUser.password | b64enc | quote }}
   {{- else }}
   BROKER_URL: {{ required "Disabling in-cluster ActiveMQ requires passing (at least) messageBroker.url" .Values.messageBroker.url | b64enc | quote }}
+  {{- end }}
   BROKER_USERNAME: {{ .Values.messageBroker.user | b64enc | quote }}
   BROKER_PASSWORD: {{ .Values.messageBroker.password | b64enc | quote }}
-  {{- end }}
 {{- end }}

--- a/helm/alfresco-content-services/templates/secret-message-broker.yaml
+++ b/helm/alfresco-content-services/templates/secret-message-broker.yaml
@@ -9,9 +9,11 @@ type: Opaque
 data:
   {{- if .Values.activemq.enabled }}
   BROKER_URL: {{ printf "failover:(nio://%s-broker:61616)?timeout=3000&jms.useCompression=true" (include "activemq.fullname" .) | b64enc | quote }}
+  BROKER_USERNAME: {{ .Values.activemq.adminUser.user | b64enc | quote }}
+  BROKER_PASSWORD: {{ .Values.activemq.adminUser.password | b64enc | quote }}
   {{- else }}
   BROKER_URL: {{ required "Disabling in-cluster ActiveMQ requires passing (at least) messageBroker.url" .Values.messageBroker.url | b64enc | quote }}
-  {{- end }}
   BROKER_USERNAME: {{ .Values.messageBroker.user | b64enc | quote }}
   BROKER_PASSWORD: {{ .Values.messageBroker.password | b64enc | quote }}
+  {{- end }}
 {{- end }}

--- a/helm/alfresco-content-services/values.yaml
+++ b/helm/alfresco-content-services/values.yaml
@@ -542,11 +542,11 @@ activemq:
   # -- Possibility to choose Node for pod, with a key-value pair label
   # e.g {"kubernetes.io/hostname": multinode-demo-m02}
   nodeSelector: {}
-# -- external activemq connection setting when activemq.enabled=false
+# -- activemq connection settings
 messageBroker: &acs_messageBroker
   url: null
-  user: null
-  password: null
+  user: admin
+  password: admin
   existingSecretName: null
 alfresco-search:
   nodeSelector: {}

--- a/helm/alfresco-content-services/values.yaml
+++ b/helm/alfresco-content-services/values.yaml
@@ -542,11 +542,16 @@ activemq:
   # -- Possibility to choose Node for pod, with a key-value pair label
   # e.g {"kubernetes.io/hostname": multinode-demo-m02}
   nodeSelector: {}
-# -- activemq connection settings
+  adminUser:
+    # -- Default username for the embedded broker admin user
+    user: admin
+    # -- Default password for the embedded broker admin user
+    password: admin
+# -- external activemq connection setting when activemq.enabled=false
 messageBroker: &acs_messageBroker
   url: null
-  user: admin
-  password: admin
+  user: null
+  password: null
   existingSecretName: null
 alfresco-search:
   nodeSelector: {}

--- a/helm/alfresco-content-services/values.yaml
+++ b/helm/alfresco-content-services/values.yaml
@@ -2,7 +2,7 @@
 # It declares variables to be passed into your templates.
 # ACS will be created in a k8s cluster with a minimum of 16GB memory to split
 # among below nodes:
-# 2 x repository, 1 x share, 1 x postgresq and
+# 2 x repository, 1 x share, 1 x postgres and
 # 1 x transformers (pdfrenderer, imagemagick, libreoffice, tika, misc)
 #
 # Limit container memory and assign X percentage to JVM. There are couple of


### PR DESCRIPTION
OPSEXP-1651

- [x] support existing secret for embedded activemq
- [x] add unit tests

[OPSEXP-1651]: https://alfresco.atlassian.net/browse/OPSEXP-1651?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ