### PR TITLE
OPSEXP-1908 Enable appVersion bump from uber manifest

### DIFF
--- a/.github/workflows/bumpVersions.yml
+++ b/.github/workflows/bumpVersions.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: alfresco/alfresco-updatecli
-          ref: master
+          ref: OPSEXP-1908-appVersion
           path: alfresco-updatecli
 
       - name: Preprocess values file appending existing keys only

--- a/updatecli-matrix-targets.yaml
+++ b/updatecli-matrix-targets.yaml
@@ -14,6 +14,7 @@ matrix:
       helm_target: &helmvalues231 >-
         helm/alfresco-content-services/values.yaml
       helm_key: $.repository.image.tag
+      helm_update_appVersion: true
     share:
       version:
       pattern:


### PR DESCRIPTION
Ref: OPSEXP-1908

Requires https://github.com/Alfresco/alfresco-updatecli/pull/8