### PR TITLE
OPSEXP-1852: fix updatecli after moving search enterprise chart

### DIFF
--- a/updatecli.d/supported-matrix.yaml
+++ b/updatecli.d/supported-matrix.yaml
@@ -39,15 +39,6 @@ matrix:
       compose_target: >-
         docker-compose/elasticsearch-override-docker-compose.yml
       compose_key: services.search.image
-      helm_target: >-
-        helm/alfresco-content-services/charts/alfresco-search-enterprise/values.yaml
-      helm_keys:
-        Reindexing: reindexing.image.tag
-        Liveindexing:
-          Mediation: liveIndexing.mediation.image.tag
-          Content: liveIndexing.content.image.tag
-          Metadata: liveIndexing.metadata.image.tag
-          Path: liveIndexing.path.image.tag
       pattern: *development_pattern
     sync:
       version: "4"

--- a/updatecli.d/uber-manifest.tpl
+++ b/updatecli.d/uber-manifest.tpl
@@ -231,6 +231,7 @@ targets:
       key: >-
         {{ index . "search-enterprise" "compose_key" }}
   {{- end }}
+  {{- if index . "search-enterprise" "helm_target" }}
   {{- $target_searchEnt := index . "search-enterprise" "helm_target" }}
   searchEnterpriseReindexingValues:
     name: Search Enterprise image tag
@@ -249,6 +250,7 @@ targets:
     spec:
       file: {{ $target_searchEnt }}
       key: {{ $value }}
+  {{- end }}
   {{- end }}
   {{- end }}
   shareCompose:


### PR DESCRIPTION
We forgot about updatecli pipeline that are impacted by the charts' dance