### PR TITLE
Added Default encoding to resolve unizp issue

### DIFF
--- a/docker-compose/7.0.N-docker-compose.yml
+++ b/docker-compose/7.0.N-docker-compose.yml
@@ -55,6 +55,8 @@ services:
         -Ddsync.service.uris=http://localhost:9090/alfresco
         -XX:MinRAMPercentage=50
         -XX:MaxRAMPercentage=80
+        -Dfile.encoding=UTF8
+        -Dsun.jnu.encoding=UTF8
   transform-router:
     mem_limit: 512m
     image: quay.io/alfresco/alfresco-transform-router:1.4.1

--- a/docker-compose/7.1.N-docker-compose.yml
+++ b/docker-compose/7.1.N-docker-compose.yml
@@ -55,6 +55,8 @@ services:
         -Ddsync.service.uris=http://localhost:9090/alfresco
         -XX:MinRAMPercentage=50
         -XX:MaxRAMPercentage=80
+        -Dfile.encoding=UTF8
+        -Dsun.jnu.encoding=UTF8
   transform-router:
     mem_limit: 512m
     image: quay.io/alfresco/alfresco-transform-router:1.5.3

--- a/docker-compose/7.2.N-docker-compose.yml
+++ b/docker-compose/7.2.N-docker-compose.yml
@@ -56,6 +56,8 @@ services:
         -Ddsync.service.uris=http://localhost:9090/alfresco
         -XX:MinRAMPercentage=50
         -XX:MaxRAMPercentage=80
+        -Dfile.encoding=UTF8
+        -Dsun.jnu.encoding=UTF8
   transform-router:
     mem_limit: 512m
     image: quay.io/alfresco/alfresco-transform-router:2.0.0

--- a/docker-compose/7.3.N-docker-compose.yml
+++ b/docker-compose/7.3.N-docker-compose.yml
@@ -56,6 +56,8 @@ services:
         -Ddsync.service.uris=http://localhost:9090/alfresco
         -XX:MinRAMPercentage=50
         -XX:MaxRAMPercentage=80
+        -Dfile.encoding=UTF8
+        -Dsun.jnu.encoding=UTF8
   transform-router:
     mem_limit: 512m
     image: quay.io/alfresco/alfresco-transform-router:2.0.0

--- a/docker-compose/7.4.N-docker-compose.yml
+++ b/docker-compose/7.4.N-docker-compose.yml
@@ -56,6 +56,8 @@ services:
         -Ddsync.service.uris=http://localhost:9090/alfresco
         -XX:MinRAMPercentage=50
         -XX:MaxRAMPercentage=80
+        -Dfile.encoding=UTF8
+        -Dsun.jnu.encoding=UTF8
   transform-router:
     mem_limit: 512m
     image: quay.io/alfresco/alfresco-transform-router:2.1.0

--- a/docker-compose/community-docker-compose.yml
+++ b/docker-compose/community-docker-compose.yml
@@ -53,6 +53,8 @@ services:
         -DlocalTransform.core-aio.url=http://transform-core-aio:8090/
         -XX:MinRAMPercentage=50
         -XX:MaxRAMPercentage=80
+        -Dfile.encoding=UTF8
+        -Dsun.jnu.encoding=UTF8
   transform-core-aio:
     image: alfresco/alfresco-transform-core-aio:3.1.0
     mem_limit: 1536m

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -56,6 +56,8 @@ services:
         -Ddsync.service.uris=http://localhost:9090/alfresco
         -XX:MinRAMPercentage=50
         -XX:MaxRAMPercentage=80
+        -Dfile.encoding=UTF8
+        -Dsun.jnu.encoding=UTF8
   transform-router:
     mem_limit: 512m
     image: quay.io/alfresco/alfresco-transform-router:2.2.0-A1

--- a/docker-compose/elasticsearch-override-docker-compose.yml
+++ b/docker-compose/elasticsearch-override-docker-compose.yml
@@ -26,6 +26,8 @@ services:
         -Ddsync.service.uris=http://localhost:9090/alfresco
         -XX:MinRAMPercentage=50
         -XX:MaxRAMPercentage=80
+        -Dfile.encoding=UTF8
+        -Dsun.jnu.encoding=UTF8
   elasticsearch:
     image: elasticsearch:7.10.1
     environment:

--- a/helm/alfresco-content-services/values.yaml
+++ b/helm/alfresco-content-services/values.yaml
@@ -587,6 +587,8 @@ share:
       memory: "2000Mi"
   environment:
     CATALINA_OPTS: >-
+      -Dfile.encoding=UTF8
+      -Dsun.jnu.encoding=UTF8
       -XX:MinRAMPercentage=50
       -XX:MaxRAMPercentage=80
   readinessProbe:


### PR DESCRIPTION
Added jvm args for encoding in docker file that sets the default encoding as UTF8 and hence resolve the file name issue that is blocking the user to unzip files with accent characters in filename.