### PR TITLE
Fix deprecation warning for helm build action

### DIFF
--- a/.github/workflows/helm-community.yml
+++ b/.github/workflows/helm-community.yml
@@ -42,7 +42,7 @@ jobs:
           charts-root: helm
           chart-name: alfresco-content-services
       - uses: >-
-          Alfresco/alfresco-build-tools/.github/actions/build-helm-chart@v1.29.0
+          Alfresco/alfresco-build-tools/.github/actions/helm-build-chart@v1.29.0
         with:
           chart-dir: helm/${{ matrix.charts.name }}
       - uses: >-


### PR DESCRIPTION
Fixes:

```
This action is deprecated, use Alfresco/alfresco-build-tools/.github/actions/helm-build-chart instead.
```

https://github.com/Alfresco/acs-deployment/actions/runs/3909451581