### PR TITLE
DESKTOPAPP-1615: Bump sync-service to 3.9.0

### DIFF
--- a/docker-compose/7.0.N-docker-compose.yml
+++ b/docker-compose/7.0.N-docker-compose.yml
@@ -163,7 +163,7 @@ services:
       - alfresco
       - share
   sync-service:
-    image: quay.io/alfresco/service-sync:3.7.2
+    image: quay.io/alfresco/service-sync:3.9.0
     mem_limit: 1g
     environment:
       JAVA_OPTS: >-

--- a/docker-compose/7.1.N-docker-compose.yml
+++ b/docker-compose/7.1.N-docker-compose.yml
@@ -164,7 +164,7 @@ services:
       - alfresco
       - share
   sync-service:
-    image: quay.io/alfresco/service-sync:3.7.2
+    image: quay.io/alfresco/service-sync:3.9.2
     mem_limit: 1g
     environment:
       JAVA_OPTS: >-

--- a/docker-compose/7.1.N-docker-compose.yml
+++ b/docker-compose/7.1.N-docker-compose.yml
@@ -164,7 +164,7 @@ services:
       - alfresco
       - share
   sync-service:
-    image: quay.io/alfresco/service-sync:3.9.2
+    image: quay.io/alfresco/service-sync:3.9.0
     mem_limit: 1g
     environment:
       JAVA_OPTS: >-

--- a/docker-compose/7.2.N-docker-compose.yml
+++ b/docker-compose/7.2.N-docker-compose.yml
@@ -177,7 +177,7 @@ services:
       - share
       - control-center
   sync-service:
-    image: quay.io/alfresco/service-sync:3.7.2
+    image: quay.io/alfresco/service-sync:3.9.0
     mem_limit: 1g
     environment:
       JAVA_OPTS: >-

--- a/docker-compose/7.3.N-docker-compose.yml
+++ b/docker-compose/7.3.N-docker-compose.yml
@@ -178,7 +178,7 @@ services:
       - share
       - control-center
   sync-service:
-    image: quay.io/alfresco/service-sync:3.8.0
+    image: quay.io/alfresco/service-sync:3.9.0
     mem_limit: 1g
     environment:
       JAVA_OPTS: >-

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -178,7 +178,7 @@ services:
       - share
       - control-center
   sync-service:
-    image: quay.io/alfresco/service-sync:4.0.0-M7
+    image: quay.io/alfresco/service-sync:3.9.0
     mem_limit: 1g
     environment:
       JAVA_OPTS: >-

--- a/helm/alfresco-content-services/7.0.N_values.yaml
+++ b/helm/alfresco-content-services/7.0.N_values.yaml
@@ -41,7 +41,7 @@ postgresql:
     tag: 13.1.0
 alfresco-sync-service:
   image:
-    tag: 3.7.2
+    tag: 3.9.0
   postgresql:
     primary:
       image:

--- a/helm/alfresco-content-services/7.1.N_values.yaml
+++ b/helm/alfresco-content-services/7.1.N_values.yaml
@@ -58,7 +58,7 @@ alfresco-digital-workspace:
     tag: 2.6.2
 alfresco-sync-service:
   image:
-    tag: 3.7.2
+    tag: 3.9.0
   postgresql:
     primary:
       image:

--- a/helm/alfresco-content-services/7.2.N_values.yaml
+++ b/helm/alfresco-content-services/7.2.N_values.yaml
@@ -67,7 +67,7 @@ postgresql:
     tag: 13.3.0
 alfresco-sync-service:
   image:
-    tag: 3.7.2
+    tag: 3.9.0
   postgresql:
     primary:
       image:

--- a/helm/alfresco-content-services/7.3.N_values.yaml
+++ b/helm/alfresco-content-services/7.3.N_values.yaml
@@ -78,4 +78,4 @@ postgresql-syncservice:
 alfresco-sync-service:
   syncservice:
     image:
-      tag: 3.8.0
+      tag: 3.9.0


### PR DESCRIPTION
Changed version of sync-service to 3.9.0 for Oxford release.