### PR TITLE
OPSEXP-2387 Ensure latest activemq image is used in docker compose

### DIFF
--- a/docker-compose/7.0.N-docker-compose.yml
+++ b/docker-compose/7.0.N-docker-compose.yml
@@ -137,7 +137,7 @@ services:
     ports:
       - "8083:8983" # Browser port
   activemq:
-    image: alfresco/alfresco-activemq:5.16.4-jre11-centos7
+    image: alfresco/alfresco-activemq:5.16-jre17-rockylinux8
     mem_limit: 1g
     ports:
       - "8161:8161" # Web Console

--- a/docker-compose/7.1.N-docker-compose.yml
+++ b/docker-compose/7.1.N-docker-compose.yml
@@ -137,7 +137,7 @@ services:
     ports:
       - "8083:8983" # Browser port
   activemq:
-    image: alfresco/alfresco-activemq:5.16.4-jre11-centos7
+    image: alfresco/alfresco-activemq:5.16-jre17-rockylinux8
     mem_limit: 1g
     ports:
       - "8161:8161" # Web Console

--- a/docker-compose/7.2.N-docker-compose.yml
+++ b/docker-compose/7.2.N-docker-compose.yml
@@ -141,7 +141,7 @@ services:
     ports:
       - "8083:8983" # Browser port
   activemq:
-    image: alfresco/alfresco-activemq:5.17.1-jre11-rockylinux8
+    image: alfresco/alfresco-activemq:5.17-jre17-rockylinux8
     mem_limit: 1g
     ports:
       - "8161:8161" # Web Console

--- a/docker-compose/7.3.N-docker-compose.yml
+++ b/docker-compose/7.3.N-docker-compose.yml
@@ -141,7 +141,7 @@ services:
     ports:
       - "8083:8983" # Browser port
   activemq:
-    image: alfresco/alfresco-activemq:5.17.1-jre11-rockylinux8
+    image: alfresco/alfresco-activemq:5.17-jre17-rockylinux8
     mem_limit: 1g
     ports:
       - "8161:8161" # Web Console

--- a/docker-compose/7.4.N-docker-compose.yml
+++ b/docker-compose/7.4.N-docker-compose.yml
@@ -141,7 +141,7 @@ services:
     ports:
       - "8083:8983" # Browser port
   activemq:
-    image: alfresco/alfresco-activemq:5.17.1-jre11-rockylinux8
+    image: alfresco/alfresco-activemq:5.17-jre17-rockylinux8
     mem_limit: 1g
     ports:
       - "8161:8161" # Web Console

--- a/docker-compose/community-docker-compose.yml
+++ b/docker-compose/community-docker-compose.yml
@@ -99,7 +99,7 @@ services:
     ports:
       - "8083:8983" # Browser port
   activemq:
-    image: alfresco/alfresco-activemq:5.17.1-jre11-rockylinux8
+    image: alfresco/alfresco-activemq:5.18-jre17-rockylinux8
     mem_limit: 1g
     ports:
       - "8161:8161" # Web Console

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -141,7 +141,7 @@ services:
     ports:
       - "8083:8983" # Browser port
   activemq:
-    image: alfresco/alfresco-activemq:5.17.1-jre11-rockylinux8
+    image: alfresco/alfresco-activemq:5.18-jre17-rockylinux8
     mem_limit: 1g
     ports:
       - "8161:8161" # Web Console


### PR DESCRIPTION
Ref: OPSEXP-2387

This also fixes CVE-2023-46604 in docker compose