### PR TITLE
OPSEXP-2311 Provide an input to trigger alternative updatecli ref

### DIFF
--- a/.github/workflows/bumpVersions.yml
+++ b/.github/workflows/bumpVersions.yml
@@ -9,6 +9,11 @@ on:
     tags-ignore:
       - '**'
   workflow_dispatch:
+    inputs:
+      alfresco-updatecli-ref:
+        description: "The version to use for alfresco/alfresco-updatecli configs"
+        type: string
+        default: master
 
 jobs:
   updatecli:
@@ -28,7 +33,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: alfresco/alfresco-updatecli
-          ref: master
+          ref: ${{ inputs.alfresco-updatecli-ref || 'master' }}
           path: alfresco-updatecli
 
       - name: Preprocess values file appending existing keys only


### PR DESCRIPTION
Ref: OPSEXP-2311

Just to run more easily the workflow against a custom alfresco-updatecli branch