### PR TITLE
OPSEXP-2174 Fixup search enterprise tags for Andromeda release

### DIFF
--- a/helm/alfresco-content-services/README.md
+++ b/helm/alfresco-content-services/README.md
@@ -104,8 +104,13 @@ Please refer to the [documentation](https://github.com/Alfresco/acs-deployment/b
 | alfresco-digital-workspace.service.envType | string | `"frontend"` |  |
 | alfresco-search-enterprise.elasticsearch.enabled | bool | `true` | Enables the embedded elasticsearch cluster |
 | alfresco-search-enterprise.enabled | bool | `false` |  |
+| alfresco-search-enterprise.liveIndexing.content.image.tag | string | `"3.4.0-M1"` |  |
+| alfresco-search-enterprise.liveIndexing.mediation.image.tag | string | `"3.4.0-M1"` |  |
+| alfresco-search-enterprise.liveIndexing.metadata.image.tag | string | `"3.4.0-M1"` |  |
+| alfresco-search-enterprise.liveIndexing.path.image.tag | string | `"3.4.0-M1"` |  |
 | alfresco-search-enterprise.messageBroker.existingSecretName | string | `"acs-alfresco-cs-brokersecret"` |  |
 | alfresco-search-enterprise.reindexing.enabled | bool | `true` |  |
+| alfresco-search-enterprise.reindexing.image.tag | string | `"3.4.0-M1"` |  |
 | alfresco-search-enterprise.reindexing.postgresql.database | string | `"alfresco"` |  |
 | alfresco-search-enterprise.reindexing.postgresql.existingSecretName | string | `"acs-alfresco-cs-dbsecret"` |  |
 | alfresco-search-enterprise.reindexing.postgresql.hostname | string | `"postgresql-acs"` |  |

--- a/helm/alfresco-content-services/values.yaml
+++ b/helm/alfresco-content-services/values.yaml
@@ -670,6 +670,19 @@ alfresco-search-enterprise:
     enabled: true
   messageBroker:
     existingSecretName: *acs_messageBroker_secretName
+  liveIndexing:
+    mediation:
+      image:
+        tag: 3.4.0-M1
+    content:
+      image:
+        tag: 3.4.0-M1
+    metadata:
+      image:
+        tag: 3.4.0-M1
+    path:
+      image:
+        tag: 3.4.0-M1
   reindexing:
     enabled: true
     postgresql:
@@ -677,6 +690,8 @@ alfresco-search-enterprise:
       hostname: postgresql-acs
       database: alfresco
       existingSecretName: *acs_database_secretName
+    image:
+      tag: 3.4.0-M1
 alfresco-digital-workspace:
   nodeSelector: {}
   enabled: true


### PR DESCRIPTION
The https://github.com/Alfresco/acs-deployment/pull/959 got merged without the latest changes introduced at a later stage in https://github.com/Alfresco/acs-deployment/pull/958

This PR reflect those missing changes.

Ref: OPSEXP-2174