### PR TITLE
OPSEXP-2435 Bump alfresco-repository chart to v0.1.2

### DIFF
--- a/helm/alfresco-content-services/Chart.lock
+++ b/helm/alfresco-content-services/Chart.lock
@@ -13,7 +13,7 @@ dependencies:
   version: 8.0.0
 - name: alfresco-repository
   repository: https://alfresco.github.io/alfresco-helm-charts/
-  version: 0.1.1
+  version: 0.1.2
 - name: activemq
   repository: https://alfresco.github.io/alfresco-helm-charts/
   version: 3.4.1
@@ -44,5 +44,5 @@ dependencies:
 - name: elasticsearch
   repository: https://helm.elastic.co
   version: 7.17.3
-digest: sha256:f786ff94fa8670c9fcf8f006fbbd0cd14bf8340020caf2fecbc8be6a73173619
-generated: "2023-11-21T09:21:32.33669806Z"
+digest: sha256:b47b523674209148ee20431d5bbde89254710e2ec55f8e126d5c3496fefefef9
+generated: "2023-12-19T10:27:41.284281+01:00"

--- a/helm/alfresco-content-services/Chart.yaml
+++ b/helm/alfresco-content-services/Chart.yaml
@@ -36,7 +36,7 @@ dependencies:
     condition: >-
       alfresco-digital-workspace.enabled
   - name: alfresco-repository
-    version: 0.1.1
+    version: 0.1.2
     repository: https://alfresco.github.io/alfresco-helm-charts/
   - name: activemq
     version: 3.4.1

--- a/helm/alfresco-content-services/README.md
+++ b/helm/alfresco-content-services/README.md
@@ -23,7 +23,7 @@ Please refer to the [documentation](https://github.com/Alfresco/acs-deployment/b
 | https://alfresco.github.io/alfresco-helm-charts/ | alfresco-common | 3.0.0 |
 | https://alfresco.github.io/alfresco-helm-charts/ | alfresco-connector-ms365 | 0.4.0 |
 | https://alfresco.github.io/alfresco-helm-charts/ | alfresco-connector-msteams | 0.2.0 |
-| https://alfresco.github.io/alfresco-helm-charts/ | alfresco-repository | 0.1.1 |
+| https://alfresco.github.io/alfresco-helm-charts/ | alfresco-repository | 0.1.2 |
 | https://alfresco.github.io/alfresco-helm-charts/ | alfresco-search-enterprise | 3.0.2 |
 | https://alfresco.github.io/alfresco-helm-charts/ | alfresco-search(alfresco-search-service) | 2.0.0 |
 | https://alfresco.github.io/alfresco-helm-charts/ | share(alfresco-share) | 0.2.1 |

--- a/helm/alfresco-content-services/README.md
+++ b/helm/alfresco-content-services/README.md
@@ -52,7 +52,7 @@ Please refer to the [documentation](https://github.com/Alfresco/acs-deployment/b
 | alfresco-connector-ms365.image.tag | string | `"2.0.0"` |  |
 | alfresco-connector-ms365.repository.existingConfigMap.keys.host | string | `"repo_svc_name"` | Name of the key in the configmap which points to the repository service hostname |
 | alfresco-connector-ms365.repository.existingConfigMap.keys.port | string | `"repo_svc_port"` | Name of the key in the configmap which points to the repository service port |
-| alfresco-connector-ms365.repository.existingConfigMap.name | string | `"alfresco-infrastructure"` | Name of the configmap which hold the repositoy connection details |
+| alfresco-connector-ms365.repository.existingConfigMap.name | string | `"alfresco-infrastructure"` | Name of the configmap which hold the repository connection details |
 | alfresco-connector-msteams.enabled | bool | `false` | Enable/Disable Alfresco Content Connector for Microsoft Teams |
 | alfresco-connector-msteams.image.repository | string | `"quay.io/alfresco/alfresco-ms-teams-service"` |  |
 | alfresco-connector-msteams.image.tag | string | `"2.0.0"` |  |
@@ -143,7 +143,7 @@ Please refer to the [documentation](https://github.com/Alfresco/acs-deployment/b
 | alfresco-search.enabled | bool | `true` |  |
 | alfresco-search.external.host | string | `nil` | Host dns/ip of the external solr6 instance. |
 | alfresco-search.external.port | string | `nil` | Port of the external solr6 instance. |
-| alfresco-search.ingress.basicAuth | string | `nil` | Default solr basic auth user/password: admin / admin You can create your own with htpasswd utilility & encode it with base64. Example: `echo -n "$(htpasswd -nbm admin admin)" | base64 | tr -d '\n'` basicAuth: YWRtaW46JGFwcjEkVVJqb29uS00kSEMuS1EwVkRScFpwSHB2a3JwTDd1Lg== |
+| alfresco-search.ingress.basicAuth | string | `nil` | Default solr basic auth user/password: admin / admin You can create your own with htpasswd utility & encode it with base64. Example: `echo -n "$(htpasswd -nbm admin admin)" | base64 | tr -d '\n'` basicAuth: YWRtaW46JGFwcjEkVVJqb29uS00kSEMuS1EwVkRScFpwSHB2a3JwTDd1Lg== |
 | alfresco-search.ingress.enabled | bool | `false` | Alfresco Search services endpoint ('/solr') |
 | alfresco-search.ingress.tls | list | `[]` |  |
 | alfresco-search.insightEngineImage.repository | string | `"quay.io/alfresco/insight-engine"` |  |
@@ -218,7 +218,7 @@ Please refer to the [documentation](https://github.com/Alfresco/acs-deployment/b
 | global.mail.host | string | `nil` | SMTP server to use for the system to send outgoing email |
 | global.mail.port | int | `587` | SMTP server port |
 | global.mail.protocol | string | `"smtp"` | SMTP protocol to use. Either smtp or smtps |
-| global.search.flavor | string | `nil` | set the type of search service used externally (solr6 of elasticsearch) |
+| global.search.flavor | string | `nil` | set the type of search service used externally (solr6 or elasticsearch) |
 | global.search.secretName | string | `"alfresco-search-secret"` | Name of the secret managed by this chart |
 | global.search.securecomms | string | `"secret"` | set the security level used with the external search service (secret, none or https) |
 | global.search.sharedSecret | string | `nil` | Mandatory secret to provide when using Solr search with 'secret' security level |
@@ -226,7 +226,7 @@ Please refer to the [documentation](https://github.com/Alfresco/acs-deployment/b
 | global.strategy.rollingUpdate.maxSurge | int | `1` |  |
 | global.strategy.rollingUpdate.maxUnavailable | int | `0` |  |
 | infrastructure.configMapName | string | `"alfresco-infrastructure"` |  |
-| messageBroker | object | `{"password":null,"secretName":"acs-alfresco-cs-brokersecret","url":null,"user":null}` | Activemq connection details (activemq.enabled msut also be set to false) |
+| messageBroker | object | `{"password":null,"secretName":"acs-alfresco-cs-brokersecret","url":null,"user":null}` | Activemq connection details (activemq.enabled must also be set to false) |
 | messageBroker.secretName | string | `"acs-alfresco-cs-brokersecret"` | Name of the secret managed by this chart |
 | postgresql.auth.database | string | `"alfresco"` |  |
 | postgresql.auth.existingSecret | string | `nil` |  |
@@ -238,7 +238,7 @@ Please refer to the [documentation](https://github.com/Alfresco/acs-deployment/b
 | postgresql.image.tag | string | `"14.4.0"` |  |
 | postgresql.nameOverride | string | `"postgresql-acs"` |  |
 | postgresql.primary.extendedConfiguration | string | `"max_connections = 250\nshared_buffers = 512MB\neffective_cache_size = 2GB\nwal_level = minimal\nmax_wal_senders = 0\nmax_replication_slots = 0\nlog_min_messages = LOG\n"` |  |
-| postgresql.primary.persistence.existingClaim | string | `nil` | provide an existing persistent volume claim name to persist SQL data Make sure the root folder has the appropriate permissions/ownhership set. |
+| postgresql.primary.persistence.existingClaim | string | `nil` | provide an existing persistent volume claim name to persist SQL data Make sure the root folder has the appropriate permissions/ownership set. |
 | postgresql.primary.persistence.storageClass | string | `nil` | set the storageClass to use for dynamic provisioning. setting it to null means "default storageClass". |
 | postgresql.primary.persistence.subPath | string | `"alfresco-content-services/database-data"` |  |
 | postgresql.primary.resources.limits.cpu | string | `"8"` |  |
@@ -251,7 +251,7 @@ Please refer to the [documentation](https://github.com/Alfresco/acs-deployment/b
 | share.nameOverride | string | `"share"` |  |
 | share.repository.existingConfigMap.keys.host | string | `"repo_svc_name"` | Name of the key in the configmap which points to the repository service hostname |
 | share.repository.existingConfigMap.keys.port | string | `"repo_svc_port"` | Name of the key in the configmap which points to the repository service port |
-| share.repository.existingConfigMap.name | string | `"alfresco-infrastructure"` | Name of the configmap which hold the repositoy connection details |
+| share.repository.existingConfigMap.name | string | `"alfresco-infrastructure"` | Name of the configmap which hold the repository connection details |
 
 Alfresco Content Service will be deployed in a Kubernetes cluster. This cluster
 needs a at least 32GB memory to split among below pods:

--- a/helm/alfresco-content-services/values.yaml
+++ b/helm/alfresco-content-services/values.yaml
@@ -43,7 +43,7 @@ global:
   search:
     # -- set this URL if you have an external search service
     url: null
-    # -- set the type of search service used externally (solr6 of elasticsearch)
+    # -- set the type of search service used externally (solr6 or elasticsearch)
     flavor: null
     # -- set the security level used with the external search service (secret, none or https)
     securecomms: secret
@@ -80,7 +80,7 @@ database:
   # -- An existing secret that contains DATABASE_USERNAME and DATABASE_PASSWORD keys.
   # When using embedded postgres you need to also set `postgresql.existingSecret`.
   existingSecretName: null
-# -- Activemq connection details (activemq.enabled msut also be set to false)
+# -- Activemq connection details (activemq.enabled must also be set to false)
 messageBroker:
   url: null
   user: null
@@ -149,7 +149,7 @@ alfresco-connector-ms365:
     tag: 2.0.0
   repository:
     existingConfigMap:
-      # -- Name of the configmap which hold the repositoy connection details
+      # -- Name of the configmap which hold the repository connection details
       name: *infrastructure_cmName
       keys:
         # -- Name of the key in the configmap which points to the repository
@@ -234,7 +234,7 @@ share:
   nameOverride: share
   repository:
     existingConfigMap:
-      # -- Name of the configmap which hold the repositoy connection details
+      # -- Name of the configmap which hold the repository connection details
       name: *infrastructure_cmName
       keys:
         # -- Name of the key in the configmap which points to the repository
@@ -276,7 +276,7 @@ alfresco-search:
     # -- Alfresco Search services endpoint ('/solr')
     enabled: false
     # -- Default solr basic auth user/password: admin / admin
-    # You can create your own with htpasswd utilility & encode it with base64.
+    # You can create your own with htpasswd utility & encode it with base64.
     # Example: `echo -n "$(htpasswd -nbm admin admin)" | base64 | tr -d '\n'`
     # basicAuth: YWRtaW46JGFwcjEkVVJqb29uS00kSEMuS1EwVkRScFpwSHB2a3JwTDd1Lg==
     basicAuth: null
@@ -442,7 +442,7 @@ postgresql:
       # setting it to null means "default storageClass".
       storageClass: null
       # -- provide an existing persistent volume claim name to persist SQL data
-      # Make sure the root folder has the appropriate permissions/ownhership set.
+      # Make sure the root folder has the appropriate permissions/ownership set.
       existingClaim: null
       subPath: "alfresco-content-services/database-data"
 alfresco-sync-service:


### PR DESCRIPTION
Ref: OPSEXP-2435

https://github.com/Alfresco/alfresco-helm-charts/releases/tag/alfresco-repository-0.1.2