### PR TITLE
OPSEXP-2109 avoid crashloop during community testing

### DIFF
--- a/.github/workflows/helm-community.yml
+++ b/.github/workflows/helm-community.yml
@@ -8,6 +8,7 @@ on:
       - 'helm/**'
       - 'test/postman/helm/**'
       - '.github/workflows/helm*'
+      - test/community-integration-test-values.yaml
   push:
     branches:
       - 'master'

--- a/test/community-integration-test-values.yaml
+++ b/test/community-integration-test-values.yaml
@@ -24,6 +24,8 @@ share:
   image:
     repository: alfresco/alfresco-share
 pdfrenderer:
+  livenessProbe:
+    initialDelaySeconds: 30
   resources:
     requests:
       cpu: "0.01"
@@ -32,6 +34,8 @@ pdfrenderer:
       memory: "512Mi"
   replicaCount: 1
 imagemagick:
+  livenessProbe:
+    initialDelaySeconds: 30
   resources:
     requests:
       cpu: "0.01"
@@ -40,6 +44,8 @@ imagemagick:
       memory: "512Mi"
   replicaCount: 1
 libreoffice:
+  livenessProbe:
+    initialDelaySeconds: 30
   resources:
     requests:
       cpu: "0.01"
@@ -48,6 +54,8 @@ libreoffice:
       memory: "1024Mi"
   replicaCount: 1
 tika:
+  livenessProbe:
+    initialDelaySeconds: 30
   resources:
     requests:
       cpu: "0.01"
@@ -56,6 +64,8 @@ tika:
       memory: "512Mi"
   replicaCount: 1
 transformmisc:
+  livenessProbe:
+    initialDelaySeconds: 30
   resources:
     requests:
       cpu: "0.01"


### PR DESCRIPTION
see [failure](https://github.com/Alfresco/acs-deployment/actions/runs/5088408110/jobs/9144773299#step:5:11)

This is the same solution I've applied in https://github.com/Alfresco/alfresco-helm-charts/pull/29

Ref: OPSEXP-2109