### PR TITLE
OPSEXP-2152 Introduce lockfile to avoid dependencies breakage

### DIFF
--- a/.github/workflows/pre-commit-compose.yml
+++ b/.github/workflows/pre-commit-compose.yml
@@ -16,7 +16,7 @@ on:
 
 env:
   # https://pre-commit.com/#temporarily-disabling-hooks
-  SKIP: helm-docs,helm-deps,helm-lint,checkov
+  SKIP: helm-docs,helm-deps-build,helm-lint,checkov
 
 jobs:
   pre_commit:

--- a/.github/workflows/pre-commit-helm.yml
+++ b/.github/workflows/pre-commit-helm.yml
@@ -28,4 +28,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: Alfresco/alfresco-build-tools/.github/actions/setup-helm-docs@v1.39.0
+      - name: Add dependency chart repos
+        run: |
+          helm repo add alfresco-helm-charts https://alfresco.github.io/alfresco-helm-charts/
+          helm repo add activiti-cloud-helm-charts https://activiti.github.io/activiti-cloud-helm-charts
       - uses: pre-commit/action@v3.0.0

--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,7 @@ target
 *.log
 *.log.*
 
-# Package Files #
+# Package Files
 *.jar
 *.war
 *.ear
@@ -30,11 +30,5 @@ target
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 
-# Helm
-*.lock
+# Helm packages
 *.tgz
-helm/alfresco-content-services/charts/activemq.yaml
-helm/alfresco-content-services/charts/alfresco-search.yaml
-helm/alfresco-content-services/charts/alfresco-search/charts/alfresco-insight-zeppelin.yaml
-helm/alfresco-content-services/charts/alfresco-sync-service.yaml
-helm/alfresco-content-services.yaml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,6 @@ repos:
   - repo: https://github.com/Alfresco/alfresco-build-tools
     rev: v1.22.0
     hooks:
-      - id: helm-deps
       - id: helm-lint
   - repo: https://github.com/bridgecrewio/checkov.git
     rev: 2.2.139

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,8 +20,9 @@ repos:
     hooks:
       - id: helm-docs
   - repo: https://github.com/Alfresco/alfresco-build-tools
-    rev: v1.22.0
+    rev: OPSEXP-2152-helm-build
     hooks:
+      - id: helm-deps-build
       - id: helm-lint
   - repo: https://github.com/bridgecrewio/checkov.git
     rev: 2.2.139

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,12 +20,12 @@ repos:
     hooks:
       - id: helm-docs
   - repo: https://github.com/Alfresco/alfresco-build-tools
-    rev: a45da534b25b0d6f5dc7da49e2149edfe9b29ac8
+    rev: v2.1.0
     hooks:
       - id: helm-deps-build
       - id: helm-lint
   - repo: https://github.com/bridgecrewio/checkov.git
-    rev: 2.2.139
+    rev: 2.3.288
     hooks:
       - id: checkov
         files: \.yaml$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
     hooks:
       - id: helm-docs
   - repo: https://github.com/Alfresco/alfresco-build-tools
-    rev: OPSEXP-2152-helm-build
+    rev: a45da534b25b0d6f5dc7da49e2149edfe9b29ac8
     hooks:
       - id: helm-deps-build
       - id: helm-lint

--- a/helm/alfresco-content-services/Chart.lock
+++ b/helm/alfresco-content-services/Chart.lock
@@ -1,0 +1,27 @@
+dependencies:
+- name: alfresco-common
+  repository: https://alfresco.github.io/alfresco-helm-charts/
+  version: 2.0.0
+- name: postgresql
+  repository: oci://registry-1.docker.io/bitnamicharts
+  version: 12.5.6
+- name: common
+  repository: https://activiti.github.io/activiti-cloud-helm-charts
+  version: 7.7.0
+- name: common
+  repository: https://activiti.github.io/activiti-cloud-helm-charts
+  version: 7.7.0
+- name: activemq
+  repository: https://alfresco.github.io/alfresco-helm-charts/
+  version: 3.1.0
+- name: alfresco-search-service
+  repository: https://alfresco.github.io/alfresco-helm-charts/
+  version: 1.1.0
+- name: alfresco-sync-service
+  repository: https://alfresco.github.io/alfresco-helm-charts/
+  version: 4.1.0
+- name: alfresco-search-enterprise
+  repository: https://alfresco.github.io/alfresco-helm-charts/
+  version: 1.2.0
+digest: sha256:1ec10d4d7b976fafd8343257e11c01d5b6ddde9acc0c3be5cea7d277b9690557
+generated: "2023-06-13T09:31:13.012866+02:00"

--- a/helm/alfresco-content-services/Chart.yaml
+++ b/helm/alfresco-content-services/Chart.yaml
@@ -21,7 +21,7 @@ dependencies:
     version: 2.0.0
     repository: https://alfresco.github.io/alfresco-helm-charts/
   - name: postgresql
-    version: 12.x.x
+    version: 12.5.6
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: postgresql.enabled
   - name: common

--- a/helm/alfresco-content-services/README.md
+++ b/helm/alfresco-content-services/README.md
@@ -23,7 +23,7 @@ Please refer to the [documentation](https://github.com/Alfresco/acs-deployment/b
 | https://alfresco.github.io/alfresco-helm-charts/ | alfresco-search-enterprise | 1.2.0 |
 | https://alfresco.github.io/alfresco-helm-charts/ | alfresco-search(alfresco-search-service) | 1.1.0 |
 | https://alfresco.github.io/alfresco-helm-charts/ | alfresco-sync-service | 4.1.0 |
-| oci://registry-1.docker.io/bitnamicharts | postgresql | 12.x.x |
+| oci://registry-1.docker.io/bitnamicharts | postgresql | 12.5.6 |
 
 ## Values
 


### PR DESCRIPTION
* Make sure we don't pull newer/untested dependencies
* Fixup failure in the creation of the sync service postgresql pod

```
CreateContainerConfigError (secret "acs-postgresql-syncservice" not found)
```

Requires https://github.com/Alfresco/alfresco-build-tools/pull/273

Ref: OPSEXP-2152