### PR TITLE
OPSEXP-2109: update updatecli

### DIFF
--- a/.github/workflows/bumpVersions.yml
+++ b/.github/workflows/bumpVersions.yml
@@ -9,30 +9,20 @@ on:
         required: true
   push:
     paths:
-      - '.github/workflows/bumpVersions.yml'
-      - 'updatecli.d/**'
+      - .github/workflows/bumpVersions.yml
+      - updatecli.d/**
     branches:
-      - 'OPSEXP-**'
+      - OPSEXP-**
 
 permissions:
-  contents: "write"
-  pull-requests: "write"
+  contents: write
+  pull-requests: write
 
 jobs:
   updatecli:
     runs-on: ubuntu-latest
-    strategy:
-      max-parallel: 1
-      matrix:
-        version:
-          - community
-          - 7.0.N
-          - 7.1.N
-          - 7.2.N
-          - 7.3.N
-          - latest
     env:
-      MATRIX_VALUES_OUTPUT: /tmp/${{ matrix.version }}-values.yaml
+      VALUES: ./updatecli.d/supported-matrix.yaml
       UPDATECLI_MANIFEST_FILE: ./updatecli.d/uber-manifest.tpl
     steps:
       - name: Checkout
@@ -42,12 +32,6 @@ jobs:
         uses: updatecli/updatecli-action@v2
         with:
           version: v0.49.2
-
-      - name: Prepare values file for ${{ matrix.version }}
-        working-directory: ./updatecli.d/
-        run: |
-          yq -e e 'explode(.) | .matrix["${{ matrix.version }}"]' supported-matrix.yaml \
-          | tee > "$MATRIX_VALUES_OUTPUT"
 
       - name: Run Updatecli in diff mode
         if: github.event_name == 'push'
@@ -59,7 +43,7 @@ jobs:
           GIT_AUTHOR_USERNAME: ${{ vars.BOT_GITHUB_USERNAME }}
         run: >-
           JIRA_ID="DRAFT" GIT_BRANCH="$GITHUB_REF_NAME"
-          updatecli diff -c "$UPDATECLI_MANIFEST_FILE" -v "$MATRIX_VALUES_OUTPUT"
+          updatecli diff -c "$UPDATECLI_MANIFEST_FILE" -v "$VALUES"
 
       - name: Run Updatecli in apply mode
         if: github.event_name == 'workflow_dispatch'
@@ -73,4 +57,4 @@ jobs:
           JIRA_ID: ${{ inputs.jira_id }}
         run: >-
           JIRA_ID=${JIRA_ID:-DRAFT}
-          updatecli apply -c "$UPDATECLI_MANIFEST_FILE" -v "$MATRIX_VALUES_OUTPUT"
+          updatecli apply -c "$UPDATECLI_MANIFEST_FILE" -v "$VALUES"

--- a/.github/workflows/bumpVersions.yml
+++ b/.github/workflows/bumpVersions.yml
@@ -2,14 +2,6 @@
 name: Bump component versions
 
 on:
-  workflow_dispatch:
-    inputs:
-      target_branch:
-        description: Branch against which to open a PR
-        required: true
-      jira_id:
-        description: ticket reference for the requested update (OPSEXP-1234)
-        required: true
   push:
     paths:
       - .github/workflows/bumpVersions.yml
@@ -44,23 +36,6 @@ jobs:
           UPDATECLI_GITHUB_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
           GIT_AUTHOR_EMAIL: ${{ vars.BOT_GITHUB_EMAIL }}
           GIT_AUTHOR_USERNAME: ${{ vars.BOT_GITHUB_USERNAME }}
-          JIRA_ID: DRAFT
         run: |
           export GIT_BRANCH="$GITHUB_REF_NAME"
-          export TGT_PR_BRANCH="$GITHUB_REF_NAME"
           updatecli diff -c "$UPDATECLI_MANIFEST_FILE" -v "$VALUES"
-
-      - name: Run Updatecli in apply mode
-        if: github.event_name == 'workflow_dispatch'
-        env:
-          QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
-          QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
-          UPDATECLI_GITHUB_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
-          GIT_AUTHOR_EMAIL: ${{ vars.BOT_GITHUB_EMAIL }}
-          GIT_AUTHOR_USERNAME: ${{ vars.BOT_GITHUB_USERNAME }}
-          JIRA_ID: ${{ inputs.jira_id }}
-        run: |
-          export GIT_BRANCH="$GITHUB_REF_NAME"
-          export TGT_PR_BRANCH="${{ inputs.target_branch }}"
-          export JIRA_ID="${JIRA_ID:-DRAFT}"
-          updatecli apply -c "$UPDATECLI_MANIFEST_FILE" -v "$VALUES"

--- a/.github/workflows/bumpVersions.yml
+++ b/.github/workflows/bumpVersions.yml
@@ -4,6 +4,9 @@ name: Bump component versions
 on:
   workflow_dispatch:
     inputs:
+      target_branch:
+        description: Branch against which to open a PR
+        required: true
       jira_id:
         description: ticket reference for the requested update (OPSEXP-1234)
         required: true
@@ -41,8 +44,10 @@ jobs:
           UPDATECLI_GITHUB_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
           GIT_AUTHOR_EMAIL: ${{ vars.BOT_GITHUB_EMAIL }}
           GIT_AUTHOR_USERNAME: ${{ vars.BOT_GITHUB_USERNAME }}
-        run: >-
-          JIRA_ID="DRAFT" GIT_BRANCH="$GITHUB_REF_NAME"
+          JIRA_ID: DRAFT
+        run: |
+          export GIT_BRANCH="$GITHUB_REF_NAME"
+          export TGT_PR_BRANCH="$GITHUB_REF_NAME"
           updatecli diff -c "$UPDATECLI_MANIFEST_FILE" -v "$VALUES"
 
       - name: Run Updatecli in apply mode
@@ -53,8 +58,9 @@ jobs:
           UPDATECLI_GITHUB_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
           GIT_AUTHOR_EMAIL: ${{ vars.BOT_GITHUB_EMAIL }}
           GIT_AUTHOR_USERNAME: ${{ vars.BOT_GITHUB_USERNAME }}
-          GIT_BRANCH: master
           JIRA_ID: ${{ inputs.jira_id }}
-        run: >-
-          JIRA_ID=${JIRA_ID:-DRAFT}
+        run: |
+          export GIT_BRANCH="$GITHUB_REF_NAME"
+          export TGT_PR_BRANCH="${{ inputs.target_branch }}"
+          export JIRA_ID="${JIRA_ID:-DRAFT}"
           updatecli apply -c "$UPDATECLI_MANIFEST_FILE" -v "$VALUES"

--- a/.github/workflows/bumpVersions.yml
+++ b/.github/workflows/bumpVersions.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Install Updatecli
         uses: updatecli/updatecli-action@v2
         with:
-          version: v0.43.0
+          version: v0.49.2
 
       - name: Prepare values file for ${{ matrix.version }}
         working-directory: ./updatecli.d/

--- a/.github/workflows/helm-enterprise.yml
+++ b/.github/workflows/helm-enterprise.yml
@@ -3,15 +3,14 @@ name: Helm (Enterprise)
 on:
   pull_request:
     branches:
-      - 'master'
+      - master
     paths:
-      - 'helm/**'
-      - 'test/postman/helm/**'
-      - '.github/workflows/helm*'
+      - helm/**
+      - test/postman/helm/**
+      - .github/workflows/helm*
   push:
     branches:
-      - 'master'
-      - pr-*
+      - master
 concurrency:
   group: ${{ github.head_ref || github.ref_name || github.run_id }}
   cancel-in-progress: false
@@ -21,8 +20,7 @@ jobs:
     if: >-
       github.event_name == 'push'
       || (
-        ! github.event.pull_request.head.repo.fork
-        && github.event.pull_request.head.user.login == 'Alfresco'
+        github.event.pull_request.head.user.login == 'Alfresco'
         && github.actor != 'dependabot[bot]'
       )
     outputs:
@@ -81,7 +79,7 @@ jobs:
           echo "app_version=$V" >> $GITHUB_OUTPUT
           echo "app_prefix=${SANITIZED_V}" >> $GITHUB_OUTPUT
       - uses: >-
-          Alfresco/alfresco-build-tools/.github/actions/dbp-charts/verify-helm@v1.36.0
+          Alfresco/alfresco-build-tools/.github/actions/dbp-charts/verify-helm@v1.38.0
         with:
           skip_checkout: 'true'
           test_newman: 'true'

--- a/README.md
+++ b/README.md
@@ -101,9 +101,25 @@ Please use [this guide](CONTRIBUTING.md) to make a contribution to the project a
 Open a PR that will:
 
 * Update the [versioning table](#versioning)
-* If any updates to the updatecli pipelines is required then make the changes and raise the PR.
-* Once the PR merge then run the manually [updatecli-workflow](https://github.com/Alfresco/acs-deployment/actions/workflows/bumpVersions.yml)
-* That will create the bump version PR automatically.
+* If any updates to the updatecli pipelines is required then make the changes
+  and raise the PR.
+* Once the PR merge switch the `updatecli.d/supported-matrix.yaml` `latest`
+  section to "release mode" by changing all `development_pattern` by `ga_hotfixes_pattern`
+* Run locally the updatecli pipeline and commit the resulting files (except the
+  `updatecli.d/supported-matrix.yaml`) to a new branch.
+
+  ```bash
+  export QUAY_USERNAME="<VALUE>"
+  export QUAY_PASSWORD="<VALUE>"
+  export UPDATECLI_GITHUB_TOKEN="<VALUE>"
+  export GIT_AUTHOR_EMAIL='build@alfresco.com'
+  export GIT_AUTHOR_USERNAME='alfresco-build'
+  export GIT_BRANCH="$(git branch --show-current)"
+  updatecli apply -c updatecli.d/uber-manifest.tpl -v updatecli.d/supported-matrix.yaml
+  ```
+
+* Restore formatting offiles edited by updatecli (See [updatecli
+  issue](https://github.com/updatecli/updatecli/issues/1028)
 * In [alfresco-content-services](helm/alfresco-content-services/Chart.yaml),
   bump chart version to the next stable release (usually by removing the
   `-SNAPSHOT` suffix and adding `-Mx` suffix if it's a prerelease)
@@ -165,4 +181,3 @@ Once the tagged workflow is successful, the release process has completed.
  `java -jar plantuml.jar filename`
 2. The other way to generate the diagrams is via official plantuml website. Go to the below url and paste your puml code and click on submit.
  `http://www.plantuml.com/plantuml/uml/SyfFKj2rKt3CoKnELR1Io4ZDoSa70000`
-  

--- a/README.md
+++ b/README.md
@@ -115,10 +115,10 @@ Open a PR that will:
   export GIT_AUTHOR_EMAIL='build@alfresco.com'
   export GIT_AUTHOR_USERNAME='alfresco-build'
   export GIT_BRANCH="$(git branch --show-current)"
-  updatecli apply -c updatecli.d/uber-manifest.tpl -v updatecli.d/supported-matrix.yaml
+  updatecli apply --commit=true --push=false -c updatecli.d/uber-manifest.tpl -v updatecli.d/supported-matrix.yaml
   ```
 
-* Restore formatting offiles edited by updatecli (See [updatecli
+* Restore formatting of files edited by updatecli (See [updatecli
   issue](https://github.com/updatecli/updatecli/issues/1028)
 * In [alfresco-content-services](helm/alfresco-content-services/Chart.yaml),
   bump chart version to the next stable release (usually by removing the

--- a/helm/alfresco-content-services/7.0.N_values.yaml
+++ b/helm/alfresco-content-services/7.0.N_values.yaml
@@ -46,6 +46,11 @@ alfresco-sync-service:
     primary:
       image:
         tag: 13.1.0
+ooiService:
+  image:
+    tag: 2.0.0
+msTeams:
+  enabled: false
 global:
   tracking:
     auth: none

--- a/helm/alfresco-content-services/7.1.N_values.yaml
+++ b/helm/alfresco-content-services/7.1.N_values.yaml
@@ -63,6 +63,12 @@ alfresco-sync-service:
     primary:
       image:
         tag: 13.3.0
+msTeamsService:
+  image:
+    tag: 1.1.0
+ooiService:
+  image:
+    tag: 2.0.0
 global:
   tracking:
     auth: none

--- a/helm/alfresco-content-services/7.2.N_values.yaml
+++ b/helm/alfresco-content-services/7.2.N_values.yaml
@@ -3,12 +3,6 @@
 repository:
   image:
     tag: 7.2.1.10
-ooiService:
-  image:
-    tag: 1.1.3
-msTeamsService:
-  image:
-    tag: 1.1.0
 transformrouter:
   image:
     tag: 2.0.0
@@ -72,3 +66,9 @@ alfresco-sync-service:
     primary:
       image:
         tag: 13.3.0
+ooiService:
+  image:
+    tag: 1.1.3
+msTeamsService:
+  image:
+    tag: 1.1.0

--- a/helm/alfresco-content-services/7.3.N_values.yaml
+++ b/helm/alfresco-content-services/7.3.N_values.yaml
@@ -3,14 +3,6 @@
 repository:
   image:
     tag: 7.3.1
-ooiService:
-  image:
-    tag: 1.1.3
-msTeams:
-  enabled: false
-msTeamsService:
-  image:
-    tag: 1.1.0
 transformrouter:
   image:
     tag: 2.0.0
@@ -68,8 +60,6 @@ alfresco-digital-workspace:
 alfresco-admin-app:
   image:
     tag: 7.8.1
-ooi:
-  enabled: false
 postgresql:
   image:
     tag: 14.4.0
@@ -79,3 +69,9 @@ postgresql-syncservice:
 alfresco-sync-service:
   image:
     tag: 3.8.0
+ooiService:
+  image:
+    tag: 1.1.3
+msTeamsService:
+  image:
+    tag: 1.1.0

--- a/updatecli.d/supported-matrix.yaml
+++ b/updatecli.d/supported-matrix.yaml
@@ -79,6 +79,10 @@ matrix:
       compose_key: transform-router.image
       helm_target: *helmvalues
       helm_key: transformrouter.image.tag
+    tengine-misc:
+      version: "~3.1.0"
+      helm_target: *helmvalues
+      helm_key: transformmisc.image.tag
   7.3.N:
     acs:
       version: "7.3"
@@ -162,6 +166,10 @@ matrix:
       compose_key: transform-router.image
       helm_target: *helmvalues73
       helm_key: transformrouter.image.tag
+    tengine-misc:
+      version: "~3.0.0"
+      helm_target: *helmvalues
+      helm_key: transformmisc.image.tag
   7.2.N:
     acs:
       version: "7.2"
@@ -245,6 +253,10 @@ matrix:
       compose_key: transform-router.image
       helm_target: *helmvalues72
       helm_key: transformrouter.image.tag
+    tengine-misc:
+      version: "^2.5.0"
+      helm_target: *helmvalues
+      helm_key: transformmisc.image.tag
   7.1.N:
     acs:
       version: "7.1"
@@ -321,6 +333,10 @@ matrix:
       compose_key: transform-router.image
       helm_target: *helmvalues71
       helm_key: transformrouter.image.tag
+    tengine-misc:
+      version: "^2.5.0"
+      helm_target: *helmvalues
+      helm_key: transformmisc.image.tag
   7.0.N:
     acs:
       version: "7.0"
@@ -377,6 +393,10 @@ matrix:
       compose_key: transform-router.image
       helm_target: *helmvalues70
       helm_key: transformrouter.image.tag
+    tengine-misc:
+      version: "^2.5.0"
+      helm_target: *helmvalues
+      helm_key: transformmisc.image.tag
   community:
     acs:
       version: "7.4"

--- a/updatecli.d/supported-matrix.yaml
+++ b/updatecli.d/supported-matrix.yaml
@@ -53,7 +53,7 @@ matrix:
       helm_key: alfresco-digital-workspace.image.tag
       pattern: *development_pattern
     adminApp:
-      version: "7"
+      version: "8"
       compose_target: *compose
       compose_key: services.control-center.image
       helm_target: *helmvalues

--- a/updatecli.d/supported-matrix.yaml
+++ b/updatecli.d/supported-matrix.yaml
@@ -133,7 +133,7 @@ matrix:
       pattern: *ga_hotfixes_pattern
       image: quay.io/alfresco/search-services
     search-enterprise:
-      version: "3.2"
+      version: "3"
       helm_target: *helmvalues73
       helm_keys:
         Reindexing: alfresco-search-enterprise.reindexing.image.tag
@@ -242,7 +242,7 @@ matrix:
       pattern: *ga_hotfixes_pattern
       image: quay.io/alfresco/search-services
     search-enterprise:
-      version: "3.1"
+      version: "3"
       helm_target: *helmvalues72
       helm_keys:
         Reindexing: alfresco-search-enterprise.reindexing.image.tag
@@ -351,7 +351,7 @@ matrix:
       pattern: *ga_hotfixes_pattern
       image: quay.io/alfresco/search-services
     search-enterprise:
-      version: "3.1"
+      version: "3"
       helm_target: *helmvalues71
       helm_keys:
         Reindexing: alfresco-search-enterprise.reindexing.image.tag

--- a/updatecli.d/supported-matrix.yaml
+++ b/updatecli.d/supported-matrix.yaml
@@ -60,9 +60,14 @@ matrix:
       helm_key: alfresco-admin-app.image.tag
       pattern: *development_pattern
     ondrive:
-      version: "1"
+      version: "2"
       helm_target: *helmvalues
       helm_key: ooiService.image.tag
+      pattern: *development_pattern
+    msteams:
+      version: "2"
+      helm_target: *helmvalues
+      helm_key: msTeamsService.image.tag
       pattern: *development_pattern
   7.3.N:
     acs:
@@ -128,9 +133,14 @@ matrix:
       helm_key: alfresco-admin-app.image.tag
       pattern: *ga_pattern
     ondrive:
-      version: "1.1"
+      version: "2.0"
       helm_target: *helmvalues
       helm_key: ooiService.image.tag
+      pattern: *ga_hotfixes_pattern
+    msteams:
+      version: "1.1"
+      helm_target: *helmvalues73
+      helm_key: msTeamsService.image.tag
       pattern: *ga_hotfixes_pattern
   7.2.N:
     acs:
@@ -196,9 +206,14 @@ matrix:
       helm_key: alfresco-admin-app.image.tag
       pattern: *ga_pattern
     ondrive:
-      version: "1.1"
+      version: "2.0"
       helm_target: *helmvalues
       helm_key: ooiService.image.tag
+      pattern: *ga_hotfixes_pattern
+    msteams:
+      version: "1.1"
+      helm_target: *helmvalues72
+      helm_key: msTeamsService.image.tag
       pattern: *ga_hotfixes_pattern
   7.1.N:
     acs:
@@ -257,9 +272,14 @@ matrix:
       helm_key: alfresco-digital-workspace.image.tag
       pattern: *ga_pattern
     ondrive:
-      version: "1.1"
+      version: "2.0"
       helm_target: *helmvalues
       helm_key: ooiService.image.tag
+      pattern: *ga_hotfixes_pattern
+    msteams:
+      version: "1.1"
+      helm_target: *helmvalues71
+      helm_key: msTeamsService.image.tag
       pattern: *ga_hotfixes_pattern
   7.0.N:
     acs:
@@ -302,6 +322,11 @@ matrix:
       helm_target: *helmvalues70
       helm_key: alfresco-digital-workspace.image.tag
       pattern: *ga_pattern
+    ondrive:
+      version: "2.0"
+      helm_target: *helmvalues
+      helm_key: ooiService.image.tag
+      pattern: *ga_hotfixes_pattern
   community:
     acs:
       version: "7.4"

--- a/updatecli.d/supported-matrix.yaml
+++ b/updatecli.d/supported-matrix.yaml
@@ -15,7 +15,7 @@ matrix:
       helm_target: &helmvalues >-
         helm/alfresco-content-services/values.yaml
       helm_key: repository.image.tag
-      pattern: *development_pattern
+      pattern: *ga_hotfixes_pattern
       image: &repository_image quay.io/alfresco/alfresco-content-repository
     share:
       version: "7.4"
@@ -23,52 +23,52 @@ matrix:
       compose_key: services.share.image
       helm_target: *helmvalues
       helm_key: share.image.tag
-      pattern: *development_pattern
+      pattern: *ga_hotfixes_pattern
       image: &share_image quay.io/alfresco/alfresco-share
     search:
       version: "^2.0"
       compose_target: *compose
       compose_key: services.solr6.image
-      pattern: *development_pattern
+      pattern: *ga_hotfixes_pattern
       image: quay.io/alfresco/search-services
     search-enterprise:
       version: "3"
       compose_target: >-
         docker-compose/elasticsearch-override-docker-compose.yml
       compose_key: services.search.image
-      pattern: *development_pattern
+      pattern: *ga_hotfixes_pattern
     sync:
-      version: "4"
+      version: "3.9"
       compose_target: *compose
       compose_key: services.sync-service.image
       helm_target: >-
         helm/alfresco-content-services/values.yaml
       helm_key: alfresco-sync-service.image.tag
-      pattern: *development_pattern
+      pattern: *ga_hotfixes_pattern
     adw:
       version: "4"
       compose_target: *compose
       compose_key: services.digital-workspace.image
       helm_target: *helmvalues
       helm_key: alfresco-digital-workspace.image.tag
-      pattern: *development_pattern
+      pattern: *ga_hotfixes_pattern
     adminApp:
       version: "8"
       compose_target: *compose
       compose_key: services.control-center.image
       helm_target: *helmvalues
       helm_key: alfresco-admin-app.image.tag
-      pattern: *development_pattern
+      pattern: *ga_hotfixes_pattern
     ondrive:
       version: "2"
       helm_target: *helmvalues
       helm_key: ooiService.image.tag
-      pattern: *development_pattern
+      pattern: *ga_hotfixes_pattern
     msteams:
       version: "2"
       helm_target: *helmvalues
       helm_key: msTeamsService.image.tag
-      pattern: *development_pattern
+      pattern: *ga_hotfixes_pattern
     intelligence:
       version: "~1.5.0"
       helm_target: *helmvalues
@@ -516,7 +516,7 @@ matrix:
       helm_target: &helmvaluesOss >-
         helm/alfresco-content-services/community_values.yaml
       helm_key: repository.image.tag
-      pattern: *development_pattern
+      pattern: *ga_hotfixes_pattern
       image: docker.io/alfresco/alfresco-content-repository-community
     share:
       version: "7.4"
@@ -524,7 +524,7 @@ matrix:
       compose_key: services.share.image
       helm_target: *helmvaluesOss
       helm_key: share.image.tag
-      pattern: *development_pattern
+      pattern: *ga_hotfixes_pattern
       image: docker.io/alfresco/alfresco-share
     search:
       version: "^2.0"
@@ -532,13 +532,13 @@ matrix:
       compose_key: services.solr6.image
       helm_target: *helmvaluesOss
       helm_key: alfresco-search.searchServicesImage.tag
-      pattern: *development_pattern
+      pattern: *ga_hotfixes_pattern
       image: docker.io/alfresco/alfresco-search-services
     ondrive:
       version: "1.1"
       helm_target: *helmvaluesOss
       helm_key: ooiService.image.tag
-      pattern: *development_pattern
+      pattern: *ga_hotfixes_pattern
     tengine-aio:
       compose_target: *composeOss
       compose_key: services.transform-core-aio.image

--- a/updatecli.d/supported-matrix.yaml
+++ b/updatecli.d/supported-matrix.yaml
@@ -76,9 +76,15 @@ matrix:
     trouter:
       version: "~2.1.0"
       compose_target: *compose
-      compose_key: transform-router.image
+      compose_key: services.transform-router.image
       helm_target: *helmvalues
       helm_key: transformrouter.image.tag
+    sfs:
+      version: "~2.1.0"
+      compose_target: *compose
+      compose_key: services.filestore.image
+      helm_target: *helmvalues
+      helm_key: filestore.image.tag
     tengine-misc:
       version: "~3.1.0"
       helm_target: *helmvalues
@@ -182,6 +188,12 @@ matrix:
       compose_key: transform-router.image
       helm_target: *helmvalues73
       helm_key: transformrouter.image.tag
+    sfs:
+      version: "~2.0.0"
+      compose_target: *compose73
+      compose_key: services.filestore.image
+      helm_target: *helmvalues73
+      helm_key: filestore.image.tag
     tengine-misc:
       version: "~3.0.0"
       helm_target: *helmvalues73
@@ -285,6 +297,12 @@ matrix:
       compose_key: transform-router.image
       helm_target: *helmvalues72
       helm_key: transformrouter.image.tag
+    sfs:
+      version: "~2.0.0"
+      compose_target: *compose72
+      compose_key: services.filestore.image
+      helm_target: *helmvalues72
+      helm_key: filestore.image.tag
     tengine-misc:
       version: "^2.5.0"
       helm_target: *helmvalues72
@@ -381,6 +399,12 @@ matrix:
       compose_key: transform-router.image
       helm_target: *helmvalues71
       helm_key: transformrouter.image.tag
+    sfs:
+      version: "^1.5.0"
+      compose_target: *compose71
+      compose_key: services.filestore.image
+      helm_target: *helmvalues71
+      helm_key: filestore.image.tag
     tengine-misc:
       version: "^2.5.0"
       helm_target: *helmvalues
@@ -457,6 +481,12 @@ matrix:
       compose_key: transform-router.image
       helm_target: *helmvalues70
       helm_key: transformrouter.image.tag
+    sfs:
+      version: "^1.5.0"
+      compose_target: *compose70
+      compose_key: services.filestore.image
+      helm_target: *helmvalues70
+      helm_key: filestore.image.tag
     tengine-misc:
       version: "^2.5.0"
       helm_target: *helmvalues

--- a/updatecli.d/supported-matrix.yaml
+++ b/updatecli.d/supported-matrix.yaml
@@ -95,6 +95,10 @@ matrix:
       version: "~3.1.0"
       helm_target: *helmvalues
       helm_key: pdfrenderer.image.tag
+    tengine-tika:
+      version: "~3.1.0"
+      helm_target: *helmvalues
+      helm_key: tika.image.tag
   7.3.N:
     acs:
       version: "7.3"
@@ -194,6 +198,10 @@ matrix:
       version: "~3.0.0"
       helm_target: *helmvalues73
       helm_key: pdfrenderer.image.tag
+    tengine-tika:
+      version: "~3.0.0"
+      helm_target: *helmvalues73
+      helm_key: tika.image.tag
   7.2.N:
     acs:
       version: "7.2"
@@ -293,6 +301,10 @@ matrix:
       version: "^2.5.0"
       helm_target: *helmvalues72
       helm_key: pdfrenderer.image.tag
+    tengine-tika:
+      version: "^2.5.0"
+      helm_target: *helmvalues72
+      helm_key: tika.image.tag
   7.1.N:
     acs:
       version: "7.1"
@@ -385,6 +397,10 @@ matrix:
       version: "^2.5.0"
       helm_target: *helmvalues71
       helm_key: pdfrenderer.image.tag
+    tengine-tika:
+      version: "^2.5.0"
+      helm_target: *helmvalues71
+      helm_key: tika.image.tag
   7.0.N:
     acs:
       version: "7.0"
@@ -457,6 +473,10 @@ matrix:
       version: "^2.5.0"
       helm_target: *helmvalues70
       helm_key: pdfrenderer.image.tag
+    tengine-tika:
+      version: "^2.5.0"
+      helm_target: *helmvalues70
+      helm_key: tika.image.tag
   community:
     acs:
       version: "7.4"

--- a/updatecli.d/supported-matrix.yaml
+++ b/updatecli.d/supported-matrix.yaml
@@ -26,7 +26,7 @@ matrix:
       pattern: *development_pattern
       image: &share_image quay.io/alfresco/alfresco-share
     search:
-      version: "2"
+      version: "^2.0"
       compose_target: *compose
       compose_key: services.solr6.image
       pattern: *development_pattern
@@ -89,7 +89,7 @@ matrix:
       pattern: *ga_hotfixes_pattern
       image: *share_image
     search:
-      version: "2"
+      version: "^2.0"
       compose_target: *compose73
       compose_key: services.solr6.image
       helm_target: *helmvalues73
@@ -162,7 +162,7 @@ matrix:
       pattern: *ga_hotfixes_pattern
       image: *share_image
     search:
-      version: "2"
+      version: "^2.0"
       compose_target: *compose72
       compose_key: services.solr6.image
       helm_target: *helmvalues72
@@ -235,7 +235,7 @@ matrix:
       pattern: *ga_hotfixes_pattern
       image: *share_image
     search:
-      version: "2"
+      version: "^2.0"
       compose_target: *compose71
       compose_key: services.solr6.image
       helm_target: *helmvalues71
@@ -301,7 +301,7 @@ matrix:
       pattern: *ga_hotfixes_pattern
       image: *share_image
     search:
-      version: "2"
+      version: "^2.0"
       compose_target: *compose70
       compose_key: services.solr6.image
       helm_target: *helmvalues70
@@ -347,7 +347,7 @@ matrix:
       pattern: *development_pattern
       image: docker.io/alfresco/alfresco-share
     search:
-      version: "2"
+      version: "^2.0"
       compose_target: *composeOss
       compose_key: services.solr6.image
       helm_target: *helmvaluesOss
@@ -358,4 +358,4 @@ matrix:
       version: "1.1"
       helm_target: *helmvalues
       helm_key: ooiService.image.tag
-      pattern: *ga_hotfixes_pattern
+      pattern: *development_pattern

--- a/updatecli.d/supported-matrix.yaml
+++ b/updatecli.d/supported-matrix.yaml
@@ -69,6 +69,16 @@ matrix:
       helm_target: *helmvalues
       helm_key: msTeamsService.image.tag
       pattern: *development_pattern
+    intelligence:
+      version: "~1.5.0"
+      helm_target: *helmvalues
+      helm_key: aiTransformer.image.tag
+    trouter:
+      version: "~2.1.0"
+      compose_target: *compose
+      compose_key: transform-router.image
+      helm_target: *helmvalues
+      helm_key: transformrouter.image.tag
   7.3.N:
     acs:
       version: "7.3"
@@ -142,6 +152,16 @@ matrix:
       helm_target: *helmvalues73
       helm_key: msTeamsService.image.tag
       pattern: *ga_hotfixes_pattern
+    intelligence:
+      version: "~1.5.0"
+      helm_target: *helmvalues73
+      helm_key: aiTransformer.image.tag
+    trouter:
+      version: "~2.0.0"
+      compose_target: *compose73
+      compose_key: transform-router.image
+      helm_target: *helmvalues73
+      helm_key: transformrouter.image.tag
   7.2.N:
     acs:
       version: "7.2"
@@ -215,6 +235,16 @@ matrix:
       helm_target: *helmvalues72
       helm_key: msTeamsService.image.tag
       pattern: *ga_hotfixes_pattern
+    intelligence:
+      version: "~1.5.0"
+      helm_target: *helmvalues72
+      helm_key: aiTransformer.image.tag
+    trouter:
+      version: "~2.0.0"
+      compose_target: *compose72
+      compose_key: transform-router.image
+      helm_target: *helmvalues72
+      helm_key: transformrouter.image.tag
   7.1.N:
     acs:
       version: "7.1"
@@ -281,6 +311,16 @@ matrix:
       helm_target: *helmvalues71
       helm_key: msTeamsService.image.tag
       pattern: *ga_hotfixes_pattern
+    intelligence:
+      version: "^1.4.0"
+      helm_target: *helmvalues71
+      helm_key: aiTransformer.image.tag
+    trouter:
+      version: "^1.5.0"
+      compose_target: *compose71
+      compose_key: transform-router.image
+      helm_target: *helmvalues71
+      helm_key: transformrouter.image.tag
   7.0.N:
     acs:
       version: "7.0"
@@ -324,9 +364,19 @@ matrix:
       pattern: *ga_pattern
     ondrive:
       version: "2.0"
-      helm_target: *helmvalues
+      helm_target: *helmvalues70
       helm_key: ooiService.image.tag
       pattern: *ga_hotfixes_pattern
+    intelligence:
+      version: "^1.3.0"
+      helm_target: *helmvalues70
+      helm_key: aiTransformer.image.tag
+    trouter:
+      version: "^1.5.0"
+      compose_target: *compose70
+      compose_key: transform-router.image
+      helm_target: *helmvalues70
+      helm_key: transformrouter.image.tag
   community:
     acs:
       version: "7.4"
@@ -356,6 +406,6 @@ matrix:
       image: docker.io/alfresco/alfresco-search-services
     ondrive:
       version: "1.1"
-      helm_target: *helmvalues
+      helm_target: *helmvaluesOss
       helm_key: ooiService.image.tag
       pattern: *development_pattern

--- a/updatecli.d/supported-matrix.yaml
+++ b/updatecli.d/supported-matrix.yaml
@@ -87,6 +87,10 @@ matrix:
       version: "~3.1.0"
       helm_target: *helmvalues
       helm_key: imagemagick.image.tag
+    tengine-lo:
+      version: "~3.1.0"
+      helm_target: *helmvalues
+      helm_key: libreoffice.image.tag
   7.3.N:
     acs:
       version: "7.3"
@@ -178,6 +182,10 @@ matrix:
       version: "~3.0.0"
       helm_target: *helmvalues73
       helm_key: imagemagick.image.tag
+    tengine-lo:
+      version: "~3.0.0"
+      helm_target: *helmvalues73
+      helm_key: libreoffice.image.tag
   7.2.N:
     acs:
       version: "7.2"
@@ -269,6 +277,10 @@ matrix:
       version: "^2.5.0"
       helm_target: *helmvalues72
       helm_key: imagemagick.image.tag
+    tengine-lo:
+      version: "^2.5.0"
+      helm_target: *helmvalues72
+      helm_key: libreoffice.image.tag
   7.1.N:
     acs:
       version: "7.1"
@@ -353,6 +365,10 @@ matrix:
       version: "^2.5.0"
       helm_target: *helmvalues71
       helm_key: imagemagick.image.tag
+    tengine-lo:
+      version: "^2.5.0"
+      helm_target: *helmvalues71
+      helm_key: libreoffice.image.tag
   7.0.N:
     acs:
       version: "7.0"
@@ -417,6 +433,10 @@ matrix:
       version: "^2.5.0"
       helm_target: *helmvalues71
       helm_key: imagemagick.image.tag
+    tengine-lo:
+      version: "^2.5.0"
+      helm_target: *helmvalues71
+      helm_key: libreoffice.image.tag
   community:
     acs:
       version: "7.4"

--- a/updatecli.d/supported-matrix.yaml
+++ b/updatecli.d/supported-matrix.yaml
@@ -409,3 +409,7 @@ matrix:
       helm_target: *helmvaluesOss
       helm_key: ooiService.image.tag
       pattern: *development_pattern
+    tengine-aio:
+      compose_target: *composeOss
+      compose_key: services.transform-core-aio.image
+      version: "^3.1.0"

--- a/updatecli.d/supported-matrix.yaml
+++ b/updatecli.d/supported-matrix.yaml
@@ -82,7 +82,7 @@ matrix:
     sfs:
       version: "~2.1.0"
       compose_target: *compose
-      compose_key: services.filestore.image
+      compose_key: services.shared-file-store.image
       helm_target: *helmvalues
       helm_key: filestore.image.tag
     tengine-misc:
@@ -185,13 +185,13 @@ matrix:
     trouter:
       version: "~2.0.0"
       compose_target: *compose73
-      compose_key: transform-router.image
+      compose_key: services.transform-router.image
       helm_target: *helmvalues73
       helm_key: transformrouter.image.tag
     sfs:
       version: "~2.0.0"
       compose_target: *compose73
-      compose_key: services.filestore.image
+      compose_key: services.shared-file-store.image
       helm_target: *helmvalues73
       helm_key: filestore.image.tag
     tengine-misc:
@@ -294,13 +294,13 @@ matrix:
     trouter:
       version: "~2.0.0"
       compose_target: *compose72
-      compose_key: transform-router.image
+      compose_key: services.transform-router.image
       helm_target: *helmvalues72
       helm_key: transformrouter.image.tag
     sfs:
       version: "~2.0.0"
       compose_target: *compose72
-      compose_key: services.filestore.image
+      compose_key: services.shared-file-store.image
       helm_target: *helmvalues72
       helm_key: filestore.image.tag
     tengine-misc:
@@ -396,13 +396,13 @@ matrix:
     trouter:
       version: "^1.5.0"
       compose_target: *compose71
-      compose_key: transform-router.image
+      compose_key: services.transform-router.image
       helm_target: *helmvalues71
       helm_key: transformrouter.image.tag
     sfs:
       version: "^1.5.0"
       compose_target: *compose71
-      compose_key: services.filestore.image
+      compose_key: services.shared-file-store.image
       helm_target: *helmvalues71
       helm_key: filestore.image.tag
     tengine-misc:
@@ -478,13 +478,13 @@ matrix:
     trouter:
       version: "^1.5.0"
       compose_target: *compose70
-      compose_key: transform-router.image
+      compose_key: services.transform-router.image
       helm_target: *helmvalues70
       helm_key: transformrouter.image.tag
     sfs:
       version: "^1.5.0"
       compose_target: *compose70
-      compose_key: services.filestore.image
+      compose_key: services.shared-file-store.image
       helm_target: *helmvalues70
       helm_key: filestore.image.tag
     tengine-misc:

--- a/updatecli.d/supported-matrix.yaml
+++ b/updatecli.d/supported-matrix.yaml
@@ -1,12 +1,13 @@
 ---
 # Reflection of https://docs.alfresco.com/content-services/latest/support/
 # TO BE ENRICHED AS RELEASES ARE OUT
+patterns:
+  ga: &ga_pattern (\.[0-9]+){1,2}
+  ga_with_hotfixes: &ga_hotfixes_pattern (\.[0-9]+){1,3}
+  development: &development_pattern (\.[0-9]+){1,3}(-[AM]\.?[0-9]+)?
 matrix:
-  patterns:
-    ga: &ga_pattern (\.[0-9]+){1,2}
-    ga_with_hotfixes: &ga_hotfixes_pattern (\.[0-9]+){1,3}
-    development: &development_pattern (\.[0-9]+){1,3}(-[AM]\.?[0-9]+)?
   latest:
+    id: 74n
     acs:
       version: "7.4"
       compose_target: &compose >-
@@ -106,6 +107,7 @@ matrix:
       helm_target: *helmvalues
       helm_key: tika.image.tag
   7.3.N:
+    id: 73n
     acs:
       version: "7.3"
       compose_target: &compose73 >-
@@ -215,6 +217,7 @@ matrix:
       helm_target: *helmvalues73
       helm_key: tika.image.tag
   7.2.N:
+    id: 72n
     acs:
       version: "7.2"
       compose_target: &compose72 >-
@@ -324,6 +327,7 @@ matrix:
       helm_target: *helmvalues72
       helm_key: tika.image.tag
   7.1.N:
+    id: 71n
     acs:
       version: "7.1"
       compose_target: &compose71 >-
@@ -426,6 +430,7 @@ matrix:
       helm_target: *helmvalues71
       helm_key: tika.image.tag
   7.0.N:
+    id: 70n
     acs:
       version: "7.0"
       compose_target: &compose70 >-
@@ -508,6 +513,7 @@ matrix:
       helm_target: *helmvalues70
       helm_key: tika.image.tag
   community:
+    id: com
     acs:
       version: "7.4"
       compose_target: &composeOss >-

--- a/updatecli.d/supported-matrix.yaml
+++ b/updatecli.d/supported-matrix.yaml
@@ -91,6 +91,10 @@ matrix:
       version: "~3.1.0"
       helm_target: *helmvalues
       helm_key: libreoffice.image.tag
+    tengine-pdf:
+      version: "~3.1.0"
+      helm_target: *helmvalues
+      helm_key: pdfrenderer.image.tag
   7.3.N:
     acs:
       version: "7.3"
@@ -156,7 +160,7 @@ matrix:
       pattern: *ga_pattern
     ondrive:
       version: "2.0"
-      helm_target: *helmvalues
+      helm_target: *helmvalues73
       helm_key: ooiService.image.tag
       pattern: *ga_hotfixes_pattern
     msteams:
@@ -186,6 +190,10 @@ matrix:
       version: "~3.0.0"
       helm_target: *helmvalues73
       helm_key: libreoffice.image.tag
+    tengine-pdf:
+      version: "~3.0.0"
+      helm_target: *helmvalues73
+      helm_key: pdfrenderer.image.tag
   7.2.N:
     acs:
       version: "7.2"
@@ -251,7 +259,7 @@ matrix:
       pattern: *ga_pattern
     ondrive:
       version: "2.0"
-      helm_target: *helmvalues
+      helm_target: *helmvalues72
       helm_key: ooiService.image.tag
       pattern: *ga_hotfixes_pattern
     msteams:
@@ -281,6 +289,10 @@ matrix:
       version: "^2.5.0"
       helm_target: *helmvalues72
       helm_key: libreoffice.image.tag
+    tengine-pdf:
+      version: "^2.5.0"
+      helm_target: *helmvalues72
+      helm_key: pdfrenderer.image.tag
   7.1.N:
     acs:
       version: "7.1"
@@ -339,7 +351,7 @@ matrix:
       pattern: *ga_pattern
     ondrive:
       version: "2.0"
-      helm_target: *helmvalues
+      helm_target: *helmvalues71
       helm_key: ooiService.image.tag
       pattern: *ga_hotfixes_pattern
     msteams:
@@ -369,6 +381,10 @@ matrix:
       version: "^2.5.0"
       helm_target: *helmvalues71
       helm_key: libreoffice.image.tag
+    tengine-pdf:
+      version: "^2.5.0"
+      helm_target: *helmvalues71
+      helm_key: pdfrenderer.image.tag
   7.0.N:
     acs:
       version: "7.0"
@@ -431,12 +447,16 @@ matrix:
       helm_key: transformmisc.image.tag
     tengine-im:
       version: "^2.5.0"
-      helm_target: *helmvalues71
+      helm_target: *helmvalues70
       helm_key: imagemagick.image.tag
     tengine-lo:
       version: "^2.5.0"
-      helm_target: *helmvalues71
+      helm_target: *helmvalues70
       helm_key: libreoffice.image.tag
+    tengine-pdf:
+      version: "^2.5.0"
+      helm_target: *helmvalues70
+      helm_key: pdfrenderer.image.tag
   community:
     acs:
       version: "7.4"

--- a/updatecli.d/supported-matrix.yaml
+++ b/updatecli.d/supported-matrix.yaml
@@ -83,6 +83,10 @@ matrix:
       version: "~3.1.0"
       helm_target: *helmvalues
       helm_key: transformmisc.image.tag
+    tengine-im:
+      version: "~3.1.0"
+      helm_target: *helmvalues
+      helm_key: imagemagick.image.tag
   7.3.N:
     acs:
       version: "7.3"
@@ -168,8 +172,12 @@ matrix:
       helm_key: transformrouter.image.tag
     tengine-misc:
       version: "~3.0.0"
-      helm_target: *helmvalues
+      helm_target: *helmvalues73
       helm_key: transformmisc.image.tag
+    tengine-im:
+      version: "~3.0.0"
+      helm_target: *helmvalues73
+      helm_key: imagemagick.image.tag
   7.2.N:
     acs:
       version: "7.2"
@@ -255,8 +263,12 @@ matrix:
       helm_key: transformrouter.image.tag
     tengine-misc:
       version: "^2.5.0"
-      helm_target: *helmvalues
+      helm_target: *helmvalues72
       helm_key: transformmisc.image.tag
+    tengine-im:
+      version: "^2.5.0"
+      helm_target: *helmvalues72
+      helm_key: imagemagick.image.tag
   7.1.N:
     acs:
       version: "7.1"
@@ -337,6 +349,10 @@ matrix:
       version: "^2.5.0"
       helm_target: *helmvalues
       helm_key: transformmisc.image.tag
+    tengine-im:
+      version: "^2.5.0"
+      helm_target: *helmvalues71
+      helm_key: imagemagick.image.tag
   7.0.N:
     acs:
       version: "7.0"
@@ -397,6 +413,10 @@ matrix:
       version: "^2.5.0"
       helm_target: *helmvalues
       helm_key: transformmisc.image.tag
+    tengine-im:
+      version: "^2.5.0"
+      helm_target: *helmvalues71
+      helm_key: imagemagick.image.tag
   community:
     acs:
       version: "7.4"

--- a/updatecli.d/uber-manifest.tpl
+++ b/updatecli.d/uber-manifest.tpl
@@ -187,6 +187,18 @@ sources:
         pattern: >-
           {{ index . "tengine-aio" "version" }}
   {{- end }}
+  {{- if index . "tengine-misc" }}
+  tengine-miscTag:
+    name: Alfresco misc Transform Engine image tag
+    kind: dockerimage
+    spec:
+      image: alfresco/alfresco-transform-misc
+      {{ template "quay_auth" }}
+      versionFilter:
+        kind: semver
+        pattern: >-
+          {{ index . "tengine-misc" "version" }}
+  {{- end }}
 
 
 targets:
@@ -390,6 +402,17 @@ targets:
       file: {{ index . "tengine-aio" "compose_target" }}
       key: >-
         {{ index . "tengine-aio" "compose_key" }}
+  {{- end }}
+  {{- if index . "tengine-misc" }}
+  tengine-miscValues:
+    name: Alfresco missc Transform Engine image tag
+    kind: yaml
+    scmid: ourRepo
+    sourceid: tengine-miscTag
+    spec:
+      file: {{ .tengine-misc.helm_target }}
+      key: >-
+        {{ .tengine-misc.helm_key }}
   {{- end }}
   {{- if index . "sync" }}
   syncCompose:

--- a/updatecli.d/uber-manifest.tpl
+++ b/updatecli.d/uber-manifest.tpl
@@ -180,7 +180,7 @@ sources:
     name: Alfresco All-In-One Transform Engine image tag
     kind: dockerimage
     spec:
-      image: alfresco/alfresco-transform-core-aio
+      image: quay.io/alfresco/alfresco-transform-core-aio
       {{ template "quay_auth" }}
       versionFilter:
         kind: semver
@@ -192,12 +192,24 @@ sources:
     name: Alfresco misc Transform Engine image tag
     kind: dockerimage
     spec:
-      image: alfresco/alfresco-transform-misc
+      image: quay.io/alfresco/alfresco-transform-misc
       {{ template "quay_auth" }}
       versionFilter:
         kind: semver
         pattern: >-
           {{ index . "tengine-misc" "version" }}
+  {{- end }}
+  {{- if index . "tengine-im" }}
+  tengine-imTag:
+    name: Alfresco ImageMagick Transform Engine image tag
+    kind: dockerimage
+    spec:
+      image: quay.io/alfresco/alfresco-imagemagick
+      {{ template "quay_auth" }}
+      versionFilter:
+        kind: semver
+        pattern: >-
+          {{ index . "tengine-im" "version" }}
   {{- end }}
 
 
@@ -405,14 +417,25 @@ targets:
   {{- end }}
   {{- if index . "tengine-misc" }}
   tengine-miscValues:
-    name: Alfresco missc Transform Engine image tag
+    name: Alfresco misc Transform Engine image tag
     kind: yaml
     scmid: ourRepo
     sourceid: tengine-miscTag
     spec:
-      file: {{ .tengine-misc.helm_target }}
+      file: {{ index . "tengine-misc" "helm_target" }}
       key: >-
-        {{ .tengine-misc.helm_key }}
+        {{ index . "tengine-misc" "helm_key" }}
+  {{- end }}
+  {{- if index . "tengine-im" }}
+  tengine-imValues:
+    name: Alfresco ImageMagick Transform Engine image tag
+    kind: yaml
+    scmid: ourRepo
+    sourceid: tengine-imTag
+    spec:
+      file: {{ index . "tengine-im" "helm_target" }}
+      key: >-
+        {{ index . "tengine-im" "helm_key" }}
   {{- end }}
   {{- if index . "sync" }}
   syncCompose:

--- a/updatecli.d/uber-manifest.tpl
+++ b/updatecli.d/uber-manifest.tpl
@@ -17,16 +17,6 @@ scms:
       branch: {{ requiredEnv "GIT_BRANCH" }}
       username: alfresco-build
       token: {{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}
-  targetRepo:
-    kind: github
-    spec:
-      user: {{ requiredEnv "GIT_AUTHOR_USERNAME" }}
-      email: {{ requiredEnv "GIT_AUTHOR_EMAIL" }}
-      owner: Alfresco
-      repository: acs-deployment
-      branch: {{ requiredEnv "TGT_PR_BRANCH" }}
-      username: alfresco-build
-      token: {{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}
   searchEnterprise:
     name: Alfresco Elasticsearch connector
     kind: github
@@ -37,16 +27,6 @@ scms:
       username: alfresco-build
       token: {{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}
       directory: /tmp/updatecli/searchEnterprise
-
-actions:
-  default:
-    kind: github/pullrequest
-    scmid: targetRepo
-    spec:
-      title: "{{ requiredEnv "JIRA_ID" }} Bump component versions"
-      draft: true
-      labels:
-        - updatecli
 
 sources:
   {{- range .matrix }}
@@ -276,7 +256,6 @@ targets:
   adminAppCompose_{{ $id }}:
     name: Alfresco Control Center
     kind: yaml
-    scmid: sourceRepo
     sourceid: adminAppTag_{{ $id }}
     transformers:
       - addprefix: "quay.io/alfresco/alfresco-admin-app:"
@@ -287,7 +266,6 @@ targets:
   adminAppValues_{{ $id }}:
     name: Helm chart default values file
     kind: yaml
-    scmid: sourceRepo
     sourceid: adminAppTag_{{ $id }}
     spec:
       file: {{ .adminApp.helm_target }}
@@ -298,7 +276,6 @@ targets:
   adwCompose_{{ $id }}:
     name: ADW image tag
     kind: yaml
-    scmid: sourceRepo
     sourceid: adwTag_{{ $id }}
     transformers:
       - addprefix: "quay.io/alfresco/alfresco-digital-workspace:"
@@ -309,7 +286,6 @@ targets:
   adwValues_{{ $id }}:
     name: ADW image tag
     kind: yaml
-    scmid: sourceRepo
     sourceid: adwTag_{{ $id }}
     spec:
       file: {{ .adw.helm_target }}
@@ -319,7 +295,6 @@ targets:
   repositoryCompose_{{ $id }}:
     name: Repo image tag
     kind: yaml
-    scmid: sourceRepo
     sourceid: repositoryTag_{{ $id }}
     transformers:
       - addprefix: "{{ index . "acs" "image" }}:"
@@ -330,7 +305,6 @@ targets:
   repositoryValues_{{ $id }}:
     name: Repo image tag
     kind: yaml
-    scmid: sourceRepo
     sourceid: repositoryTag_{{ $id }}
     spec:
       file: {{ .acs.helm_target }}
@@ -340,7 +314,6 @@ targets:
   searchCompose_{{ $id }}:
     name: search image tag
     kind: yaml
-    scmid: sourceRepo
     sourceid: searchTag_{{ $id }}
     transformers:
       - addprefix: "{{ index . "search" "image" }}:"
@@ -352,7 +325,6 @@ targets:
   searchValues_{{ $id }}:
     name: search image tag
     kind: yaml
-    scmid: sourceRepo
     sourceid: searchTag_{{ $id }}
     spec:
       file: {{ .search.helm_target }}
@@ -365,7 +337,6 @@ targets:
   searchEnterpriseCompose_{{ $id }}:
     name: Search Enterprise image tag
     kind: yaml
-    scmid: sourceRepo
     sourceid: searchEnterpriseTag_{{ $id }}
     transformers:
       - addprefix: "quay.io/alfresco/alfresco-elasticsearch-live-indexing:"
@@ -379,7 +350,6 @@ targets:
   searchEnterpriseReindexingValues_{{ $id }}:
     name: Search Enterprise image tag
     kind: yaml
-    scmid: sourceRepo
     sourceid: searchEnterpriseTag_{{ $id }}
     spec:
       file: {{ $target_searchEnt }}
@@ -388,7 +358,6 @@ targets:
   searchEnterprise{{ $key }}Values_{{ $id }}:
     name: Search Enterprise image tag
     kind: yaml
-    scmid: sourceRepo
     sourceid: searchEnterpriseTag_{{ $id }}
     spec:
       file: {{ $target_searchEnt }}
@@ -399,7 +368,6 @@ targets:
   shareCompose_{{ $id }}:
     name: Share image tag
     kind: yaml
-    scmid: sourceRepo
     sourceid: shareTag_{{ $id }}
     transformers:
       - addprefix: "{{ index . "share" "image" }}:"
@@ -410,7 +378,6 @@ targets:
   shareValues_{{ $id }}:
     name: Share image tag
     kind: yaml
-    scmid: sourceRepo
     sourceid: shareTag_{{ $id }}
     spec:
       file: {{ .share.helm_target }}
@@ -420,7 +387,6 @@ targets:
   onedriveValues_{{ $id }}:
     name: Onedrive image tag
     kind: yaml
-    scmid: sourceRepo
     sourceid: onedriveTag_{{ $id }}
     spec:
       file: {{ .onedrive.helm_target }}
@@ -431,7 +397,6 @@ targets:
   msteamsValues_{{ $id }}:
     name: MS Teams image tag
     kind: yaml
-    scmid: sourceRepo
     sourceid: msteamsTag_{{ $id }}
     spec:
       file: {{ .msteams.helm_target }}
@@ -442,7 +407,6 @@ targets:
   intelligenceValues_{{ $id }}:
     name: Alfresco Intelligence image tag
     kind: yaml
-    scmid: sourceRepo
     sourceid: intelligenceTag_{{ $id }}
     spec:
       file: {{ .intelligence.helm_target }}
@@ -453,7 +417,6 @@ targets:
   trouterCompose_{{ $id }}:
     name: Alfresco Transform Router image tag
     kind: yaml
-    scmid: sourceRepo
     sourceid: trouterTag_{{ $id }}
     transformers:
       - addprefix: "quay.io/alfresco/alfresco-transform-router:"
@@ -464,7 +427,6 @@ targets:
   trouterValues_{{ $id }}:
     name: Alfresco Transform Router image tag
     kind: yaml
-    scmid: sourceRepo
     sourceid: trouterTag_{{ $id }}
     spec:
       file: {{ .trouter.helm_target }}
@@ -475,7 +437,6 @@ targets:
   sfsCompose_{{ $id }}:
     name: Alfresco Shared Filestore image tag
     kind: yaml
-    scmid: sourceRepo
     sourceid: sfsTag_{{ $id }}
     transformers:
       - addprefix: "quay.io/alfresco/alfresco-shared-file-store:"
@@ -486,7 +447,6 @@ targets:
   sfsValues_{{ $id }}:
     name: Alfresco Shared Filestore image tag
     kind: yaml
-    scmid: sourceRepo
     sourceid: sfsTag_{{ $id }}
     spec:
       file: {{ .sfs.helm_target }}
@@ -497,7 +457,6 @@ targets:
   tengine-aioCompose_{{ $id }}:
     name: Alfresco All-In-One Transform Engine image tag
     kind: yaml
-    scmid: sourceRepo
     sourceid: tengine-aioTag_{{ $id }}
     transformers:
       - addprefix: "alfresco/alfresco-transform-core-aio:"
@@ -510,7 +469,6 @@ targets:
   tengine-miscValues_{{ $id }}:
     name: Alfresco misc Transform Engine image tag
     kind: yaml
-    scmid: sourceRepo
     sourceid: tengine-miscTag_{{ $id }}
     spec:
       file: {{ index . "tengine-misc" "helm_target" }}
@@ -521,7 +479,6 @@ targets:
   tengine-imValues_{{ $id }}:
     name: Alfresco ImageMagick Transform Engine image tag
     kind: yaml
-    scmid: sourceRepo
     sourceid: tengine-imTag_{{ $id }}
     spec:
       file: {{ index . "tengine-im" "helm_target" }}
@@ -532,7 +489,6 @@ targets:
   tengine-loValues_{{ $id }}:
     name: Alfresco LibreOffice Transform Engine image tag
     kind: yaml
-    scmid: sourceRepo
     sourceid: tengine-loTag_{{ $id }}
     spec:
       file: {{ index . "tengine-lo" "helm_target" }}
@@ -543,7 +499,6 @@ targets:
   tengine-pdfValues_{{ $id }}:
     name: Alfresco PDF Transform Engine image tag
     kind: yaml
-    scmid: sourceRepo
     sourceid: tengine-pdfTag_{{ $id }}
     spec:
       file: {{ index . "tengine-pdf" "helm_target" }}
@@ -554,7 +509,6 @@ targets:
   tengine-tikaValues_{{ $id }}:
     name: Alfresco tika Transform Engine image tag
     kind: yaml
-    scmid: sourceRepo
     sourceid: tengine-tikaTag_{{ $id }}
     spec:
       file: {{ index . "tengine-tika" "helm_target" }}
@@ -565,7 +519,6 @@ targets:
   syncCompose_{{ $id }}:
     name: Sync image tag
     kind: yaml
-    scmid: sourceRepo
     sourceid: syncTag_{{ $id }}
     transformers:
       - addprefix: "quay.io/alfresco/service-sync:"
@@ -576,7 +529,6 @@ targets:
   syncValues_{{ $id }}:
     name: Sync image tag
     kind: yaml
-    scmid: sourceRepo
     sourceid: syncTag_{{ $id }}
     spec:
       file: {{ .sync.helm_target }}

--- a/updatecli.d/uber-manifest.tpl
+++ b/updatecli.d/uber-manifest.tpl
@@ -39,9 +39,12 @@ actions:
         - updatecli
 
 sources:
+  {{- range .matrix }}
+  {{- $id := .id -}}
   {{- if index . "adminApp" }}
-  adminAppTag:
-    name: Alfresco admin application tag
+  adminAppTag_{{ $id }}:
+    name: >-
+      Alfresco admin application tag
     kind: dockerimage
     spec:
       image: quay.io/alfresco/alfresco-control-center
@@ -52,7 +55,7 @@ sources:
           ^{{ index . "adminApp" "version" }}{{ index . "adminApp" "pattern" }}$
   {{- end }}
   {{- if index . "adw" }}
-  adwTag:
+  adwTag_{{ $id }}:
     name: Alfresco Digital Workspace tag
     kind: dockerimage
     spec:
@@ -64,7 +67,7 @@ sources:
           ^{{ index . "adw" "version" }}{{ index . "adw" "pattern" }}$
   {{- end }}
   {{ $repo_image := index . "acs" "image" }}
-  repositoryTag:
+  repositoryTag_{{ $id }}:
     name: ACS repository tag
     kind: dockerimage
     spec:
@@ -77,7 +80,7 @@ sources:
         pattern: >-
           ^{{ index . "acs" "version" }}{{ index . "acs" "pattern" }}$
   {{- if index . "search-enterprise" }}
-  searchEnterpriseTag:
+  searchEnterpriseTag_{{ $id }}:
     name: Search Enterprise tag
     kind: gittag
     scmid: searchEnterprise
@@ -89,7 +92,7 @@ sources:
   {{ end }}
   {{- if index . "search" }}
   {{ $search_image := index . "search" "image" }}
-  searchTag:
+  searchTag_{{ $id }}:
     name: Alfresco Search Services
     kind: dockerimage
     spec:
@@ -103,7 +106,7 @@ sources:
           {{ index . "search" "version" }}
   {{- end }}
   {{ $share_image := index . "share" "image" }}
-  shareTag:
+  shareTag_{{ $id }}:
     name: Share repository tag
     kind: dockerimage
     spec:
@@ -116,7 +119,7 @@ sources:
         pattern: >-
           ^{{ index . "share" "version" }}{{ index . "share" "pattern" }}$
   {{- if index . "sync" }}
-  syncTag:
+  syncTag_{{ $id }}:
     name: Sync Service image tag
     kind: dockerimage
     spec:
@@ -128,7 +131,7 @@ sources:
           ^{{ index . "sync" "version" }}{{ index . "sync" "pattern" }}$
   {{- end }}
   {{- if index . "onedrive" }}
-  onedriveTag:
+  onedriveTag_{{ $id }}:
     name: Onedrive (OOI) Service image tag
     kind: dockerimage
     spec:
@@ -140,7 +143,7 @@ sources:
           ^{{ index . "onedrive" "version" }}{{ index . "onedrive" "pattern" }}$
   {{- end }}
   {{- if index . "msteams" }}
-  msteamsTag:
+  msteamsTag_{{ $id }}:
     name: MS Teams Service image tag
     kind: dockerimage
     spec:
@@ -152,7 +155,7 @@ sources:
           ^{{ index . "msteams" "version" }}{{ index . "msteams" "pattern" }}$
   {{- end }}
   {{- if index . "intelligence" }}
-  intelligenceTag:
+  intelligenceTag_{{ $id }}:
     name: Intelligence Service image tag
     kind: dockerimage
     spec:
@@ -164,7 +167,7 @@ sources:
           {{ index . "intelligence" "version" }}
   {{- end }}
   {{- if index . "trouter" }}
-  trouterTag:
+  trouterTag_{{ $id }}:
     name: Alfresco Transform Router image tag
     kind: dockerimage
     spec:
@@ -176,7 +179,7 @@ sources:
           {{ index . "trouter" "version" }}
   {{- end }}
   {{- if index . "sfs" }}
-  sfsTag:
+  sfsTag_{{ $id }}:
     name: Alfresco Shared Filestore image tag
     kind: dockerimage
     spec:
@@ -188,7 +191,7 @@ sources:
           {{ index . "sfs" "version" }}
   {{- end }}
   {{- if index . "tengine-aio" }}
-  tengine-aioTag:
+  tengine-aioTag_{{ $id }}:
     name: Alfresco All-In-One Transform Engine image tag
     kind: dockerimage
     spec:
@@ -199,7 +202,7 @@ sources:
           {{ index . "tengine-aio" "version" }}
   {{- end }}
   {{- if index . "tengine-misc" }}
-  tengine-miscTag:
+  tengine-miscTag_{{ $id }}:
     name: Alfresco misc Transform Engine image tag
     kind: dockerimage
     spec:
@@ -210,7 +213,7 @@ sources:
           {{ index . "tengine-misc" "version" }}
   {{- end }}
   {{- if index . "tengine-im" }}
-  tengine-imTag:
+  tengine-imTag_{{ $id }}:
     name: Alfresco ImageMagick Transform Engine image tag
     kind: dockerimage
     spec:
@@ -221,7 +224,7 @@ sources:
           {{ index . "tengine-im" "version" }}
   {{- end }}
   {{- if index . "tengine-lo" }}
-  tengine-loTag:
+  tengine-loTag_{{ $id }}:
     name: Alfresco LibreOffice Transform Engine image tag
     kind: dockerimage
     spec:
@@ -232,7 +235,7 @@ sources:
           {{ index . "tengine-lo" "version" }}
   {{- end }}
   {{- if index . "tengine-pdf" }}
-  tengine-pdfTag:
+  tengine-pdfTag_{{ $id }}:
     name: Alfresco PDF Transform Engine image tag
     kind: dockerimage
     spec:
@@ -243,7 +246,7 @@ sources:
           {{ index . "tengine-pdf" "version" }}
   {{- end }}
   {{- if index . "tengine-tika" }}
-  tengine-tikaTag:
+  tengine-tikaTag_{{ $id }}:
     name: Alfresco tika Transform Engine image tag
     kind: dockerimage
     spec:
@@ -253,79 +256,82 @@ sources:
         pattern: >-
           {{ index . "tengine-tika" "version" }}
   {{- end }}
+  {{- end }}
 
 
 targets:
+  {{- range .matrix }}
+  {{- $id := .id -}}
   {{- if index . "adminApp" }}
-  adminAppCompose:
+  adminAppCompose_{{ $id }}:
     name: Alfresco Control Center
     kind: yaml
     scmid: ourRepo
-    sourceid: adminAppTag
+    sourceid: adminAppTag_{{ $id }}
     transformers:
       - addprefix: "quay.io/alfresco/alfresco-admin-app:"
     spec:
       file: {{ .adminApp.compose_target }}
       key: >-
         {{ .adminApp.compose_key }}
-  adminAppValues:
+  adminAppValues_{{ $id }}:
     name: Helm chart default values file
     kind: yaml
     scmid: ourRepo
-    sourceid: adminAppTag
+    sourceid: adminAppTag_{{ $id }}
     spec:
       file: {{ .adminApp.helm_target }}
       key: >-
         {{ .adminApp.helm_key }}
   {{- end }}
   {{- if index . "adw" }}
-  adwCompose:
+  adwCompose_{{ $id }}:
     name: ADW image tag
     kind: yaml
     scmid: ourRepo
-    sourceid: adwTag
+    sourceid: adwTag_{{ $id }}
     transformers:
       - addprefix: "quay.io/alfresco/alfresco-digital-workspace:"
     spec:
       file: {{ .adw.compose_target }}
       key: >-
         {{ .adw.compose_key }}
-  adwValues:
+  adwValues_{{ $id }}:
     name: ADW image tag
     kind: yaml
     scmid: ourRepo
-    sourceid: adwTag
+    sourceid: adwTag_{{ $id }}
     spec:
       file: {{ .adw.helm_target }}
       key: >-
         {{ .adw.helm_key }}
   {{- end }}
-  repositoryCompose:
+  repositoryCompose_{{ $id }}:
     name: Repo image tag
     kind: yaml
     scmid: ourRepo
-    sourceid: repositoryTag
+    sourceid: repositoryTag_{{ $id }}
     transformers:
       - addprefix: "{{ index . "acs" "image" }}:"
     spec:
       file: {{ .acs.compose_target }}
       key: >-
         {{ .acs.compose_key }}
-  repositoryValues:
+  repositoryValues_{{ $id }}:
     name: Repo image tag
     kind: yaml
     scmid: ourRepo
-    sourceid: repositoryTag
+    sourceid: repositoryTag_{{ $id }}
     spec:
       file: {{ .acs.helm_target }}
       key: >-
         {{ .acs.helm_key }}
   {{- if index . "search" }}
-  searchCompose:
+  searchCompose_{{ $id }}:
     name: search image tag
     kind: yaml
     scmid: ourRepo
-    sourceid: searchTag
+    sourceid: searchTag_{{ $id }}
     transformers:
       - addprefix: "{{ index . "search" "image" }}:"
     spec:
@@ -333,11 +339,11 @@ targets:
       key: >-
         {{ .search.compose_key }}
   {{- if and .search.helm_target .search.helm_key }}
-  searchValues:
+  searchValues_{{ $id }}:
     name: search image tag
     kind: yaml
     scmid: ourRepo
-    sourceid: searchTag
+    sourceid: searchTag_{{ $id }}
     spec:
       file: {{ .search.helm_target }}
       key: >-
@@ -346,11 +352,11 @@ targets:
   {{- end }}
   {{- if index . "search-enterprise" }}
   {{- if index . "search-enterprise" "compose_target" }}
-  searchEnterpriseCompose:
+  searchEnterpriseCompose_{{ $id }}:
     name: Search Enterprise image tag
     kind: yaml
     scmid: ourRepo
-    sourceid: searchEnterpriseTag
+    sourceid: searchEnterpriseTag_{{ $id }}
     transformers:
       - addprefix: "quay.io/alfresco/alfresco-elasticsearch-live-indexing:"
     spec:
@@ -360,129 +366,129 @@ targets:
   {{- end }}
   {{- if index . "search-enterprise" "helm_target" }}
   {{- $target_searchEnt := index . "search-enterprise" "helm_target" }}
-  searchEnterpriseReindexingValues:
+  searchEnterpriseReindexingValues_{{ $id }}:
     name: Search Enterprise image tag
     kind: yaml
     scmid: ourRepo
-    sourceid: searchEnterpriseTag
+    sourceid: searchEnterpriseTag_{{ $id }}
     spec:
       file: {{ $target_searchEnt }}
       key: {{ index . "search-enterprise" "helm_keys" "Reindexing" }}
   {{- range $key, $value := index . "search-enterprise" "helm_keys" "Liveindexing" }}
-  searchEnterprise{{ $key }}Values:
+  searchEnterprise{{ $key }}Values_{{ $id }}:
     name: Search Enterprise image tag
     kind: yaml
     scmid: ourRepo
-    sourceid: searchEnterpriseTag
+    sourceid: searchEnterpriseTag_{{ $id }}
     spec:
       file: {{ $target_searchEnt }}
       key: {{ $value }}
   {{- end }}
   {{- end }}
   {{- end }}
-  shareCompose:
+  shareCompose_{{ $id }}:
     name: Share image tag
     kind: yaml
     scmid: ourRepo
-    sourceid: shareTag
+    sourceid: shareTag_{{ $id }}
     transformers:
       - addprefix: "{{ index . "share" "image" }}:"
     spec:
       file: {{ .share.compose_target }}
       key: >-
         {{ .share.compose_key }}
-  shareValues:
+  shareValues_{{ $id }}:
     name: Share image tag
     kind: yaml
     scmid: ourRepo
-    sourceid: shareTag
+    sourceid: shareTag_{{ $id }}
     spec:
       file: {{ .share.helm_target }}
       key: >-
         {{ .share.helm_key }}
   {{- if index . "onedrive" }}
-  onedriveValues:
+  onedriveValues_{{ $id }}:
     name: Onedrive image tag
     kind: yaml
     scmid: ourRepo
-    sourceid: onedriveTag
+    sourceid: onedriveTag_{{ $id }}
     spec:
       file: {{ .onedrive.helm_target }}
       key: >-
         {{ .onedrive.helm_key }}
   {{- end }}
   {{- if index . "msteams" }}
-  msteamsValues:
+  msteamsValues_{{ $id }}:
     name: MS Teams image tag
     kind: yaml
     scmid: ourRepo
-    sourceid: msteamsTag
+    sourceid: msteamsTag_{{ $id }}
     spec:
       file: {{ .msteams.helm_target }}
       key: >-
         {{ .msteams.helm_key }}
   {{- end }}
   {{- if index . "intelligence" }}
-  intelligenceValues:
+  intelligenceValues_{{ $id }}:
     name: Alfresco Intelligence image tag
     kind: yaml
     scmid: ourRepo
-    sourceid: intelligenceTag
+    sourceid: intelligenceTag_{{ $id }}
     spec:
       file: {{ .intelligence.helm_target }}
       key: >-
         {{ .intelligence.helm_key }}
   {{- end }}
   {{- if index . "trouter" }}
-  trouterCompose:
+  trouterCompose_{{ $id }}:
     name: Alfresco Transform Router image tag
     kind: yaml
     scmid: ourRepo
-    sourceid: trouterTag
+    sourceid: trouterTag_{{ $id }}
     transformers:
       - addprefix: "quay.io/alfresco/alfresco-transform-router:"
     spec:
       file: {{ index . "trouter" "compose_target" }}
       key: >-
         {{ index . "trouter" "compose_key" }}
-  trouterValues:
+  trouterValues_{{ $id }}:
     name: Alfresco Transform Router image tag
     kind: yaml
     scmid: ourRepo
-    sourceid: trouterTag
+    sourceid: trouterTag_{{ $id }}
     spec:
       file: {{ .trouter.helm_target }}
       key: >-
         {{ .trouter.helm_key }}
   {{- end }}
   {{- if index . "sfs" }}
-  sfsCompose:
+  sfsCompose_{{ $id }}:
     name: Alfresco Shared Filestore image tag
     kind: yaml
     scmid: ourRepo
-    sourceid: sfsTag
+    sourceid: sfsTag_{{ $id }}
     transformers:
       - addprefix: "quay.io/alfresco/alfresco-shared-file-store:"
     spec:
       file: {{ index . "sfs" "compose_target" }}
       key: >-
         {{ index . "sfs" "compose_key" }}
-  sfsValues:
+  sfsValues_{{ $id }}:
     name: Alfresco Shared Filestore image tag
     kind: yaml
     scmid: ourRepo
-    sourceid: sfsTag
+    sourceid: sfsTag_{{ $id }}
     spec:
       file: {{ .sfs.helm_target }}
       key: >-
         {{ .sfs.helm_key }}
   {{- end }}
   {{- if index . "tengine-aio" }}
-  tengine-aioCompose:
+  tengine-aioCompose_{{ $id }}:
     name: Alfresco All-In-One Transform Engine image tag
     kind: yaml
     scmid: ourRepo
-    sourceid: tengine-aioTag
+    sourceid: tengine-aioTag_{{ $id }}
     transformers:
       - addprefix: "alfresco/alfresco-transform-core-aio:"
     spec:
@@ -491,79 +497,80 @@ targets:
         {{ index . "tengine-aio" "compose_key" }}
   {{- end }}
   {{- if index . "tengine-misc" }}
-  tengine-miscValues:
+  tengine-miscValues_{{ $id }}:
     name: Alfresco misc Transform Engine image tag
     kind: yaml
     scmid: ourRepo
-    sourceid: tengine-miscTag
+    sourceid: tengine-miscTag_{{ $id }}
     spec:
       file: {{ index . "tengine-misc" "helm_target" }}
       key: >-
         {{ index . "tengine-misc" "helm_key" }}
   {{- end }}
   {{- if index . "tengine-im" }}
-  tengine-imValues:
+  tengine-imValues_{{ $id }}:
     name: Alfresco ImageMagick Transform Engine image tag
     kind: yaml
     scmid: ourRepo
-    sourceid: tengine-imTag
+    sourceid: tengine-imTag_{{ $id }}
     spec:
       file: {{ index . "tengine-im" "helm_target" }}
       key: >-
         {{ index . "tengine-im" "helm_key" }}
   {{- end }}
   {{- if index . "tengine-lo" }}
-  tengine-loValues:
+  tengine-loValues_{{ $id }}:
     name: Alfresco LibreOffice Transform Engine image tag
     kind: yaml
     scmid: ourRepo
-    sourceid: tengine-loTag
+    sourceid: tengine-loTag_{{ $id }}
     spec:
       file: {{ index . "tengine-lo" "helm_target" }}
       key: >-
         {{ index . "tengine-lo" "helm_key" }}
   {{- end }}
   {{- if index . "tengine-pdf" }}
-  tengine-pdfValues:
+  tengine-pdfValues_{{ $id }}:
     name: Alfresco PDF Transform Engine image tag
     kind: yaml
     scmid: ourRepo
-    sourceid: tengine-pdfTag
+    sourceid: tengine-pdfTag_{{ $id }}
     spec:
       file: {{ index . "tengine-pdf" "helm_target" }}
       key: >-
         {{ index . "tengine-pdf" "helm_key" }}
   {{- end }}
   {{- if index . "tengine-tika" }}
-  tengine-tikaValues:
+  tengine-tikaValues_{{ $id }}:
     name: Alfresco tika Transform Engine image tag
     kind: yaml
     scmid: ourRepo
-    sourceid: tengine-tikaTag
+    sourceid: tengine-tikaTag_{{ $id }}
     spec:
       file: {{ index . "tengine-tika" "helm_target" }}
       key: >-
         {{ index . "tengine-tika" "helm_key" }}
   {{- end }}
   {{- if index . "sync" }}
-  syncCompose:
+  syncCompose_{{ $id }}:
     name: Sync image tag
     kind: yaml
     scmid: ourRepo
-    sourceid: syncTag
+    sourceid: syncTag_{{ $id }}
     transformers:
       - addprefix: "quay.io/alfresco/service-sync:"
     spec:
       file: {{ .sync.compose_target }}
       key: >-
         {{ .sync.compose_key }}
-  syncValues:
+  syncValues_{{ $id }}:
     name: Sync image tag
     kind: yaml
     scmid: ourRepo
-    sourceid: syncTag
+    sourceid: syncTag_{{ $id }}
     spec:
       file: {{ .sync.helm_target }}
       key: >-
         {{ .sync.helm_key }}
+  {{- end }}
   {{- end }}

--- a/updatecli.d/uber-manifest.tpl
+++ b/updatecli.d/uber-manifest.tpl
@@ -151,6 +151,30 @@ sources:
         pattern: >-
           ^{{ index . "msteams" "version" }}{{ index . "msteams" "pattern" }}$
   {{- end }}
+  {{- if index . "intelligence" }}
+  intelligenceTag:
+    name: Intelligence Service image tag
+    kind: dockerimage
+    spec:
+      image: quay.io/alfresco/alfresco-ai-docker-engine
+      {{ template "quay_auth" }}
+      versionFilter:
+        kind: semver
+        pattern: >-
+          {{ index . "intelligence" "version" }}
+  {{- end }}
+  {{- if index . "trouter" }}
+  trouterTag:
+    name: Alfresco Transform Router image tag
+    kind: dockerimage
+    spec:
+      image: quay.io/alfresco/alfresco-transform-router
+      {{ template "quay_auth" }}
+      versionFilter:
+        kind: semver
+        pattern: >-
+          {{ index . "trouter" "version" }}
+  {{- end }}
 
 
 targets:

--- a/updatecli.d/uber-manifest.tpl
+++ b/updatecli.d/uber-manifest.tpl
@@ -139,7 +139,18 @@ sources:
         pattern: >-
           ^{{ index . "onedrive" "version" }}{{ index . "onedrive" "pattern" }}$
   {{- end }}
-
+  {{- if index . "msteams" }}
+  msteamsTag:
+    name: MS Teams Service image tag
+    kind: dockerimage
+    spec:
+      image: quay.io/alfresco/alfresco-ms-teams-service
+      {{ template "quay_auth" }}
+      versionFilter:
+        kind: regex
+        pattern: >-
+          ^{{ index . "msteams" "version" }}{{ index . "msteams" "pattern" }}$
+  {{- end }}
 
 
 targets:
@@ -297,6 +308,17 @@ targets:
       file: {{ .onedrive.helm_target }}
       key: >-
         {{ .onedrive.helm_key }}
+  {{- end }}
+  {{- if index . "msteams" }}
+  msteamsValues:
+    name: MS Teams image tag
+    kind: yaml
+    scmid: ourRepo
+    sourceid: msteamsTag
+    spec:
+      file: {{ .msteams.helm_target }}
+      key: >-
+        {{ .msteams.helm_key }}
   {{- end }}
   {{- if index . "sync" }}
   syncCompose:

--- a/updatecli.d/uber-manifest.tpl
+++ b/updatecli.d/uber-manifest.tpl
@@ -223,6 +223,18 @@ sources:
         pattern: >-
           {{ index . "tengine-lo" "version" }}
   {{- end }}
+  {{- if index . "tengine-pdf" }}
+  tengine-pdfTag:
+    name: Alfresco PDF Transform Engine image tag
+    kind: dockerimage
+    spec:
+      image: quay.io/alfresco/alfresco-pdf-renderer
+      {{ template "quay_auth" }}
+      versionFilter:
+        kind: semver
+        pattern: >-
+          {{ index . "tengine-pdf" "version" }}
+  {{- end }}
 
 
 targets:
@@ -459,6 +471,17 @@ targets:
       file: {{ index . "tengine-lo" "helm_target" }}
       key: >-
         {{ index . "tengine-lo" "helm_key" }}
+  {{- end }}
+  {{- if index . "tengine-pdf" }}
+  tengine-pdfValues:
+    name: Alfresco PDF Transform Engine image tag
+    kind: yaml
+    scmid: ourRepo
+    sourceid: tengine-pdfTag
+    spec:
+      file: {{ index . "tengine-pdf" "helm_target" }}
+      key: >-
+        {{ index . "tengine-pdf" "helm_key" }}
   {{- end }}
   {{- if index . "sync" }}
   syncCompose:

--- a/updatecli.d/uber-manifest.tpl
+++ b/updatecli.d/uber-manifest.tpl
@@ -98,9 +98,9 @@ sources:
       {{ template "quay_auth" }}
       {{ end }}
       versionFilter:
-        kind: regex
+        kind: semver
         pattern: >-
-          ^{{ index . "search" "version" }}{{ index . "search" "pattern" }}$
+          {{ index . "search" "version" }}
   {{- end }}
   {{ $share_image := index . "share" "image" }}
   shareTag:

--- a/updatecli.d/uber-manifest.tpl
+++ b/updatecli.d/uber-manifest.tpl
@@ -192,8 +192,7 @@ sources:
     name: Alfresco All-In-One Transform Engine image tag
     kind: dockerimage
     spec:
-      image: quay.io/alfresco/alfresco-transform-core-aio
-      {{ template "quay_auth" }}
+      image: alfresco/alfresco-transform-core-aio
       versionFilter:
         kind: semver
         pattern: >-
@@ -204,8 +203,7 @@ sources:
     name: Alfresco misc Transform Engine image tag
     kind: dockerimage
     spec:
-      image: quay.io/alfresco/alfresco-transform-misc
-      {{ template "quay_auth" }}
+      image: alfresco/alfresco-transform-misc
       versionFilter:
         kind: semver
         pattern: >-
@@ -216,8 +214,7 @@ sources:
     name: Alfresco ImageMagick Transform Engine image tag
     kind: dockerimage
     spec:
-      image: quay.io/alfresco/alfresco-imagemagick
-      {{ template "quay_auth" }}
+      image: alfresco/alfresco-imagemagick
       versionFilter:
         kind: semver
         pattern: >-
@@ -228,8 +225,7 @@ sources:
     name: Alfresco LibreOffice Transform Engine image tag
     kind: dockerimage
     spec:
-      image: quay.io/alfresco/alfresco-libreoffice
-      {{ template "quay_auth" }}
+      image: alfresco/alfresco-libreoffice
       versionFilter:
         kind: semver
         pattern: >-
@@ -240,8 +236,7 @@ sources:
     name: Alfresco PDF Transform Engine image tag
     kind: dockerimage
     spec:
-      image: quay.io/alfresco/alfresco-pdf-renderer
-      {{ template "quay_auth" }}
+      image: alfresco/alfresco-pdf-renderer
       versionFilter:
         kind: semver
         pattern: >-
@@ -252,8 +247,7 @@ sources:
     name: Alfresco tika Transform Engine image tag
     kind: dockerimage
     spec:
-      image: quay.io/alfresco/alfresco-tika
-      {{ template "quay_auth" }}
+      image: alfresco/alfresco-tika
       versionFilter:
         kind: semver
         pattern: >-
@@ -446,7 +440,7 @@ targets:
     scmid: ourRepo
     sourceid: trouterTag
     transformers:
-      - addprefix: "{{ index . "trouter" "image" }}:"
+      - addprefix: "quay.io/alfresco/alfresco-transform-router:"
     spec:
       file: {{ index . "trouter" "compose_target" }}
       key: >-
@@ -468,7 +462,7 @@ targets:
     scmid: ourRepo
     sourceid: sfsTag
     transformers:
-      - addprefix: "{{ index . "sfs" "image" }}:"
+      - addprefix: "quay.io/alfresco/alfresco-shared-file-store:"
     spec:
       file: {{ index . "sfs" "compose_target" }}
       key: >-
@@ -490,7 +484,7 @@ targets:
     scmid: ourRepo
     sourceid: tengine-aioTag
     transformers:
-      - addprefix: "{{ index . "tengine-aio" "image" }}:"
+      - addprefix: "alfresco/alfresco-transform-core-aio:"
     spec:
       file: {{ index . "tengine-aio" "compose_target" }}
       key: >-

--- a/updatecli.d/uber-manifest.tpl
+++ b/updatecli.d/uber-manifest.tpl
@@ -7,7 +7,7 @@ title: Images updates for all versions of Helm charts and Docker compose
 {{- end }}
 
 scms:
-  ourRepo:
+  sourceRepo:
     kind: github
     spec:
       user: {{ requiredEnv "GIT_AUTHOR_USERNAME" }}
@@ -15,6 +15,16 @@ scms:
       owner: Alfresco
       repository: acs-deployment
       branch: {{ requiredEnv "GIT_BRANCH" }}
+      username: alfresco-build
+      token: {{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}
+  targetRepo:
+    kind: github
+    spec:
+      user: {{ requiredEnv "GIT_AUTHOR_USERNAME" }}
+      email: {{ requiredEnv "GIT_AUTHOR_EMAIL" }}
+      owner: Alfresco
+      repository: acs-deployment
+      branch: {{ requiredEnv "TGT_PR_BRANCH" }}
       username: alfresco-build
       token: {{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}
   searchEnterprise:
@@ -31,7 +41,7 @@ scms:
 actions:
   default:
     kind: github/pullrequest
-    scmid: ourRepo
+    scmid: targetRepo
     spec:
       title: "{{ requiredEnv "JIRA_ID" }} Bump component versions"
       draft: true
@@ -266,7 +276,7 @@ targets:
   adminAppCompose_{{ $id }}:
     name: Alfresco Control Center
     kind: yaml
-    scmid: ourRepo
+    scmid: sourceRepo
     sourceid: adminAppTag_{{ $id }}
     transformers:
       - addprefix: "quay.io/alfresco/alfresco-admin-app:"
@@ -277,7 +287,7 @@ targets:
   adminAppValues_{{ $id }}:
     name: Helm chart default values file
     kind: yaml
-    scmid: ourRepo
+    scmid: sourceRepo
     sourceid: adminAppTag_{{ $id }}
     spec:
       file: {{ .adminApp.helm_target }}
@@ -288,7 +298,7 @@ targets:
   adwCompose_{{ $id }}:
     name: ADW image tag
     kind: yaml
-    scmid: ourRepo
+    scmid: sourceRepo
     sourceid: adwTag_{{ $id }}
     transformers:
       - addprefix: "quay.io/alfresco/alfresco-digital-workspace:"
@@ -299,7 +309,7 @@ targets:
   adwValues_{{ $id }}:
     name: ADW image tag
     kind: yaml
-    scmid: ourRepo
+    scmid: sourceRepo
     sourceid: adwTag_{{ $id }}
     spec:
       file: {{ .adw.helm_target }}
@@ -309,7 +319,7 @@ targets:
   repositoryCompose_{{ $id }}:
     name: Repo image tag
     kind: yaml
-    scmid: ourRepo
+    scmid: sourceRepo
     sourceid: repositoryTag_{{ $id }}
     transformers:
       - addprefix: "{{ index . "acs" "image" }}:"
@@ -320,7 +330,7 @@ targets:
   repositoryValues_{{ $id }}:
     name: Repo image tag
     kind: yaml
-    scmid: ourRepo
+    scmid: sourceRepo
     sourceid: repositoryTag_{{ $id }}
     spec:
       file: {{ .acs.helm_target }}
@@ -330,7 +340,7 @@ targets:
   searchCompose_{{ $id }}:
     name: search image tag
     kind: yaml
-    scmid: ourRepo
+    scmid: sourceRepo
     sourceid: searchTag_{{ $id }}
     transformers:
       - addprefix: "{{ index . "search" "image" }}:"
@@ -342,7 +352,7 @@ targets:
   searchValues_{{ $id }}:
     name: search image tag
     kind: yaml
-    scmid: ourRepo
+    scmid: sourceRepo
     sourceid: searchTag_{{ $id }}
     spec:
       file: {{ .search.helm_target }}
@@ -355,7 +365,7 @@ targets:
   searchEnterpriseCompose_{{ $id }}:
     name: Search Enterprise image tag
     kind: yaml
-    scmid: ourRepo
+    scmid: sourceRepo
     sourceid: searchEnterpriseTag_{{ $id }}
     transformers:
       - addprefix: "quay.io/alfresco/alfresco-elasticsearch-live-indexing:"
@@ -369,7 +379,7 @@ targets:
   searchEnterpriseReindexingValues_{{ $id }}:
     name: Search Enterprise image tag
     kind: yaml
-    scmid: ourRepo
+    scmid: sourceRepo
     sourceid: searchEnterpriseTag_{{ $id }}
     spec:
       file: {{ $target_searchEnt }}
@@ -378,7 +388,7 @@ targets:
   searchEnterprise{{ $key }}Values_{{ $id }}:
     name: Search Enterprise image tag
     kind: yaml
-    scmid: ourRepo
+    scmid: sourceRepo
     sourceid: searchEnterpriseTag_{{ $id }}
     spec:
       file: {{ $target_searchEnt }}
@@ -389,7 +399,7 @@ targets:
   shareCompose_{{ $id }}:
     name: Share image tag
     kind: yaml
-    scmid: ourRepo
+    scmid: sourceRepo
     sourceid: shareTag_{{ $id }}
     transformers:
       - addprefix: "{{ index . "share" "image" }}:"
@@ -400,7 +410,7 @@ targets:
   shareValues_{{ $id }}:
     name: Share image tag
     kind: yaml
-    scmid: ourRepo
+    scmid: sourceRepo
     sourceid: shareTag_{{ $id }}
     spec:
       file: {{ .share.helm_target }}
@@ -410,7 +420,7 @@ targets:
   onedriveValues_{{ $id }}:
     name: Onedrive image tag
     kind: yaml
-    scmid: ourRepo
+    scmid: sourceRepo
     sourceid: onedriveTag_{{ $id }}
     spec:
       file: {{ .onedrive.helm_target }}
@@ -421,7 +431,7 @@ targets:
   msteamsValues_{{ $id }}:
     name: MS Teams image tag
     kind: yaml
-    scmid: ourRepo
+    scmid: sourceRepo
     sourceid: msteamsTag_{{ $id }}
     spec:
       file: {{ .msteams.helm_target }}
@@ -432,7 +442,7 @@ targets:
   intelligenceValues_{{ $id }}:
     name: Alfresco Intelligence image tag
     kind: yaml
-    scmid: ourRepo
+    scmid: sourceRepo
     sourceid: intelligenceTag_{{ $id }}
     spec:
       file: {{ .intelligence.helm_target }}
@@ -443,7 +453,7 @@ targets:
   trouterCompose_{{ $id }}:
     name: Alfresco Transform Router image tag
     kind: yaml
-    scmid: ourRepo
+    scmid: sourceRepo
     sourceid: trouterTag_{{ $id }}
     transformers:
       - addprefix: "quay.io/alfresco/alfresco-transform-router:"
@@ -454,7 +464,7 @@ targets:
   trouterValues_{{ $id }}:
     name: Alfresco Transform Router image tag
     kind: yaml
-    scmid: ourRepo
+    scmid: sourceRepo
     sourceid: trouterTag_{{ $id }}
     spec:
       file: {{ .trouter.helm_target }}
@@ -465,7 +475,7 @@ targets:
   sfsCompose_{{ $id }}:
     name: Alfresco Shared Filestore image tag
     kind: yaml
-    scmid: ourRepo
+    scmid: sourceRepo
     sourceid: sfsTag_{{ $id }}
     transformers:
       - addprefix: "quay.io/alfresco/alfresco-shared-file-store:"
@@ -476,7 +486,7 @@ targets:
   sfsValues_{{ $id }}:
     name: Alfresco Shared Filestore image tag
     kind: yaml
-    scmid: ourRepo
+    scmid: sourceRepo
     sourceid: sfsTag_{{ $id }}
     spec:
       file: {{ .sfs.helm_target }}
@@ -487,7 +497,7 @@ targets:
   tengine-aioCompose_{{ $id }}:
     name: Alfresco All-In-One Transform Engine image tag
     kind: yaml
-    scmid: ourRepo
+    scmid: sourceRepo
     sourceid: tengine-aioTag_{{ $id }}
     transformers:
       - addprefix: "alfresco/alfresco-transform-core-aio:"
@@ -500,7 +510,7 @@ targets:
   tengine-miscValues_{{ $id }}:
     name: Alfresco misc Transform Engine image tag
     kind: yaml
-    scmid: ourRepo
+    scmid: sourceRepo
     sourceid: tengine-miscTag_{{ $id }}
     spec:
       file: {{ index . "tengine-misc" "helm_target" }}
@@ -511,7 +521,7 @@ targets:
   tengine-imValues_{{ $id }}:
     name: Alfresco ImageMagick Transform Engine image tag
     kind: yaml
-    scmid: ourRepo
+    scmid: sourceRepo
     sourceid: tengine-imTag_{{ $id }}
     spec:
       file: {{ index . "tengine-im" "helm_target" }}
@@ -522,7 +532,7 @@ targets:
   tengine-loValues_{{ $id }}:
     name: Alfresco LibreOffice Transform Engine image tag
     kind: yaml
-    scmid: ourRepo
+    scmid: sourceRepo
     sourceid: tengine-loTag_{{ $id }}
     spec:
       file: {{ index . "tengine-lo" "helm_target" }}
@@ -533,7 +543,7 @@ targets:
   tengine-pdfValues_{{ $id }}:
     name: Alfresco PDF Transform Engine image tag
     kind: yaml
-    scmid: ourRepo
+    scmid: sourceRepo
     sourceid: tengine-pdfTag_{{ $id }}
     spec:
       file: {{ index . "tengine-pdf" "helm_target" }}
@@ -544,7 +554,7 @@ targets:
   tengine-tikaValues_{{ $id }}:
     name: Alfresco tika Transform Engine image tag
     kind: yaml
-    scmid: ourRepo
+    scmid: sourceRepo
     sourceid: tengine-tikaTag_{{ $id }}
     spec:
       file: {{ index . "tengine-tika" "helm_target" }}
@@ -555,7 +565,7 @@ targets:
   syncCompose_{{ $id }}:
     name: Sync image tag
     kind: yaml
-    scmid: ourRepo
+    scmid: sourceRepo
     sourceid: syncTag_{{ $id }}
     transformers:
       - addprefix: "quay.io/alfresco/service-sync:"
@@ -566,7 +576,7 @@ targets:
   syncValues_{{ $id }}:
     name: Sync image tag
     kind: yaml
-    scmid: ourRepo
+    scmid: sourceRepo
     sourceid: syncTag_{{ $id }}
     spec:
       file: {{ .sync.helm_target }}

--- a/updatecli.d/uber-manifest.tpl
+++ b/updatecli.d/uber-manifest.tpl
@@ -235,6 +235,18 @@ sources:
         pattern: >-
           {{ index . "tengine-pdf" "version" }}
   {{- end }}
+  {{- if index . "tengine-tika" }}
+  tengine-tikaTag:
+    name: Alfresco tika Transform Engine image tag
+    kind: dockerimage
+    spec:
+      image: quay.io/alfresco/alfresco-tika
+      {{ template "quay_auth" }}
+      versionFilter:
+        kind: semver
+        pattern: >-
+          {{ index . "tengine-tika" "version" }}
+  {{- end }}
 
 
 targets:
@@ -482,6 +494,17 @@ targets:
       file: {{ index . "tengine-pdf" "helm_target" }}
       key: >-
         {{ index . "tengine-pdf" "helm_key" }}
+  {{- end }}
+  {{- if index . "tengine-tika" }}
+  tengine-tikaValues:
+    name: Alfresco tika Transform Engine image tag
+    kind: yaml
+    scmid: ourRepo
+    sourceid: tengine-tikaTag
+    spec:
+      file: {{ index . "tengine-tika" "helm_target" }}
+      key: >-
+        {{ index . "tengine-tika" "helm_key" }}
   {{- end }}
   {{- if index . "sync" }}
   syncCompose:

--- a/updatecli.d/uber-manifest.tpl
+++ b/updatecli.d/uber-manifest.tpl
@@ -211,6 +211,18 @@ sources:
         pattern: >-
           {{ index . "tengine-im" "version" }}
   {{- end }}
+  {{- if index . "tengine-lo" }}
+  tengine-loTag:
+    name: Alfresco LibreOffice Transform Engine image tag
+    kind: dockerimage
+    spec:
+      image: quay.io/alfresco/alfresco-libreoffice
+      {{ template "quay_auth" }}
+      versionFilter:
+        kind: semver
+        pattern: >-
+          {{ index . "tengine-lo" "version" }}
+  {{- end }}
 
 
 targets:
@@ -436,6 +448,17 @@ targets:
       file: {{ index . "tengine-im" "helm_target" }}
       key: >-
         {{ index . "tengine-im" "helm_key" }}
+  {{- end }}
+  {{- if index . "tengine-lo" }}
+  tengine-loValues:
+    name: Alfresco LibreOffice Transform Engine image tag
+    kind: yaml
+    scmid: ourRepo
+    sourceid: tengine-loTag
+    spec:
+      file: {{ index . "tengine-lo" "helm_target" }}
+      key: >-
+        {{ index . "tengine-lo" "helm_key" }}
   {{- end }}
   {{- if index . "sync" }}
   syncCompose:

--- a/updatecli.d/uber-manifest.tpl
+++ b/updatecli.d/uber-manifest.tpl
@@ -175,6 +175,18 @@ sources:
         pattern: >-
           {{ index . "trouter" "version" }}
   {{- end }}
+  {{- if index . "sfs" }}
+  sfsTag:
+    name: Alfresco Shared Filestore image tag
+    kind: dockerimage
+    spec:
+      image: quay.io/alfresco/alfresco-shared-file-store
+      {{ template "quay_auth" }}
+      versionFilter:
+        kind: semver
+        pattern: >-
+          {{ index . "sfs" "version" }}
+  {{- end }}
   {{- if index . "tengine-aio" }}
   tengine-aioTag:
     name: Alfresco All-In-One Transform Engine image tag
@@ -428,6 +440,17 @@ targets:
         {{ .intelligence.helm_key }}
   {{- end }}
   {{- if index . "trouter" }}
+  trouterCompose:
+    name: Alfresco Transform Router image tag
+    kind: yaml
+    scmid: ourRepo
+    sourceid: trouterTag
+    transformers:
+      - addprefix: "{{ index . "trouter" "image" }}:"
+    spec:
+      file: {{ index . "trouter" "compose_target" }}
+      key: >-
+        {{ index . "trouter" "compose_key" }}
   trouterValues:
     name: Alfresco Transform Router image tag
     kind: yaml
@@ -437,6 +460,28 @@ targets:
       file: {{ .trouter.helm_target }}
       key: >-
         {{ .trouter.helm_key }}
+  {{- end }}
+  {{- if index . "sfs" }}
+  sfsCompose:
+    name: Alfresco Shared Filestore image tag
+    kind: yaml
+    scmid: ourRepo
+    sourceid: sfsTag
+    transformers:
+      - addprefix: "{{ index . "sfs" "image" }}:"
+    spec:
+      file: {{ index . "sfs" "compose_target" }}
+      key: >-
+        {{ index . "sfs" "compose_key" }}
+  sfsValues:
+    name: Alfresco Shared Filestore image tag
+    kind: yaml
+    scmid: ourRepo
+    sourceid: sfsTag
+    spec:
+      file: {{ .sfs.helm_target }}
+      key: >-
+        {{ .sfs.helm_key }}
   {{- end }}
   {{- if index . "tengine-aio" }}
   tengine-aioCompose:

--- a/updatecli.d/uber-manifest.tpl
+++ b/updatecli.d/uber-manifest.tpl
@@ -69,7 +69,7 @@ sources:
     kind: dockerimage
     spec:
       image: {{ $repo_image }}
-      {{ if eq (slice $repo_image 0 8) "quay.io/" }}
+      {{ if eq (printf "%.8s" $repo_image) "quay.io/" }}
       {{ template "quay_auth" }}
       {{ end }}
       versionFilter:
@@ -94,7 +94,7 @@ sources:
     kind: dockerimage
     spec:
       image: {{ $search_image }}
-      {{ if eq (slice $search_image 0 8) "quay.io/" }}
+      {{ if eq (printf "%.8s" $search_image) "quay.io/" }}
       {{ template "quay_auth" }}
       {{ end }}
       versionFilter:
@@ -108,7 +108,7 @@ sources:
     kind: dockerimage
     spec:
       image: {{ $share_image }}
-      {{ if eq (slice $share_image 0 8) "quay.io/" }}
+      {{ if eq (printf "%.8s" $share_image) "quay.io/" }}
       {{ template "quay_auth" }}
       {{ end }}
       versionFilter:

--- a/updatecli.d/uber-manifest.tpl
+++ b/updatecli.d/uber-manifest.tpl
@@ -175,6 +175,18 @@ sources:
         pattern: >-
           {{ index . "trouter" "version" }}
   {{- end }}
+  {{- if index . "tengine-aio" }}
+  tengine-aioTag:
+    name: Alfresco All-In-One Transform Engine image tag
+    kind: dockerimage
+    spec:
+      image: alfresco/alfresco-transform-core-aio
+      {{ template "quay_auth" }}
+      versionFilter:
+        kind: semver
+        pattern: >-
+          {{ index . "tengine-aio" "version" }}
+  {{- end }}
 
 
 targets:
@@ -343,6 +355,41 @@ targets:
       file: {{ .msteams.helm_target }}
       key: >-
         {{ .msteams.helm_key }}
+  {{- end }}
+  {{- if index . "intelligence" }}
+  intelligenceValues:
+    name: Alfresco Intelligence image tag
+    kind: yaml
+    scmid: ourRepo
+    sourceid: intelligenceTag
+    spec:
+      file: {{ .intelligence.helm_target }}
+      key: >-
+        {{ .intelligence.helm_key }}
+  {{- end }}
+  {{- if index . "trouter" }}
+  trouterValues:
+    name: Alfresco Transform Router image tag
+    kind: yaml
+    scmid: ourRepo
+    sourceid: trouterTag
+    spec:
+      file: {{ .trouter.helm_target }}
+      key: >-
+        {{ .trouter.helm_key }}
+  {{- end }}
+  {{- if index . "tengine-aio" }}
+  tengine-aioCompose:
+    name: Alfresco All-In-One Transform Engine image tag
+    kind: yaml
+    scmid: ourRepo
+    sourceid: tengine-aioTag
+    transformers:
+      - addprefix: "{{ index . "tengine-aio" "image" }}:"
+    spec:
+      file: {{ index . "tengine-aio" "compose_target" }}
+      key: >-
+        {{ index . "tengine-aio" "compose_key" }}
   {{- end }}
   {{- if index . "sync" }}
   syncCompose:


### PR DESCRIPTION
Updatecli pipeline and workflow.

pipeline:
* add components released during oxford and bump versions
workflow:
* remove the `workflow_dispatch` and the updatecli PR target action
* remove matrix to have a single PR and avoid triggering numerous actions on each commit. Even if we have concurrency only the first commit is built which do not make sense (as we would prefer building the branch in its final state), and we can't cancel job to build only on the last commit other wise we might have leftover releases on acs-cluster.