### PR TITLE
OPSEXP-1651 Use secret to configure elasticsearch credentials

### DIFF
--- a/helm/alfresco-content-services/charts/alfresco-elasticsearch-connector/README.md
+++ b/helm/alfresco-content-services/charts/alfresco-elasticsearch-connector/README.md
@@ -23,7 +23,7 @@ Please refer to the [documentation](https://github.com/Alfresco/acs-deployment/b
 | fullnameOverride | string | `""` |  |
 | global.alfrescoRegistryPullSecrets | string | `"quay-registry-secret"` |  |
 | global.elasticsearch | object | `{"existingSecretName":null,"host":null,"password":null,"port":null,"protocol":null,"user":null}` | Shared connections details for Elasticsearch/Opensearch |
-| global.elasticsearch.existingSecretName | string | `nil` | An existing secret that contains X and Y keys |
+| global.elasticsearch.existingSecretName | string | `nil` | An existing secret that contains ELASTICSEARCH_USERNAME and ELASTICSEARCH_PASSWORD keys |
 | global.elasticsearch.host | string | `nil` | The host where service is available |
 | global.elasticsearch.password | string | `nil` | The password required to access the service, if any |
 | global.elasticsearch.port | string | `nil` | The port where service is available |

--- a/helm/alfresco-content-services/charts/alfresco-elasticsearch-connector/README.md
+++ b/helm/alfresco-content-services/charts/alfresco-elasticsearch-connector/README.md
@@ -19,7 +19,7 @@ Please refer to the [documentation](https://github.com/Alfresco/acs-deployment/b
 | affinity | object | `{}` |  |
 | contentMediaTypeCache.enabled | bool | `true` |  |
 | contentMediaTypeCache.refreshTime | string | `"0 0 * * * *"` |  |
-| elasticsearch | object | `{"host":null,"password":null,"port":null,"protocol":null,"user":null}` | Overrides .Values.global.elasticsearch |
+| elasticsearch | object | `{"existingSecretName":null,"host":null,"password":null,"port":null,"protocol":null,"user":null}` | Overrides .Values.global.elasticsearch |
 | fullnameOverride | string | `""` |  |
 | global.alfrescoRegistryPullSecrets | string | `"quay-registry-secret"` |  |
 | global.elasticsearch | object | `{"existingSecretName":null,"host":null,"password":null,"port":null,"protocol":null,"user":null}` | Shared connections details for Elasticsearch/Opensearch |

--- a/helm/alfresco-content-services/charts/alfresco-elasticsearch-connector/README.md
+++ b/helm/alfresco-content-services/charts/alfresco-elasticsearch-connector/README.md
@@ -22,7 +22,8 @@ Please refer to the [documentation](https://github.com/Alfresco/acs-deployment/b
 | elasticsearch | object | `{"host":null,"password":null,"port":null,"protocol":null,"user":null}` | Overrides .Values.global.elasticsearch |
 | fullnameOverride | string | `""` |  |
 | global.alfrescoRegistryPullSecrets | string | `"quay-registry-secret"` |  |
-| global.elasticsearch | object | `{"host":null,"password":null,"port":null,"protocol":null,"user":null}` | Shared connections details for Elasticsearch/Opensearch |
+| global.elasticsearch | object | `{"existingSecretName":null,"host":null,"password":null,"port":null,"protocol":null,"user":null}` | Shared connections details for Elasticsearch/Opensearch |
+| global.elasticsearch.existingSecretName | string | `nil` | An existing secret that contains X and Y keys |
 | global.elasticsearch.host | string | `nil` | The host where service is available |
 | global.elasticsearch.password | string | `nil` | The password required to access the service, if any |
 | global.elasticsearch.port | string | `nil` | The port where service is available |

--- a/helm/alfresco-content-services/charts/alfresco-elasticsearch-connector/templates/_helpers-elasticsearch.tpl
+++ b/helm/alfresco-content-services/charts/alfresco-elasticsearch-connector/templates/_helpers-elasticsearch.tpl
@@ -1,3 +1,16 @@
 {{- define "spring.elasticsearch.config" -}}
   SPRING_ELASTICSEARCH_REST_URIS: "{{ .Values.elasticsearch.protocol | default .Values.global.elasticsearch.protocol }}://{{ .Values.elasticsearch.host | default .Values.global.elasticsearch.host }}:{{ .Values.elasticsearch.port | default .Values.global.elasticsearch.port }}"
 {{- end -}}
+
+{{- define "spring.elasticsearch.env.credentials" -}}
+- name: SPRING_ELASTICSEARCH_REST_USERNAME
+  valueFrom:
+    secretKeyRef:
+      name: {{ default (printf "%s-elasticsearch-secret" (include "alfresco-elasticsearch-connector.fullName" $)) $.Values.global.elasticsearch.existingSecretName }}
+      key: ELASTICSEARCH_USERNAME
+- name: SPRING_ELASTICSEARCH_REST_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ default (printf "%s-elasticsearch-secret" (include "alfresco-elasticsearch-connector.fullName" $)) $.Values.global.elasticsearch.existingSecretName }}
+      key: ELASTICSEARCH_PASSWORD
+{{- end -}}

--- a/helm/alfresco-content-services/charts/alfresco-elasticsearch-connector/templates/_helpers-elasticsearch.tpl
+++ b/helm/alfresco-content-services/charts/alfresco-elasticsearch-connector/templates/_helpers-elasticsearch.tpl
@@ -1,5 +1,3 @@
 {{- define "spring.elasticsearch.config" -}}
   SPRING_ELASTICSEARCH_REST_URIS: "{{ .Values.elasticsearch.protocol | default .Values.global.elasticsearch.protocol }}://{{ .Values.elasticsearch.host | default .Values.global.elasticsearch.host }}:{{ .Values.elasticsearch.port | default .Values.global.elasticsearch.port }}"
-  SPRING_ELASTICSEARCH_REST_USERNAME: "{{ .Values.elasticsearch.user | default .Values.global.elasticsearch.user }}"
-  SPRING_ELASTICSEARCH_REST_PASSWORD: "{{ .Values.elasticsearch.password  | default .Values.global.elasticsearch.password }}"
 {{- end -}}

--- a/helm/alfresco-content-services/charts/alfresco-elasticsearch-connector/templates/liveindexing-deployment.yaml
+++ b/helm/alfresco-content-services/charts/alfresco-elasticsearch-connector/templates/liveindexing-deployment.yaml
@@ -39,13 +39,11 @@ spec:
           env:
             {{- include "spring.activemq.env" . | nindent 12 }}
         - name: SPRING_ELASTICSEARCH_REST_USERNAME
-          value: "{{ .Values.adminUser.username }}"
           valueFrom:
             secretKeyRef:
               name: {{ default (printf "%s-elasticsearch-secret" (include "alfresco-elasticsearch-connector.fullName" $)) $.Values.global.elasticsearch.existingSecretName }}
               key: ELASTICSEARCH_USERNAME
         - name: SPRING_ELASTICSEARCH_REST_PASSWORD
-          value: "{{ .Values.adminUser.password }}"
           valueFrom:
             secretKeyRef:
               name: {{ default (printf "%s-elasticsearch-secret" (include "alfresco-elasticsearch-connector.fullName" $)) $.Values.global.elasticsearch.existingSecretName }}

--- a/helm/alfresco-content-services/charts/alfresco-elasticsearch-connector/templates/liveindexing-deployment.yaml
+++ b/helm/alfresco-content-services/charts/alfresco-elasticsearch-connector/templates/liveindexing-deployment.yaml
@@ -38,16 +38,7 @@ spec:
                 name: {{ default (printf "%s-brokersecret" (include "content-services.shortname" $)) $.Values.messageBroker.existingSecretName }}
           env:
             {{- include "spring.activemq.env" . | nindent 12 }}
-          - name: SPRING_ELASTICSEARCH_REST_USERNAME
-            valueFrom:
-              secretKeyRef:
-                name: {{ default (printf "%s-elasticsearch-secret" (include "alfresco-elasticsearch-connector.fullName" $)) $.Values.global.elasticsearch.existingSecretName }}
-                key: ELASTICSEARCH_USERNAME
-          - name: SPRING_ELASTICSEARCH_REST_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: {{ default (printf "%s-elasticsearch-secret" (include "alfresco-elasticsearch-connector.fullName" $)) $.Values.global.elasticsearch.existingSecretName }}
-                key: ELASTICSEARCH_PASSWORD
+            {{- include "spring.elasticsearch.env.credentials" $ | nindent 12 }}
           ports:
             - name: http
               containerPort: 8080

--- a/helm/alfresco-content-services/charts/alfresco-elasticsearch-connector/templates/liveindexing-deployment.yaml
+++ b/helm/alfresco-content-services/charts/alfresco-elasticsearch-connector/templates/liveindexing-deployment.yaml
@@ -38,6 +38,18 @@ spec:
                 name: {{ default (printf "%s-brokersecret" (include "content-services.shortname" $)) $.Values.messageBroker.existingSecretName }}
           env:
             {{- include "spring.activemq.env" . | nindent 12 }}
+        - name: SPRING_ELASTICSEARCH_REST_USERNAME
+          value: "{{ .Values.adminUser.username }}"
+          valueFrom:
+            secretKeyRef:
+              name: {{ default (printf "%s-elasticsearch-secret" (include "alfresco-elasticsearch-connector.fullName" $)) $.Values.global.elasticsearch.existingSecretName }}
+              key: ELASTICSEARCH_USERNAME
+        - name: SPRING_ELASTICSEARCH_REST_PASSWORD
+          value: "{{ .Values.adminUser.password }}"
+          valueFrom:
+            secretKeyRef:
+              name: {{ default (printf "%s-elasticsearch-secret" (include "alfresco-elasticsearch-connector.fullName" $)) $.Values.global.elasticsearch.existingSecretName }}
+              key: ELASTICSEARCH_PASSWORD
           ports:
             - name: http
               containerPort: 8080

--- a/helm/alfresco-content-services/charts/alfresco-elasticsearch-connector/templates/liveindexing-deployment.yaml
+++ b/helm/alfresco-content-services/charts/alfresco-elasticsearch-connector/templates/liveindexing-deployment.yaml
@@ -38,16 +38,16 @@ spec:
                 name: {{ default (printf "%s-brokersecret" (include "content-services.shortname" $)) $.Values.messageBroker.existingSecretName }}
           env:
             {{- include "spring.activemq.env" . | nindent 12 }}
-        - name: SPRING_ELASTICSEARCH_REST_USERNAME
-          valueFrom:
-            secretKeyRef:
-              name: {{ default (printf "%s-elasticsearch-secret" (include "alfresco-elasticsearch-connector.fullName" $)) $.Values.global.elasticsearch.existingSecretName }}
-              key: ELASTICSEARCH_USERNAME
-        - name: SPRING_ELASTICSEARCH_REST_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: {{ default (printf "%s-elasticsearch-secret" (include "alfresco-elasticsearch-connector.fullName" $)) $.Values.global.elasticsearch.existingSecretName }}
-              key: ELASTICSEARCH_PASSWORD
+          - name: SPRING_ELASTICSEARCH_REST_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: {{ default (printf "%s-elasticsearch-secret" (include "alfresco-elasticsearch-connector.fullName" $)) $.Values.global.elasticsearch.existingSecretName }}
+                key: ELASTICSEARCH_USERNAME
+          - name: SPRING_ELASTICSEARCH_REST_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{ default (printf "%s-elasticsearch-secret" (include "alfresco-elasticsearch-connector.fullName" $)) $.Values.global.elasticsearch.existingSecretName }}
+                key: ELASTICSEARCH_PASSWORD
           ports:
             - name: http
               containerPort: 8080

--- a/helm/alfresco-content-services/charts/alfresco-elasticsearch-connector/templates/liveindexing-deployment.yaml
+++ b/helm/alfresco-content-services/charts/alfresco-elasticsearch-connector/templates/liveindexing-deployment.yaml
@@ -16,8 +16,9 @@ spec:
       {{- include "alfresco-elasticsearch-connector.selectorLabels" $ | nindent 6 }}
   template:
     metadata:
-      {{- with $.Values.podAnnotations }}
       annotations:
+        checksum/secret-elasticsearch: {{ include (print $.Template.BasePath "/secret-elasticsearch.yaml") $ | sha256sum }}
+      {{- with $.Values.podAnnotations }}
         {{- toYaml $ | nindent 8 }}
       {{- end }}
       labels:

--- a/helm/alfresco-content-services/charts/alfresco-elasticsearch-connector/templates/reindexing-job.yaml
+++ b/helm/alfresco-content-services/charts/alfresco-elasticsearch-connector/templates/reindexing-job.yaml
@@ -41,6 +41,7 @@ spec:
                   name: {{ template "content-services.shortname" . }}-dbsecret
                   key: DATABASE_USERNAME
             {{- include "spring.activemq.env" . | nindent 12 }}
+            {{- include "spring.elasticsearch.env.credentials" $ | nindent 12 }}
           ports:
               - name: http
                 containerPort: 8080

--- a/helm/alfresco-content-services/charts/alfresco-elasticsearch-connector/templates/secret-elasticsearch.yaml
+++ b/helm/alfresco-content-services/charts/alfresco-elasticsearch-connector/templates/secret-elasticsearch.yaml
@@ -10,6 +10,6 @@ metadata:
     component: search
 type: Opaque
 data:
-  ELASTICSEARCH_USERNAME: {{ .Values.elasticsearch.user | default .Values.global.elasticsearch.user | b64enc | quote }}
-  ELASTICSEARCH_PASSWORD: {{ .Values.elasticsearch.password  | default .Values.global.elasticsearch.password | b64enc | quote }}
+  ELASTICSEARCH_USERNAME: {{ .Values.elasticsearch.user | default .Values.global.elasticsearch.user | default "" | b64enc | quote }}
+  ELASTICSEARCH_PASSWORD: {{ .Values.elasticsearch.password | default .Values.global.elasticsearch.password | default "" | b64enc | quote }}
 {{- end }}

--- a/helm/alfresco-content-services/charts/alfresco-elasticsearch-connector/templates/secret-elasticsearch.yaml
+++ b/helm/alfresco-content-services/charts/alfresco-elasticsearch-connector/templates/secret-elasticsearch.yaml
@@ -1,0 +1,15 @@
+{{- if not .Values.global.elasticsearch.existingSecretName }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "alfresco-elasticsearch-connector.fullName" . }}-elasticsearch-secret
+  labels:
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    component: search
+type: Opaque
+data:
+  ELASTICSEARCH_USERNAME: {{ .Values.elasticsearch.user | default .Values.global.elasticsearch.user | b64enc | quote }}
+  ELASTICSEARCH_PASSWORD: {{ .Values.elasticsearch.password  | default .Values.global.elasticsearch.password | b64enc | quote }}
+{{- end }}

--- a/helm/alfresco-content-services/charts/alfresco-elasticsearch-connector/templates/secret-elasticsearch.yaml
+++ b/helm/alfresco-content-services/charts/alfresco-elasticsearch-connector/templates/secret-elasticsearch.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.global.elasticsearch.existingSecretName }}
+{{- if and (not .Values.global.elasticsearch.existingSecretName) (not .Values.elasticsearch.existingSecretName)  }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/helm/alfresco-content-services/charts/alfresco-elasticsearch-connector/tests/liveindexing_test.yaml
+++ b/helm/alfresco-content-services/charts/alfresco-elasticsearch-connector/tests/liveindexing_test.yaml
@@ -4,7 +4,7 @@ templates:
   - liveindexing-config.yaml
 tests:
   - it: |
-      Render elastcisearch Liveindexing,
+      Render elasticsearch Liveindexing configmap,
       using global config to ensure it overrides default values.
     values:
       - ../../../tests/values/test_values.yaml
@@ -19,11 +19,8 @@ tests:
       - equal:
           path: data.SPRING_ELASTICSEARCH_REST_URIS
           value: https://someglobally.used.host:1443
-      - equal:
-          path: data.SPRING_ELASTICSEARCH_REST_USERNAME
-          value: admin
   - it: |
-      Render elastcisearch Liveindexing,
+      Render elasticsearch Liveindexing configmap,
       using config provided in elasticsearch context to ensure it takes
       precedence over any global parameter.
     values:
@@ -38,6 +35,3 @@ tests:
       - equal:
           path: data.SPRING_ELASTICSEARCH_REST_URIS
           value: https://some.es.instance.somwhere.on.the.cloud:443
-      - equal:
-          path: data.SPRING_ELASTICSEARCH_REST_USERNAME
-          value: alfresco

--- a/helm/alfresco-content-services/charts/alfresco-elasticsearch-connector/tests/liveindexing_test.yaml
+++ b/helm/alfresco-content-services/charts/alfresco-elasticsearch-connector/tests/liveindexing_test.yaml
@@ -2,11 +2,12 @@
 suite: test liveindexing template rendering
 templates:
   - liveindexing-config.yaml
+  - liveindexing-deployment.yaml
 tests:
   - it: |
       Render elasticsearch Liveindexing configmap,
       using global config to ensure it overrides default values.
-    values:
+    values: &testvalues
       - ../../../tests/values/test_values.yaml
     set:
       global:
@@ -35,3 +36,14 @@ tests:
       - equal:
           path: data.SPRING_ELASTICSEARCH_REST_URIS
           value: https://some.es.instance.somwhere.on.the.cloud:443
+  - it: should have env vars for elasticsearch credentials
+    values: *testvalues
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[3].name
+          value: SPRING_ELASTICSEARCH_REST_USERNAME
+        template: liveindexing-deployment.yaml
+      - equal:
+          path: spec.template.spec.containers[0].env[4].name
+          value: SPRING_ELASTICSEARCH_REST_PASSWORD
+        template: liveindexing-deployment.yaml

--- a/helm/alfresco-content-services/charts/alfresco-elasticsearch-connector/tests/reindexing_test.yaml
+++ b/helm/alfresco-content-services/charts/alfresco-elasticsearch-connector/tests/reindexing_test.yaml
@@ -13,6 +13,21 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].env[1].name
           value: SPRING_DATASOURCE_USERNAME
+  - it: should have env vars for elasticsearch credentials
+    values: *testvalues
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[5].name
+          value: SPRING_ELASTICSEARCH_REST_USERNAME
+      - equal:
+          path: spec.template.spec.containers[0].env[5].valueFrom.secretKeyRef.name
+          value: RELEASE-NAME-alfresco-elasticsearch-connector-elasticsearch-secret
+      - equal:
+          path: spec.template.spec.containers[0].env[6].name
+          value: SPRING_ELASTICSEARCH_REST_PASSWORD
+      - equal:
+          path: spec.template.spec.containers[0].env[6].valueFrom.secretKeyRef.name
+          value: RELEASE-NAME-alfresco-elasticsearch-connector-elasticsearch-secret
   - it: should not be present when disabled
     values: *testvalues
     set:

--- a/helm/alfresco-content-services/charts/alfresco-elasticsearch-connector/tests/secret-elasticsearch_test.yaml
+++ b/helm/alfresco-content-services/charts/alfresco-elasticsearch-connector/tests/secret-elasticsearch_test.yaml
@@ -16,6 +16,7 @@ tests:
           path: data.ELASTICSEARCH_USERNAME
       - isEmpty:
           path: data.ELASTICSEARCH_PASSWORD
+
   - it: should have credentials populated when global credentials are set
     values: *testvalues
     set:
@@ -24,11 +25,14 @@ tests:
           user: admin
           password: letmein
     asserts:
-      - isNotEmpty:
+      - equal:
           path: data.ELASTICSEARCH_USERNAME
-      - isNotEmpty:
+          value: YWRtaW4=
+      - equal:
           path: data.ELASTICSEARCH_PASSWORD
-  - it: should not have a secret manifest at all when global existingSecretName is set
+          value: bGV0bWVpbg==
+
+  - it: should not have a secret when global existingSecretName is set
     values: *testvalues
     set:
       global:
@@ -37,7 +41,8 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
-  - it: should not have a secret manifest at all when override existingSecretName is set
+
+  - it: should not have a secret when override existingSecretName is set
     values: *testvalues
     set:
       elasticsearch:

--- a/helm/alfresco-content-services/charts/alfresco-elasticsearch-connector/tests/secret-elasticsearch_test.yaml
+++ b/helm/alfresco-content-services/charts/alfresco-elasticsearch-connector/tests/secret-elasticsearch_test.yaml
@@ -28,12 +28,20 @@ tests:
           path: data.ELASTICSEARCH_USERNAME
       - isNotEmpty:
           path: data.ELASTICSEARCH_PASSWORD
-  - it: should not have a secret manifest at all when existingSecretName is set
+  - it: should not have a secret manifest at all when global existingSecretName is set
     values: *testvalues
     set:
       global:
         elasticsearch:
           existingSecretName: whatever
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: should not have a secret manifest at all when override existingSecretName is set
+    values: *testvalues
+    set:
+      elasticsearch:
+        existingSecretName: whatever
     asserts:
       - hasDocuments:
           count: 0

--- a/helm/alfresco-content-services/charts/alfresco-elasticsearch-connector/tests/secret_test.yaml
+++ b/helm/alfresco-content-services/charts/alfresco-elasticsearch-connector/tests/secret_test.yaml
@@ -6,6 +6,11 @@ tests:
   - it: should have empty credentials as default
     values: &testvalues
       - ../../../tests/values/test_values.yaml
+    set:
+      global:
+        elasticsearch:
+          user: null
+          password: null
     asserts:
       - isEmpty:
           path: data.ELASTICSEARCH_USERNAME

--- a/helm/alfresco-content-services/charts/alfresco-elasticsearch-connector/tests/secret_test.yaml
+++ b/helm/alfresco-content-services/charts/alfresco-elasticsearch-connector/tests/secret_test.yaml
@@ -1,0 +1,34 @@
+---
+suite: test es credentials secret manifest
+templates:
+  - secret-elasticsearch.yaml
+tests:
+  - it: should have empty credentials as default
+    values: &testvalues
+      - ../../../tests/values/test_values.yaml
+    asserts:
+      - isEmpty:
+          path: data.ELASTICSEARCH_USERNAME
+      - isEmpty:
+          path: data.ELASTICSEARCH_PASSWORD
+  - it: should have credentials populated when global credentials are set
+    values: *testvalues
+    set:
+      global:
+        elasticsearch:
+          user: admin
+          password: letmein
+    asserts:
+      - isNotEmpty:
+          path: data.ELASTICSEARCH_USERNAME
+      - isNotEmpty:
+          path: data.ELASTICSEARCH_PASSWORD
+  - it: should not have a secret manifest at all when existingSecretName is set
+    values: *testvalues
+    set:
+      global:
+        elasticsearch:
+          existingSecretName: whatever
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/helm/alfresco-content-services/charts/alfresco-elasticsearch-connector/values.yaml
+++ b/helm/alfresco-content-services/charts/alfresco-elasticsearch-connector/values.yaml
@@ -87,5 +87,5 @@ global:
     user: null
     # -- The password required to access the service, if any
     password: null
-    # -- An existing secret that contains X and Y keys
+    # -- An existing secret that contains ELASTICSEARCH_USERNAME and ELASTICSEARCH_PASSWORD keys
     existingSecretName:

--- a/helm/alfresco-content-services/charts/alfresco-elasticsearch-connector/values.yaml
+++ b/helm/alfresco-content-services/charts/alfresco-elasticsearch-connector/values.yaml
@@ -87,3 +87,5 @@ global:
     user: null
     # -- The password required to access the service, if any
     password: null
+    # -- An existing secret that contains X and Y keys
+    existingSecretName:

--- a/helm/alfresco-content-services/charts/alfresco-elasticsearch-connector/values.yaml
+++ b/helm/alfresco-content-services/charts/alfresco-elasticsearch-connector/values.yaml
@@ -65,6 +65,7 @@ elasticsearch:
   protocol: null
   user: null
   password: null
+  existingSecretName:
 messageBroker:
   # --  Broker URL formatted as per:
   # https://activemq.apache.org/failover-transport-reference


### PR DESCRIPTION
Ref: OPSEXP-1651

- [x] elasticsearch credentials in existing secret
- [x] add unit tests

[OPSEXP-1651]: https://alfresco.atlassian.net/browse/OPSEXP-1651?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ