### PR TITLE
OPSEXP-2132 Properly handle tengine-aio bumping in updatecli

### DIFF
--- a/docker-compose/7.0.N-docker-compose.yml
+++ b/docker-compose/7.0.N-docker-compose.yml
@@ -71,7 +71,7 @@ services:
     links:
       - activemq
   transform-core-aio:
-    image: alfresco/alfresco-transform-core-aio:2.5.3
+    image: alfresco/alfresco-transform-core-aio:2.5.7
     mem_limit: 1536m
     environment:
       JAVA_OPTS: >-

--- a/docker-compose/7.2.N-docker-compose.yml
+++ b/docker-compose/7.2.N-docker-compose.yml
@@ -72,7 +72,7 @@ services:
     links:
       - activemq
   transform-core-aio:
-    image: alfresco/alfresco-transform-core-aio:2.6.0
+    image: alfresco/alfresco-transform-core-aio:2.5.7
     mem_limit: 1536m
     environment:
       JAVA_OPTS: >-

--- a/docker-compose/7.4.N-docker-compose.yml
+++ b/docker-compose/7.4.N-docker-compose.yml
@@ -72,7 +72,7 @@ services:
     links:
       - activemq
   transform-core-aio:
-    image: alfresco/alfresco-transform-core-aio:3.0.0
+    image: alfresco/alfresco-transform-core-aio:3.1.0
     mem_limit: 1536m
     environment:
       JAVA_OPTS: >-

--- a/updatecli.d/supported-matrix.yaml
+++ b/updatecli.d/supported-matrix.yaml
@@ -88,6 +88,10 @@ matrix:
       compose_key: $.services.shared-file-store.image
       helm_target: *helmvalues231
       helm_key: $.filestore.image.tag
+    tengine-aio:
+      version: ">=3.1.0-0"
+      compose_target: *compose231
+      compose_key: $.services.transform-core-aio.image
     tengine-misc:
       version: ">=3.1.0-0"
       helm_target: *helmvalues231
@@ -188,6 +192,10 @@ matrix:
       compose_key: $.services.shared-file-store.image
       helm_target: *helmvalues74
       helm_key: $.filestore.image.tag
+    tengine-aio:
+      version: "~3.1.0"
+      compose_target: *compose74
+      compose_key: $.services.transform-core-aio.image
     tengine-misc:
       version: "~3.1.0"
       helm_target: *helmvalues74
@@ -298,6 +306,10 @@ matrix:
       compose_key: $.services.shared-file-store.image
       helm_target: *helmvalues73
       helm_key: $.filestore.image.tag
+    tengine-aio:
+      version: "~3.0.0"
+      compose_target: *compose73
+      compose_key: $.services.transform-core-aio.image
     tengine-misc:
       version: "~3.0.0"
       helm_target: *helmvalues73
@@ -408,6 +420,10 @@ matrix:
       compose_key: $.services.shared-file-store.image
       helm_target: *helmvalues72
       helm_key: $.filestore.image.tag
+    tengine-aio:
+      version: "~2.5.0"
+      compose_target: *compose72
+      compose_key: $.services.transform-core-aio.image
     tengine-misc:
       version: "~2.5.0"
       helm_target: *helmvalues72
@@ -511,6 +527,10 @@ matrix:
       compose_key: $.services.shared-file-store.image
       helm_target: *helmvalues71
       helm_key: $.filestore.image.tag
+    tengine-aio:
+      version: "~2.5.0"
+      compose_target: *compose71
+      compose_key: $.services.transform-core-aio.image
     tengine-misc:
       version: "~2.5.0"
       helm_target: *helmvalues71
@@ -594,6 +614,10 @@ matrix:
       compose_key: $.services.shared-file-store.image
       helm_target: *helmvalues70
       helm_key: $.filestore.image.tag
+    tengine-aio:
+      version: "~2.5.0"
+      compose_target: *compose70
+      compose_key: $.services.transform-core-aio.image
     tengine-misc:
       version: "~2.5.0"
       helm_target: *helmvalues70
@@ -643,6 +667,6 @@ matrix:
       pattern: *ga_hotfixes_pattern
       image: docker.io/alfresco/alfresco-search-services
     tengine-aio:
+      version: "~3.1.0"
       compose_target: *composeOss
       compose_key: $.services.transform-core-aio.image
-      version: "~3.1.0"


### PR DESCRIPTION
Ref: OPSEXP-2132

tengine-aio component used only in docker compose was missing in updatecli config

no need to release as it was correctly bumped manually for 6.0.0 and the inconsistency was exposed only after https://github.com/Alfresco/acs-deployment/pull/937