### PR TITLE
OPSEXP-2422 Bump intelligence for ACS 7.1 to fix CVE-2023-46604

### DIFF
--- a/helm/alfresco-content-services/7.1.N_values.yaml
+++ b/helm/alfresco-content-services/7.1.N_values.yaml
@@ -5,7 +5,7 @@ alfresco-repository:
     tag: 7.1.1.10
 alfresco-ai-transformer:
   image:
-    tag: 1.4.5
+    tag: 1.5.1
 alfresco-transform-service:
   transformrouter:
     image:


### PR DESCRIPTION
Ref: OPSEXP-2422