### PR TITLE
OPSEXP-2242: bump alfresco-repository chart to 0.1.0-alpha.16

### DIFF
--- a/helm/alfresco-content-services/Chart.lock
+++ b/helm/alfresco-content-services/Chart.lock
@@ -13,7 +13,7 @@ dependencies:
   version: 7.11.0
 - name: alfresco-repository
   repository: https://alfresco.github.io/alfresco-helm-charts/
-  version: 0.1.0-alpha.15
+  version: 0.1.0-alpha.16
 - name: activemq
   repository: https://alfresco.github.io/alfresco-helm-charts/
   version: 3.3.0
@@ -41,5 +41,5 @@ dependencies:
 - name: alfresco-ai-transformer
   repository: https://alfresco.github.io/alfresco-helm-charts/
   version: 0.3.0
-digest: sha256:d361ff51b5be3b3f0f8a08c145c35f08ec803aab4c72eca1107c652080086904
-generated: "2023-10-05T12:21:11.226953+02:00"
+digest: sha256:b519cf8c975072c45e3284114a149b50187459deedde12828b9063842022a4a2
+generated: "2023-10-09T16:32:36.159974+02:00"

--- a/helm/alfresco-content-services/Chart.yaml
+++ b/helm/alfresco-content-services/Chart.yaml
@@ -36,7 +36,7 @@ dependencies:
     condition: >-
       alfresco-digital-workspace.enabled
   - name: alfresco-repository
-    version: 0.1.0-alpha.15
+    version: 0.1.0-alpha.16
     repository: https://alfresco.github.io/alfresco-helm-charts/
   - name: activemq
     version: 3.3.0

--- a/helm/alfresco-content-services/README.md
+++ b/helm/alfresco-content-services/README.md
@@ -23,7 +23,7 @@ Please refer to the [documentation](https://github.com/Alfresco/acs-deployment/b
 | https://alfresco.github.io/alfresco-helm-charts/ | alfresco-common | 3.0.0-alpha.2 |
 | https://alfresco.github.io/alfresco-helm-charts/ | alfresco-connector-ms365 | 0.4.0 |
 | https://alfresco.github.io/alfresco-helm-charts/ | alfresco-connector-msteams | 0.2.0 |
-| https://alfresco.github.io/alfresco-helm-charts/ | alfresco-repository | 0.1.0-alpha.15 |
+| https://alfresco.github.io/alfresco-helm-charts/ | alfresco-repository | 0.1.0-alpha.16 |
 | https://alfresco.github.io/alfresco-helm-charts/ | alfresco-search-enterprise | 3.0.0-alpha.1 |
 | https://alfresco.github.io/alfresco-helm-charts/ | alfresco-search(alfresco-search-service) | 2.0.0-alpha.2 |
 | https://alfresco.github.io/alfresco-helm-charts/ | share(alfresco-share) | 0.1.1 |


### PR DESCRIPTION
Ref: OPSEXP-2242

bring back env projection support in alfresco-repository