### PR TITLE
OPSEXP-1651 support existing secret for search ingress

### DIFF
--- a/helm/alfresco-content-services/README.md
+++ b/helm/alfresco-content-services/README.md
@@ -107,7 +107,7 @@ Please refer to the [documentation](https://github.com/Alfresco/acs-deployment/b
 | alfresco-search.external.host | string | `nil` | Host dns/ip of the external solr6 instance. |
 | alfresco-search.external.port | string | `nil` | Port of the external solr6 instance. |
 | alfresco-search.ingress.basicAuth | string | `nil` | Default solr basic auth user/password: admin / admin You can create your own with htpasswd utilility & encode it with base64. Example: `echo -n "$(htpasswd -nbm admin admin)" | base64 | tr -d '\n'` basicAuth: YWRtaW46JGFwcjEkVVJqb29uS00kSEMuS1EwVkRScFpwSHB2a3JwTDd1Lg== |
-| alfresco-search.ingress.enabled | bool | `false` | Alfresco Search services endpoint ('/solr') is disabled by default |
+| alfresco-search.ingress.enabled | bool | `false` | Alfresco Search services endpoint ('/solr') |
 | alfresco-search.ingress.tls | list | `[]` |  |
 | alfresco-search.nodeSelector | object | `{}` |  |
 | alfresco-search.repository.host | string | `"alfresco-cs"` |  |

--- a/helm/alfresco-content-services/charts/alfresco-search/README.md
+++ b/helm/alfresco-content-services/charts/alfresco-search/README.md
@@ -30,6 +30,7 @@ Please refer to the [documentation](https://github.com/Alfresco/acs-deployment/b
 | global.tracking.sharedsecret | string | `nil` | Shared secret to authenticate repo/solr traffic |
 | ingress.basicAuth | string | `"YWRtaW46JGFwcjEkVVJqb29uS00kSEMuS1EwVkRScFpwSHB2a3JwTDd1Lg=="` | Default solr basic auth user/password: admin / admin You can create your own with htpasswd utilility & encode it with base640. Example: `echo -n "$(htpasswd -nbm admin admin)" | base64 | tr -d '\n'` # i.e. admin / admin basicAuth: YWRtaW46JGFwcjEkVVJqb29uS00kSEMuS1EwVkRScFpwSHB2a3JwTDd1Lg== |
 | ingress.enabled | bool | `true` |  |
+| ingress.existingSecretName | string | `nil` | An existing secret that contains an `auth` key with a value in the same format of `ingress.basicAuth` |
 | ingress.path | string | `"/solr"` |  |
 | ingress.tls | list | `[]` |  |
 | ingress.whitelist_ips | string | `"0.0.0.0/0"` | Comma separated list of IP CIDR to limit search endpoint over the internet |

--- a/helm/alfresco-content-services/charts/alfresco-search/README.md
+++ b/helm/alfresco-content-services/charts/alfresco-search/README.md
@@ -28,8 +28,8 @@ Please refer to the [documentation](https://github.com/Alfresco/acs-deployment/b
 | global | object | `{"alfrescoRegistryPullSecrets":"quay-registry-secret","tracking":{"auth":"secret","sharedsecret":null}}` | Apply your secret file in k8s environment to access quay.io images (Example: https://github.com/Alfresco/alfresco-anaxes-shipyard/blob/master/SECRETS.md) Global definition of Docker registry pull secret which can be overridden from parent ACS Helm chart(s) |
 | global.tracking.auth | string | `"secret"` | Select how solr and repo authenticate to each other none: work only prior to acs 7.2 (and was the default) secret: use a shared secret (to specify using `tracking.sharedsecret`) https: to use mTLS auth (require appropriate certificate configuration) |
 | global.tracking.sharedsecret | string | `nil` | Shared secret to authenticate repo/solr traffic |
-| ingress.basicAuth | string | `"YWRtaW46JGFwcjEkVVJqb29uS00kSEMuS1EwVkRScFpwSHB2a3JwTDd1Lg=="` | Default solr basic auth user/password: admin / admin You can create your own with htpasswd utilility & encode it with base640. Example: `echo -n "$(htpasswd -nbm admin admin)" | base64 | tr -d '\n'` # i.e. admin / admin basicAuth: YWRtaW46JGFwcjEkVVJqb29uS00kSEMuS1EwVkRScFpwSHB2a3JwTDd1Lg== |
-| ingress.enabled | bool | `true` |  |
+| ingress.basicAuth | string | `nil` | Default solr basic auth user/password: admin / admin You can create your own with htpasswd utilility & encode it with base640. Example: `echo -n "$(htpasswd -nbm admin admin)" | base64 | tr -d '\n'` # i.e. admin / admin basicAuth: YWRtaW46JGFwcjEkVVJqb29uS00kSEMuS1EwVkRScFpwSHB2a3JwTDd1Lg== |
+| ingress.enabled | bool | `false` | Expose the solr admin console behind basic auth |
 | ingress.existingSecretName | string | `nil` | An existing secret that contains an `auth` key with a value in the same format of `ingress.basicAuth` |
 | ingress.path | string | `"/solr"` |  |
 | ingress.tls | list | `[]` |  |

--- a/helm/alfresco-content-services/charts/alfresco-search/templates/ingress.yaml
+++ b/helm/alfresco-content-services/charts/alfresco-search/templates/ingress.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/auth-type: basic
-    nginx.ingress.kubernetes.io/auth-secret: {{ template "alfresco-search.fullName" . }}-solr
+    nginx.ingress.kubernetes.io/auth-secret: {{ default (printf "%s-solr" (include "alfresco-search.fullName" $)) $.Values.ingress.existingSecretName }}
     nginx.ingress.kubernetes.io/auth-realm: "Authentication Required - Alfresco Search Services"
     nginx.ingress.kubernetes.io/whitelist-source-range: {{ .Values.ingress.whitelist_ips }}
 

--- a/helm/alfresco-content-services/charts/alfresco-search/templates/secrets.yaml
+++ b/helm/alfresco-content-services/charts/alfresco-search/templates/secrets.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.ingress.enabled }}
+{{- if and (not .Values.ingress.existingSecretName) .Values.ingress.enabled }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/helm/alfresco-content-services/charts/alfresco-search/tests/ingress_test.yaml
+++ b/helm/alfresco-content-services/charts/alfresco-search/tests/ingress_test.yaml
@@ -3,14 +3,23 @@ suite: test ingress
 templates:
   - ingress.yaml
 tests:
-  - it: should reference the default secret with default values
+  - it: should have basic metadata in place
     values: &testvalues
       - ../../../tests/values/test_values.yaml
+      - values/ingress.yaml
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-alfresco-search-solr
+        template: ingress.yaml
+
+  - it: should reference the default secret with default values
+    values: *testvalues
     asserts:
       - equal:
           path: metadata.annotations.nginx\.ingress\.kubernetes\.io/auth-secret
           value: RELEASE-NAME-alfresco-search-solr
-        documentIndex: 0
+        template: ingress.yaml
 
   - it: should reference the existing secret when ingress.existingSecretName is set
     values: *testvalues
@@ -21,4 +30,4 @@ tests:
       - equal:
           path: metadata.annotations.nginx\.ingress\.kubernetes\.io/auth-secret
           value: my-custom-ingress-secret
-        documentIndex: 0
+        template: ingress.yaml

--- a/helm/alfresco-content-services/charts/alfresco-search/tests/ingress_test.yaml
+++ b/helm/alfresco-content-services/charts/alfresco-search/tests/ingress_test.yaml
@@ -1,0 +1,24 @@
+---
+suite: test ingress
+templates:
+  - ingress.yaml
+tests:
+  - it: should reference the default secret with default values
+    values: &testvalues
+      - ../../../tests/values/test_values.yaml
+    asserts:
+      - equal:
+          path: metadata.annotations.nginx\.ingress\.kubernetes\.io/auth-secret
+          value: RELEASE-NAME-alfresco-search-solr
+        documentIndex: 0
+
+  - it: should reference the existing secret when ingress.existingSecretName is set
+    values: *testvalues
+    set:
+      ingress:
+        existingSecretName: my-custom-ingress-secret
+    asserts:
+      - equal:
+          path: metadata.annotations.nginx\.ingress\.kubernetes\.io/auth-secret
+          value: my-custom-ingress-secret
+        documentIndex: 0

--- a/helm/alfresco-content-services/charts/alfresco-search/tests/secret_test.yaml
+++ b/helm/alfresco-content-services/charts/alfresco-search/tests/secret_test.yaml
@@ -1,0 +1,31 @@
+---
+suite: test ingress secret
+templates:
+  - secrets.yaml
+tests:
+  - it: should have credentials in the ingress secret
+    values: &testvalues
+      - ../../../tests/values/test_values.yaml
+    asserts:
+      - equal:
+          path: data.auth
+          value: YWRtaW46JGFwcjEkVVJqb29uS00kSEMuS1EwVkRScFpwSHB2a3JwTDd1Lg==
+        documentIndex: 0
+  - it: should not render ingress secret when ingress is disabled
+    values: *testvalues
+    set:
+      ingress:
+        enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+        documentIndex: 0
+  - it: should not render ingress secret when and existing secret name is set
+    values: *testvalues
+    set:
+      ingress:
+        existingSecretName: my-custom-secret
+    asserts:
+      - hasDocuments:
+          count: 0
+        documentIndex: 0

--- a/helm/alfresco-content-services/charts/alfresco-search/tests/secret_test.yaml
+++ b/helm/alfresco-content-services/charts/alfresco-search/tests/secret_test.yaml
@@ -6,11 +6,13 @@ tests:
   - it: should have credentials in the ingress secret
     values: &testvalues
       - ../../../tests/values/test_values.yaml
+      - values/ingress.yaml
     asserts:
       - equal:
           path: data.auth
           value: YWRtaW46JGFwcjEkVVJqb29uS00kSEMuS1EwVkRScFpwSHB2a3JwTDd1Lg==
-        documentIndex: 0
+        template: secrets.yaml
+  
   - it: should not render ingress secret when ingress is disabled
     values: *testvalues
     set:
@@ -19,7 +21,8 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
-        documentIndex: 0
+        template: secrets.yaml
+  
   - it: should not render ingress secret when and existing secret name is set
     values: *testvalues
     set:
@@ -28,4 +31,4 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
-        documentIndex: 0
+        template: secrets.yaml

--- a/helm/alfresco-content-services/charts/alfresco-search/tests/values/ingress.yaml
+++ b/helm/alfresco-content-services/charts/alfresco-search/tests/values/ingress.yaml
@@ -1,0 +1,3 @@
+---
+ingress:
+  enabled: true

--- a/helm/alfresco-content-services/charts/alfresco-search/tests/values/ingress.yaml
+++ b/helm/alfresco-content-services/charts/alfresco-search/tests/values/ingress.yaml
@@ -1,3 +1,4 @@
 ---
 ingress:
   enabled: true
+  basicAuth: YWRtaW46JGFwcjEkVVJqb29uS00kSEMuS1EwVkRScFpwSHB2a3JwTDd1Lg==

--- a/helm/alfresco-content-services/charts/alfresco-search/values.yaml
+++ b/helm/alfresco-content-services/charts/alfresco-search/values.yaml
@@ -25,7 +25,8 @@ service:
   type: ClusterIP
   externalPort: 80
 ingress:
-  enabled: true
+  # -- Expose the solr admin console behind basic auth
+  enabled: false
   path: /solr
   tls: []
   #  - secretName: chart-example-tls
@@ -36,7 +37,7 @@ ingress:
   # You can create your own with htpasswd utilility & encode it with base640.
   # Example: `echo -n "$(htpasswd -nbm admin admin)" | base64 | tr -d '\n'` # i.e. admin / admin
   # basicAuth: YWRtaW46JGFwcjEkVVJqb29uS00kSEMuS1EwVkRScFpwSHB2a3JwTDd1Lg==
-  basicAuth: YWRtaW46JGFwcjEkVVJqb29uS00kSEMuS1EwVkRScFpwSHB2a3JwTDd1Lg==
+  basicAuth:
   # -- An existing secret that contains an `auth` key with a value in the same format of `ingress.basicAuth`
   existingSecretName:
   # -- Comma separated list of IP CIDR to limit search endpoint over the internet

--- a/helm/alfresco-content-services/charts/alfresco-search/values.yaml
+++ b/helm/alfresco-content-services/charts/alfresco-search/values.yaml
@@ -37,6 +37,8 @@ ingress:
   # Example: `echo -n "$(htpasswd -nbm admin admin)" | base64 | tr -d '\n'` # i.e. admin / admin
   # basicAuth: YWRtaW46JGFwcjEkVVJqb29uS00kSEMuS1EwVkRScFpwSHB2a3JwTDd1Lg==
   basicAuth: YWRtaW46JGFwcjEkVVJqb29uS00kSEMuS1EwVkRScFpwSHB2a3JwTDd1Lg==
+  # -- An existing secret that contains an `auth` key with a value in the same format of `ingress.basicAuth`
+  existingSecretName:
   # -- Comma separated list of IP CIDR to limit search endpoint over the internet
   whitelist_ips: "0.0.0.0/0"
 # -- The parent chart will set the values for "repository.host" and "repository.port"

--- a/helm/alfresco-content-services/values.yaml
+++ b/helm/alfresco-content-services/values.yaml
@@ -571,7 +571,7 @@ alfresco-search:
       enabled: false
     repository: *repositoryHostPort
   ingress:
-    # -- Alfresco Search services endpoint ('/solr') is disabled by default
+    # -- Alfresco Search services endpoint ('/solr')
     enabled: false
     # -- Default solr basic auth user/password: admin / admin
     # You can create your own with htpasswd utilility & encode it with base64.


### PR DESCRIPTION
Ref: OPSEXP-1651

- [x] support existing secret for search ingress
- [x] add unit tests

[OPSEXP-1651]: https://alfresco.atlassian.net/browse/OPSEXP-1651?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ