### PR TITLE
OPSEXP-1761: Bump Alfresco/alfresco-build-tools from 1.26.0 to 1.28.0

### DIFF
--- a/.github/workflows/docker-compose-community.yml
+++ b/.github/workflows/docker-compose-community.yml
@@ -17,6 +17,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: >-
-          Alfresco/alfresco-build-tools/.github/actions/dbp-charts/verify-compose@v1.26.0
+          Alfresco/alfresco-build-tools/.github/actions/dbp-charts/verify-compose@v1.28.0
         with:
           compose_file_path: docker-compose/community-docker-compose.yml

--- a/.github/workflows/docker-compose-enterprise.yml
+++ b/.github/workflows/docker-compose-enterprise.yml
@@ -32,7 +32,7 @@ jobs:
       )
     steps:
       - uses: >-
-          Alfresco/alfresco-build-tools/.github/actions/dbp-charts/verify-compose@v1.26.0
+          Alfresco/alfresco-build-tools/.github/actions/dbp-charts/verify-compose@v1.28.0
         with:
           compose_file_path: docker-compose/${{ matrix.compose_file }}
           quay_username: ${{ secrets.QUAY_USERNAME }}

--- a/.github/workflows/helm-community.yml
+++ b/.github/workflows/helm-community.yml
@@ -42,11 +42,11 @@ jobs:
           charts-root: helm
           chart-name: alfresco-content-services
       - uses: >-
-          Alfresco/alfresco-build-tools/.github/actions/build-helm-chart@v1.26.0
+          Alfresco/alfresco-build-tools/.github/actions/build-helm-chart@v1.28.0
         with:
           chart-dir: helm/${{ matrix.charts.name }}
       - uses: >-
-          Alfresco/alfresco-build-tools/.github/actions/helm-unit-tests@v1.26.0
+          Alfresco/alfresco-build-tools/.github/actions/helm-unit-tests@v1.28.0
         with:
           chart-dir: helm/${{ matrix.charts.name }}
           chart-type: ${{ matrix.charts.type }}
@@ -57,7 +57,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Setup cluster
-        uses: Alfresco/alfresco-build-tools/.github/actions/setup-kind@v1.26.0
+        uses: Alfresco/alfresco-build-tools/.github/actions/setup-kind@v1.28.0
       - name: Use local dependencies
         uses: ./.github/actions/use-local-deps
         with:

--- a/.github/workflows/helm-enterprise.yml
+++ b/.github/workflows/helm-enterprise.yml
@@ -61,7 +61,6 @@ jobs:
     name: Helm ${{ matrix.name }} ${{ matrix.values }} 
     strategy:
       fail-fast: false
-      max-parallel: 2
       matrix:
         include: ${{ fromJSON(needs.build_vars.outputs.ver_json) }}
     steps:
@@ -86,7 +85,7 @@ jobs:
           charts-root: helm
           chart-name: ${{ matrix.name }}
       - uses: >-
-          Alfresco/alfresco-build-tools/.github/actions/dbp-charts/verify-helm@v1.26.0
+          Alfresco/alfresco-build-tools/.github/actions/dbp-charts/verify-helm@v1.28.0
         with:
           skip_checkout: 'true'
           test_newman: 'true'

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -42,7 +42,7 @@ jobs:
           fetch-depth: 0
       - name: Publish chart
         uses: >-
-          Alfresco/alfresco-build-tools/.github/actions/dbp-charts/publish-chart@v1.26.0
+          Alfresco/alfresco-build-tools/.github/actions/dbp-charts/publish-chart@v1.28.0
         with:
           chart_name: ${{ matrix.charts }}
           github_token: ${{ secrets.BOT_GITHUB_TOKEN }}

--- a/.github/workflows/pre-commit-compose.yml
+++ b/.github/workflows/pre-commit-compose.yml
@@ -21,4 +21,4 @@ jobs:
     name: Run pre-commit
     runs-on: ubuntu-latest
     steps:
-      - uses: Alfresco/alfresco-build-tools/.github/actions/pre-commit@v1.26.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/pre-commit@v1.28.0

--- a/.github/workflows/pre-commit-helm-docs.yml
+++ b/.github/workflows/pre-commit-helm-docs.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-helm-docs@v1.26.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-helm-docs@v1.28.0
       - uses: pre-commit/action@v3.0.0
         with:
           extra_args: helm-docs --all-files


### PR DESCRIPTION
Ref: OPSEXP-1761
Ref: https://github.com/Alfresco/alfresco-build-tools/pull/210

Also unset concurrency limits 

[OPSEXP-1761]: https://alfresco.atlassian.net/browse/OPSEXP-1761?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ