### PR TITLE
OPSEXP-1651 Use existing secret to configure ACS postgres credentials

### DIFF
--- a/helm/alfresco-content-services/README.md
+++ b/helm/alfresco-content-services/README.md
@@ -124,11 +124,11 @@ Please refer to the [documentation](https://github.com/Alfresco/acs-deployment/b
 | alfresco-sync-service.nodeSelector | object | `{}` |  |
 | alfresco-sync-service.syncservice.enabled | bool | `true` |  |
 | apiexplorer | object | `{"ingress":{"path":"/api-explorer"}}` | Declares the api-explorer service used by the content repository |
-| database | object | `{"driver":null,"external":false,"password":null,"url":null,"user":null}` | Defines properties required by alfresco for connecting to the database Note! : If you set database.external to true you will have to setup the driver, user, password and JdbcUrl. Also make sure that the container has the db driver in /usr/local/tomcat/lib since the current image only has the postgresql driver |
-| database.driver | string | `nil` | ex: org.postgresql.Driver |
-| database.password | string | `nil` | ex: alfresco |
-| database.url | string | `nil` | ex: jdbc:postgresql://oldfashioned-mule-postgresql-acs:5432/alfresco |
-| database.user | string | `nil` | ex: alfresco |
+| database.driver | string | `nil` | Postgresql jdbc driver name ex: org.postgresql.Driver. It should be available in the container image. |
+| database.external | bool | `false` | Enable using an external database for Alfresco Content Services |
+| database.password | string | `nil` | External Postgresql database password |
+| database.url | string | `nil` | External Postgresql jdbc url ex: `jdbc:postgresql://oldfashioned-mule-postgresql-acs:5432/alfresco` |
+| database.user | string | `nil` | External Postgresql database user |
 | elasticsearch | object | `{"clusterHealthCheckParams":"wait_for_status=yellow&timeout=1s","enabled":false,"image":"docker.elastic.co/elasticsearch/elasticsearch-oss","replicas":1}` | Embedded ElasticSearch cluster powered by Bitnami charts |
 | elasticsearch.enabled | bool | `false` | Enable the embedded ElasticSearch cluster |
 | email | object | `{"handler":{"folder":{"overwriteDuplicates":true}},"inbound":{"emailContributorsAuthority":"EMAIL_CONTRIBUTORS","enabled":false,"unknownUser":"anonymous"},"initContainers":{"pemToKeystore":{"image":{"pullPolicy":"IfNotPresent","repository":"registry.access.redhat.com/redhat-sso-7/sso71-openshift","tag":"1.1-16"}},"pemToTruststore":{"image":{"pullPolicy":"IfNotPresent","repository":"registry.access.redhat.com/redhat-sso-7/sso71-openshift","tag":"1.1-16"}},"setPerms":{"image":{"pullPolicy":"IfNotPresent","repository":"busybox","tag":"1.35.0"}}},"server":{"allowed":{"senders":".*"},"auth":{"enabled":true},"blocked":{"senders":null},"connections":{"max":3},"domain":null,"enableTLS":true,"enabled":false,"hideTLS":false,"port":1125,"requireTLS":false},"ssl":{"secretName":null}}` | For a full information of configuring the inbound email ssytem, see https://docs.alfresco.com/content-services/latest/config/email/#manage-inbound-emails |
@@ -207,7 +207,6 @@ Please refer to the [documentation](https://github.com/Alfresco/acs-deployment/b
 | ooiService.service.name | string | `"ooi-service"` |  |
 | ooiService.service.type | string | `"ClusterIP"` |  |
 | pdfrenderer | object | `{"environment":{"JAVA_OPTS":"-XX:MinRAMPercentage=50 -XX:MaxRAMPercentage=80"},"image":{"internalPort":8090,"pullPolicy":"IfNotPresent","repository":"alfresco/alfresco-pdf-renderer","tag":"3.0.0"},"livenessProbe":{"initialDelaySeconds":10,"livenessPercent":150,"livenessTransformPeriodSeconds":600,"maxTransformSeconds":1200,"maxTransforms":10000,"periodSeconds":20,"timeoutSeconds":10},"nodeSelector":{},"readinessProbe":{"initialDelaySeconds":20,"periodSeconds":60,"timeoutSeconds":10},"replicaCount":2,"resources":{"limits":{"memory":"1000Mi"},"requests":{"memory":"1000Mi"}},"service":{"externalPort":80,"name":"pdfrenderer","type":"ClusterIP"}}` | Declares the alfresco-pdf-renderer service used by the content repository to transform pdf files |
-| postgresql | object | `{"commonAnnotations":{"application":"alfresco-content-services"},"enabled":true,"existingSecretName":null,"image":{"pullPolicy":"IfNotPresent","tag":"14.4.0"},"nameOverride":"postgresql-acs","persistence":{"existingClaim":null,"storageClass":null,"subPath":"alfresco-content-services/database-data"},"postgresqlDatabase":"alfresco","postgresqlExtendedConf":{"log_min_messages":"LOG","max_connections":300},"postgresqlPassword":"alfresco","postgresqlUsername":"alfresco","primary":{"nodeSelector":{}},"replicaCount":1,"resources":{"limits":{"memory":"1500Mi"},"requests":{"memory":"1500Mi"}}}` | Defines the properties to be used for the required postgres DB Note: the database (tables) information is also saved in the persistent volume claim |
 | postgresql-syncservice.commonAnnotations.application | string | `"alfresco-content-services"` |  |
 | postgresql-syncservice.enabled | bool | `true` | Enable embedded postgres for Alfresco Sync service leveraging the postgresql Bitnami chart |
 | postgresql-syncservice.image.pullPolicy | string | `"IfNotPresent"` |  |
@@ -224,13 +223,24 @@ Please refer to the [documentation](https://github.com/Alfresco/acs-deployment/b
 | postgresql-syncservice.resources.limits.memory | string | `"1500Mi"` |  |
 | postgresql-syncservice.resources.requests.memory | string | `"1500Mi"` |  |
 | postgresql-syncservice.service.port | int | `5432` |  |
+| postgresql.commonAnnotations.application | string | `"alfresco-content-services"` |  |
 | postgresql.enabled | bool | `true` | Enable embedded postgres for Alfresco Content Services leveraging the postgresql Bitnami chart Note: Must be set to false if you use an external database. |
 | postgresql.existingSecretName | string | `nil` | An existing secret that contains DATABASE_USERNAME and DATABASE_PASSWORD keys |
+| postgresql.image.pullPolicy | string | `"IfNotPresent"` |  |
+| postgresql.image.tag | string | `"14.4.0"` |  |
+| postgresql.nameOverride | string | `"postgresql-acs"` |  |
 | postgresql.persistence.existingClaim | string | `nil` | provide an existing persistent volume claim name to persist SQL data Make sure the root folder has the appropriate permissions/ownhership set. |
 | postgresql.persistence.storageClass | string | `nil` | set the storageClass to use for dynamic provisioning. setting it to null means "default storageClass". |
+| postgresql.persistence.subPath | string | `"alfresco-content-services/database-data"` |  |
 | postgresql.postgresqlDatabase | string | `"alfresco"` | Postgresql database name |
+| postgresql.postgresqlExtendedConf.log_min_messages | string | `"LOG"` |  |
+| postgresql.postgresqlExtendedConf.max_connections | int | `300` |  |
 | postgresql.postgresqlPassword | string | `"alfresco"` | Postgresql database password |
 | postgresql.postgresqlUsername | string | `"alfresco"` | Postgresql database user |
+| postgresql.primary.nodeSelector | object | `{}` |  |
+| postgresql.replicaCount | int | `1` |  |
+| postgresql.resources.limits.memory | string | `"1500Mi"` |  |
+| postgresql.resources.requests.memory | string | `"1500Mi"` |  |
 | repository.adminPassword | string | `"209c6174da490caeb422f3fa5a7ae634"` | Administrator password for ACS in md5 hash format |
 | repository.command | list | `[]` |  |
 | repository.edition | string | `"Enterprise"` |  |

--- a/helm/alfresco-content-services/README.md
+++ b/helm/alfresco-content-services/README.md
@@ -125,7 +125,8 @@ Please refer to the [documentation](https://github.com/Alfresco/acs-deployment/b
 | alfresco-sync-service.syncservice.enabled | bool | `true` |  |
 | apiexplorer | object | `{"ingress":{"path":"/api-explorer"}}` | Declares the api-explorer service used by the content repository |
 | database.driver | string | `nil` | Postgresql jdbc driver name ex: org.postgresql.Driver. It should be available in the container image. |
-| database.external | bool | `false` | Enable using an external database for Alfresco Content Services |
+| database.existingSecretName | string | `nil` | An existing secret that contains DATABASE_USERNAME and DATABASE_PASSWORD keys. When using embedded postgres you need to also set `postgresql.existingSecret`. |
+| database.external | bool | `false` | Enable using an external database for Alfresco Content Services. Must disable `postgresql.enabled` when true. |
 | database.password | string | `nil` | External Postgresql database password |
 | database.url | string | `nil` | External Postgresql jdbc url ex: `jdbc:postgresql://oldfashioned-mule-postgresql-acs:5432/alfresco` |
 | database.user | string | `nil` | External Postgresql database user |
@@ -224,8 +225,8 @@ Please refer to the [documentation](https://github.com/Alfresco/acs-deployment/b
 | postgresql-syncservice.resources.requests.memory | string | `"1500Mi"` |  |
 | postgresql-syncservice.service.port | int | `5432` |  |
 | postgresql.commonAnnotations.application | string | `"alfresco-content-services"` |  |
-| postgresql.enabled | bool | `true` | Enable embedded postgres for Alfresco Content Services leveraging the postgresql Bitnami chart Note: Must be set to false if you use an external database. |
-| postgresql.existingSecretName | string | `nil` | An existing secret that contains DATABASE_USERNAME and DATABASE_PASSWORD keys |
+| postgresql.enabled | bool | `true` | Enable embedded postgres for Alfresco Content Services leveraging the postgresql Bitnami chart |
+| postgresql.existingSecret | string | `nil` | Name of existing secret to use for PostgreSQL passwords The secret has to contain the keys postgresql-password which is the password for postgresqlUsername when it is different of postgres, postgresql-postgres-password which will override postgresqlPassword. The same secret must be set also as `database.existingSecretName` to provide the credentials to ACS. |
 | postgresql.image.pullPolicy | string | `"IfNotPresent"` |  |
 | postgresql.image.tag | string | `"14.4.0"` |  |
 | postgresql.nameOverride | string | `"postgresql-acs"` |  |

--- a/helm/alfresco-content-services/README.md
+++ b/helm/alfresco-content-services/README.md
@@ -207,12 +207,12 @@ Please refer to the [documentation](https://github.com/Alfresco/acs-deployment/b
 | ooiService.service.name | string | `"ooi-service"` |  |
 | ooiService.service.type | string | `"ClusterIP"` |  |
 | pdfrenderer | object | `{"environment":{"JAVA_OPTS":"-XX:MinRAMPercentage=50 -XX:MaxRAMPercentage=80"},"image":{"internalPort":8090,"pullPolicy":"IfNotPresent","repository":"alfresco/alfresco-pdf-renderer","tag":"3.0.0"},"livenessProbe":{"initialDelaySeconds":10,"livenessPercent":150,"livenessTransformPeriodSeconds":600,"maxTransformSeconds":1200,"maxTransforms":10000,"periodSeconds":20,"timeoutSeconds":10},"nodeSelector":{},"readinessProbe":{"initialDelaySeconds":20,"periodSeconds":60,"timeoutSeconds":10},"replicaCount":2,"resources":{"limits":{"memory":"1000Mi"},"requests":{"memory":"1000Mi"}},"service":{"externalPort":80,"name":"pdfrenderer","type":"ClusterIP"}}` | Declares the alfresco-pdf-renderer service used by the content repository to transform pdf files |
-| postgresql | object | `{"commonAnnotations":{"application":"alfresco-content-services"},"enabled":true,"image":{"pullPolicy":"IfNotPresent","tag":"14.4.0"},"nameOverride":"postgresql-acs","persistence":{"existingClaim":null,"storageClass":null,"subPath":"alfresco-content-services/database-data"},"postgresqlDatabase":"alfresco","postgresqlExtendedConf":{"log_min_messages":"LOG","max_connections":300},"postgresqlPassword":"alfresco","postgresqlUsername":"alfresco","primary":{"nodeSelector":{}},"replicaCount":1,"resources":{"limits":{"memory":"1500Mi"},"requests":{"memory":"1500Mi"}}}` | Defines the properties to be used for the required postgres DB Note: the database (tables) information is also saved in the persistent volume claim |
+| postgresql | object | `{"commonAnnotations":{"application":"alfresco-content-services"},"enabled":true,"existingSecretName":null,"image":{"pullPolicy":"IfNotPresent","tag":"14.4.0"},"nameOverride":"postgresql-acs","persistence":{"existingClaim":null,"storageClass":null,"subPath":"alfresco-content-services/database-data"},"postgresqlDatabase":"alfresco","postgresqlExtendedConf":{"log_min_messages":"LOG","max_connections":300},"postgresqlPassword":"alfresco","postgresqlUsername":"alfresco","primary":{"nodeSelector":{}},"replicaCount":1,"resources":{"limits":{"memory":"1500Mi"},"requests":{"memory":"1500Mi"}}}` | Defines the properties to be used for the required postgres DB Note: the database (tables) information is also saved in the persistent volume claim |
 | postgresql-syncservice.commonAnnotations.application | string | `"alfresco-content-services"` |  |
-| postgresql-syncservice.enabled | bool | `true` |  |
+| postgresql-syncservice.enabled | bool | `true` | Enable embedded postgres for Alfresco Sync service leveraging the postgresql Bitnami chart |
 | postgresql-syncservice.image.pullPolicy | string | `"IfNotPresent"` |  |
 | postgresql-syncservice.image.tag | string | `"14.4.0"` |  |
-| postgresql-syncservice.name | string | `"postgresql-syncservice"` | If true, install the postgresql chart alongside Alfresco Sync service. Note: Set this to false if you use an external database. |
+| postgresql-syncservice.name | string | `"postgresql-syncservice"` |  |
 | postgresql-syncservice.nameOverride | string | `"postgresql-syncservice"` |  |
 | postgresql-syncservice.postgresqlDatabase | string | `"syncservice-postgresql"` |  |
 | postgresql-syncservice.postgresqlExtendedConf.log_min_messages | string | `"LOG"` |  |
@@ -224,7 +224,8 @@ Please refer to the [documentation](https://github.com/Alfresco/acs-deployment/b
 | postgresql-syncservice.resources.limits.memory | string | `"1500Mi"` |  |
 | postgresql-syncservice.resources.requests.memory | string | `"1500Mi"` |  |
 | postgresql-syncservice.service.port | int | `5432` |  |
-| postgresql.enabled | bool | `true` | If true, install the postgresql chart alongside Alfresco Content Services Note: Set this to false if you use an external database. |
+| postgresql.enabled | bool | `true` | Enable embedded postgres for Alfresco Content Services leveraging the postgresql Bitnami chart Note: Must be set to false if you use an external database. |
+| postgresql.existingSecretName | string | `nil` | An existing secret that contains DATABASE_USERNAME and DATABASE_PASSWORD keys |
 | postgresql.persistence.existingClaim | string | `nil` | provide an existing persistent volume claim name to persist SQL data Make sure the root folder has the appropriate permissions/ownhership set. |
 | postgresql.persistence.storageClass | string | `nil` | set the storageClass to use for dynamic provisioning. setting it to null means "default storageClass". |
 | postgresql.postgresqlDatabase | string | `"alfresco"` | Postgresql database name |

--- a/helm/alfresco-content-services/charts/alfresco-elasticsearch-connector/README.md
+++ b/helm/alfresco-content-services/charts/alfresco-elasticsearch-connector/README.md
@@ -60,6 +60,7 @@ Please refer to the [documentation](https://github.com/Alfresco/acs-deployment/b
 | reindexing.image.tag | string | `"3.3.0-M1"` |  |
 | reindexing.pathIndexingEnabled | bool | `true` |  |
 | reindexing.postgresql.database | string | `"alfresco"` |  |
+| reindexing.postgresql.existingSecretName | string | `nil` | An existing secret that contains DATABASE_USERNAME and DATABASE_PASSWORD keys |
 | reindexing.postgresql.hostname | string | `"postgresql-acs"` |  |
 | reindexing.postgresql.port | int | `5432` |  |
 | reindexing.postgresql.url | string | `nil` |  |

--- a/helm/alfresco-content-services/charts/alfresco-elasticsearch-connector/templates/reindexing-job.yaml
+++ b/helm/alfresco-content-services/charts/alfresco-elasticsearch-connector/templates/reindexing-job.yaml
@@ -33,12 +33,12 @@ spec:
             - name: SPRING_DATASOURCE_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "content-services.shortname" . }}-dbsecret
+                  name: {{ default (printf "%s-dbsecret" (include "content-services.shortname" $)) $.Values.reindexing.postgresql.existingSecretName }}
                   key: DATABASE_PASSWORD
             - name: SPRING_DATASOURCE_USERNAME
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "content-services.shortname" . }}-dbsecret
+                  name: {{ default (printf "%s-dbsecret" (include "content-services.shortname" $)) $.Values.reindexing.postgresql.existingSecretName }}
                   key: DATABASE_USERNAME
             {{- include "spring.activemq.env" . | nindent 12 }}
           ports:

--- a/helm/alfresco-content-services/charts/alfresco-elasticsearch-connector/tests/reindexing_test.yaml
+++ b/helm/alfresco-content-services/charts/alfresco-elasticsearch-connector/tests/reindexing_test.yaml
@@ -3,7 +3,7 @@ suite: test reindexing job manifest
 templates:
   - reindexing-job.yaml
 tests:
-  - it: should have env vars for spring database credentials
+  - it: should have env vars for spring database credentials referencing the main chart secret
     values: &testvalues
       - ../../../tests/values/test_values.yaml
     asserts:
@@ -13,6 +13,23 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].env[1].name
           value: SPRING_DATASOURCE_USERNAME
+      - equal:
+          path: spec.template.spec.containers[0].env[0].valueFrom.secretKeyRef.name
+          value: RELEASE-NAME-alfresco-cs-dbsecret
+      - equal:
+          path: spec.template.spec.containers[0].env[1].valueFrom.secretKeyRef.name
+          value: RELEASE-NAME-alfresco-cs-dbsecret
+  - it: should have overridden secret for spring database credentials when existingSecretName is set
+    values: *testvalues
+    set:
+      reindexing.postgresql.existingSecretName: my-custom-secret
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[0].valueFrom.secretKeyRef.name
+          value: my-custom-secret
+      - equal:
+          path: spec.template.spec.containers[0].env[1].valueFrom.secretKeyRef.name
+          value: my-custom-secret
   - it: should not be present when disabled
     values: *testvalues
     set:

--- a/helm/alfresco-content-services/charts/alfresco-elasticsearch-connector/values.yaml
+++ b/helm/alfresco-content-services/charts/alfresco-elasticsearch-connector/values.yaml
@@ -58,6 +58,8 @@ reindexing:
     hostname: postgresql-acs
     database: alfresco
     port: 5432
+    # -- An existing secret that contains DATABASE_USERNAME and DATABASE_PASSWORD keys
+    existingSecretName:
 # -- Overrides .Values.global.elasticsearch
 elasticsearch:
   host: null

--- a/helm/alfresco-content-services/templates/deployment-repository.yaml
+++ b/helm/alfresco-content-services/templates/deployment-repository.yaml
@@ -49,7 +49,7 @@ spec:
               name: {{ printf "%s-repository-jtoolopts" .Release.Name | quote }}
           {{- end }}
           - secretRef:
-              name: {{ template "content-services.shortname" . }}-dbsecret
+              name: {{ default (printf "%s-dbsecret" (include "content-services.shortname" $)) $.Values.postgresql.existingSecretName }}
           {{- if .Values.s3connector.enabled }}
           {{- if .Values.s3connector.secrets }}
           - secretRef:

--- a/helm/alfresco-content-services/templates/secret-database.yaml
+++ b/helm/alfresco-content-services/templates/secret-database.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.postgresql.existingSecretName }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -8,3 +9,4 @@ type: Opaque
 data:
   DATABASE_USERNAME: {{ .Values.database.user | default .Values.postgresql.postgresqlUsername | b64enc | quote }}
   DATABASE_PASSWORD: {{ .Values.database.password | default .Values.postgresql.postgresqlPassword | b64enc | quote }}
+{{- end }}

--- a/helm/alfresco-content-services/templates/secret-database.yaml
+++ b/helm/alfresco-content-services/templates/secret-database.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.postgresql.existingSecretName }}
+{{- if not .Values.database.existingSecretName }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/helm/alfresco-content-services/tests/secret-database_test.yaml
+++ b/helm/alfresco-content-services/tests/secret-database_test.yaml
@@ -16,7 +16,7 @@ tests:
   - it: should not have a secret manifest at all when existingSecretName is set
     values: *testvalues
     set:
-      postgresql.existingSecretName: whatever
+      database.existingSecretName: whatever
     asserts:
       - hasDocuments:
           count: 0

--- a/helm/alfresco-content-services/tests/secret-database_test.yaml
+++ b/helm/alfresco-content-services/tests/secret-database_test.yaml
@@ -1,0 +1,35 @@
+---
+suite: test database secret manifest
+templates:
+  - secret-database.yaml
+tests:
+  - it: should have secrets set with default values
+    values: &testvalues
+      - values/test_values.yaml
+    asserts:
+      - equal:
+          path: data.DATABASE_USERNAME
+          value: YWxmcmVzY28=
+      - equal:
+          path: data.DATABASE_USERNAME
+          value: YWxmcmVzY28=
+  - it: should not have a secret manifest at all when existingSecretName is set
+    values: *testvalues
+    set:
+      postgresql.existingSecretName: whatever
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: should override credentials when `database.*` are set
+    values: *testvalues
+    set:
+      database:
+        user: mycustomadmin
+        password: mycustompassword
+    asserts:
+      - equal:
+          path: data.DATABASE_USERNAME
+          value: bXljdXN0b21hZG1pbg==
+      - equal:
+          path: data.DATABASE_USERNAME
+          value: bXljdXN0b21hZG1pbg==

--- a/helm/alfresco-content-services/tests/secret-database_test.yaml
+++ b/helm/alfresco-content-services/tests/secret-database_test.yaml
@@ -11,8 +11,9 @@ tests:
           path: data.DATABASE_USERNAME
           value: YWxmcmVzY28=
       - equal:
-          path: data.DATABASE_USERNAME
+          path: data.DATABASE_PASSWORD
           value: YWxmcmVzY28=
+
   - it: should not have a secret manifest at all when existingSecretName is set
     values: *testvalues
     set:
@@ -20,6 +21,7 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
+
   - it: should override credentials when `database.*` are set
     values: *testvalues
     set:
@@ -31,5 +33,5 @@ tests:
           path: data.DATABASE_USERNAME
           value: bXljdXN0b21hZG1pbg==
       - equal:
-          path: data.DATABASE_USERNAME
-          value: bXljdXN0b21hZG1pbg==
+          path: data.DATABASE_PASSWORD
+          value: bXljdXN0b21wYXNzd29yZA==

--- a/helm/alfresco-content-services/values.yaml
+++ b/helm/alfresco-content-services/values.yaml
@@ -689,8 +689,8 @@ database:
 # claim
 postgresql:
   replicaCount: 1
-  # -- If true, install the postgresql chart alongside Alfresco Content Services
-  # Note: Set this to false if you use an external database.
+  # -- Enable embedded postgres for Alfresco Content Services leveraging the postgresql Bitnami chart
+  # Note: Must be set to false if you use an external database.
   enabled: true
   nameOverride: postgresql-acs
   image:
@@ -698,6 +698,8 @@ postgresql:
     pullPolicy: IfNotPresent
   commonAnnotations:
     application: alfresco-content-services
+  # -- An existing secret that contains DATABASE_USERNAME and DATABASE_PASSWORD keys
+  existingSecretName:
   # -- Postgresql database user
   postgresqlUsername: alfresco
   # -- Postgresql database password
@@ -723,9 +725,8 @@ postgresql:
     limits:
       memory: "1500Mi"
 postgresql-syncservice:
-  # -- If true, install the postgresql chart alongside Alfresco Sync service.
-  # Note: Set this to false if you use an external database.
   name: postgresql-syncservice
+  # -- Enable embedded postgres for Alfresco Sync service leveraging the postgresql Bitnami chart
   enabled: true
   replicaCount: 1
   nameOverride: postgresql-syncservice

--- a/helm/alfresco-content-services/values.yaml
+++ b/helm/alfresco-content-services/values.yaml
@@ -670,7 +670,7 @@ alfresco-admin-app:
 ooi:
   enabled: false
 database:
-  # -- Enable using an external database for Alfresco Content Services
+  # -- Enable using an external database for Alfresco Content Services. Must disable `postgresql.enabled` when true.
   external: false
   # -- Postgresql jdbc driver name ex: org.postgresql.Driver. It should be available in the container image.
   driver:
@@ -680,9 +680,11 @@ database:
   password:
   # -- External Postgresql jdbc url ex: `jdbc:postgresql://oldfashioned-mule-postgresql-acs:5432/alfresco`
   url:
+  # -- An existing secret that contains DATABASE_USERNAME and DATABASE_PASSWORD keys.
+  # When using embedded postgres you need to also set `postgresql.existingSecret`.
+  existingSecretName:
 postgresql:
   # -- Enable embedded postgres for Alfresco Content Services leveraging the postgresql Bitnami chart
-  # Note: Must be set to false if you use an external database.
   enabled: true
   replicaCount: 1
   nameOverride: postgresql-acs
@@ -691,8 +693,11 @@ postgresql:
     pullPolicy: IfNotPresent
   commonAnnotations:
     application: alfresco-content-services
-  # -- An existing secret that contains DATABASE_USERNAME and DATABASE_PASSWORD keys
-  existingSecretName:
+  # -- Name of existing secret to use for PostgreSQL passwords
+  # The secret has to contain the keys postgresql-password which is the password for postgresqlUsername when it is
+  # different of postgres, postgresql-postgres-password which will override postgresqlPassword.
+  # The same secret must be set also as `database.existingSecretName` to provide the credentials to ACS.
+  existingSecret:
   # -- Postgresql database user
   postgresqlUsername: alfresco
   # -- Postgresql database password

--- a/helm/alfresco-content-services/values.yaml
+++ b/helm/alfresco-content-services/values.yaml
@@ -669,29 +669,22 @@ alfresco-admin-app:
 # -- Enable/Disable Alfresco Collaboration Connector for Microsoft 365
 ooi:
   enabled: false
-# -- Defines properties required by alfresco for connecting to the database
-# Note! : If you set database.external to true you will have to setup the
-# driver, user, password and JdbcUrl. Also make sure that the container has the
-# db driver in /usr/local/tomcat/lib since the current image only has the
-# postgresql driver
 database:
+  # -- Enable using an external database for Alfresco Content Services
   external: false
-  # -- ex: org.postgresql.Driver
+  # -- Postgresql jdbc driver name ex: org.postgresql.Driver. It should be available in the container image.
   driver:
-  # -- ex: alfresco
+  # -- External Postgresql database user
   user:
-  # -- ex: alfresco
+  # -- External Postgresql database password
   password:
-  # -- ex: jdbc:postgresql://oldfashioned-mule-postgresql-acs:5432/alfresco
+  # -- External Postgresql jdbc url ex: `jdbc:postgresql://oldfashioned-mule-postgresql-acs:5432/alfresco`
   url:
-# -- Defines the properties to be used for the required postgres DB
-# Note: the database (tables) information is also saved in the persistent volume
-# claim
 postgresql:
-  replicaCount: 1
   # -- Enable embedded postgres for Alfresco Content Services leveraging the postgresql Bitnami chart
   # Note: Must be set to false if you use an external database.
   enabled: true
+  replicaCount: 1
   nameOverride: postgresql-acs
   image:
     tag: 14.4.0


### PR DESCRIPTION
Ref: OPSEXP-1651

- [x] support existing secret for acs db
- [x] document support for existing secret in bitnami chart
- [x] add unit tests  