### PR TITLE
OPSEXP-2445 Fix flaky docker compose enterprise tests

### DIFF
--- a/.github/workflows/bumpVersions.yml
+++ b/.github/workflows/bumpVersions.yml
@@ -52,9 +52,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-helm-docs@v5.12.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-helm-docs@v5.13.0
       - name: Regenerate helm docs if necessary
-        uses: Alfresco/alfresco-build-tools/.github/actions/pre-commit@v5.12.0
+        uses: Alfresco/alfresco-build-tools/.github/actions/pre-commit@v5.13.0
         with:
           pre-commit-args: helm-docs || true
           skip_checkout: "true"
@@ -107,9 +107,9 @@ jobs:
           QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
           UPDATECLI_GITHUB_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
 
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-helm-docs@v5.12.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-helm-docs@v5.13.0
       - name: Regenerate helm docs if necessary
-        uses: Alfresco/alfresco-build-tools/.github/actions/pre-commit@v5.12.0
+        uses: Alfresco/alfresco-build-tools/.github/actions/pre-commit@v5.13.0
         with:
           pre-commit-args: helm-docs || true
           skip_checkout: "true"

--- a/.github/workflows/docker-compose-community.yml
+++ b/.github/workflows/docker-compose-community.yml
@@ -22,6 +22,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: >-
-          Alfresco/alfresco-build-tools/.github/actions/dbp-charts/verify-compose@v5.12.0
+          Alfresco/alfresco-build-tools/.github/actions/dbp-charts/verify-compose@v5.13.0
         with:
           compose_file_path: docker-compose/community-docker-compose.yml

--- a/.github/workflows/docker-compose-enterprise.yml
+++ b/.github/workflows/docker-compose-enterprise.yml
@@ -56,7 +56,7 @@ jobs:
           quay_username: ${{ secrets.QUAY_USERNAME }}
           quay_password: ${{ secrets.QUAY_PASSWORD }}
       - name: Debug alfresco on failure
-        if: failure() || cancelled()
+        if: always()
         working-directory: docker-compose
         run: |
           docker-compose -f ${{ matrix.compose_file }} logs alfresco

--- a/.github/workflows/docker-compose-enterprise.yml
+++ b/.github/workflows/docker-compose-enterprise.yml
@@ -56,7 +56,7 @@ jobs:
           quay_username: ${{ secrets.QUAY_USERNAME }}
           quay_password: ${{ secrets.QUAY_PASSWORD }}
       - name: Debug alfresco on failure
-        #if: failure() || cancelled()
+        if: failure() || cancelled()
         working-directory: docker-compose
         run: |
           docker-compose -f ${{ matrix.compose_file }} logs alfresco

--- a/.github/workflows/docker-compose-enterprise.yml
+++ b/.github/workflows/docker-compose-enterprise.yml
@@ -54,7 +54,7 @@ jobs:
     steps:
       - uses: >-
           Alfresco/alfresco-build-tools/.github/actions/dbp-charts/verify-compose@v5.12.0
-        timeout-minutes: 5
+        timeout-minutes: 10
         with:
           compose_file_path: docker-compose/${{ matrix.compose_file }}
           quay_username: ${{ secrets.QUAY_USERNAME }}

--- a/.github/workflows/docker-compose-enterprise.yml
+++ b/.github/workflows/docker-compose-enterprise.yml
@@ -52,7 +52,8 @@ jobs:
         && github.event.pull_request.head.user.login == 'Alfresco'
       )
     steps:
-      - uses: >-
+      - name: Verify docker-compose
+        uses: >-
           Alfresco/alfresco-build-tools/.github/actions/dbp-charts/verify-compose@debug-verify-compose
         timeout-minutes: 10
         with:

--- a/.github/workflows/docker-compose-enterprise.yml
+++ b/.github/workflows/docker-compose-enterprise.yml
@@ -55,3 +55,7 @@ jobs:
           compose_file_path: docker-compose/${{ matrix.compose_file }}
           quay_username: ${{ secrets.QUAY_USERNAME }}
           quay_password: ${{ secrets.QUAY_PASSWORD }}
+      - name: Debug alfresco on failure
+        if: failure() || cancelled()
+        run: |
+          docker-compose logs alfresco

--- a/.github/workflows/docker-compose-enterprise.yml
+++ b/.github/workflows/docker-compose-enterprise.yml
@@ -41,7 +41,6 @@ jobs:
       fail-fast: true
       matrix: ${{ fromJSON(needs.build_vars.outputs.matrix_json) }}
     runs-on: ubuntu-latest
-    timeout-minutes: 5
     if: >-
       github.event_name == 'push'
       || (
@@ -51,6 +50,7 @@ jobs:
     steps:
       - uses: >-
           Alfresco/alfresco-build-tools/.github/actions/dbp-charts/verify-compose@v5.12.0
+        timeout-minutes: 5
         with:
           compose_file_path: docker-compose/${{ matrix.compose_file }}
           quay_username: ${{ secrets.QUAY_USERNAME }}

--- a/.github/workflows/docker-compose-enterprise.yml
+++ b/.github/workflows/docker-compose-enterprise.yml
@@ -54,7 +54,7 @@ jobs:
     steps:
       - name: Verify docker-compose
         uses: >-
-          Alfresco/alfresco-build-tools/.github/actions/dbp-charts/verify-compose@debug-verify-compose
+          Alfresco/alfresco-build-tools/.github/actions/dbp-charts/verify-compose@v5.13.0
         timeout-minutes: 10
         with:
           compose_file_path: docker-compose/${{ matrix.compose_file }}

--- a/.github/workflows/docker-compose-enterprise.yml
+++ b/.github/workflows/docker-compose-enterprise.yml
@@ -41,6 +41,7 @@ jobs:
       fail-fast: true
       matrix: ${{ fromJSON(needs.build_vars.outputs.matrix_json) }}
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     if: >-
       github.event_name == 'push'
       || (

--- a/.github/workflows/docker-compose-enterprise.yml
+++ b/.github/workflows/docker-compose-enterprise.yml
@@ -60,6 +60,12 @@ jobs:
           quay_username: ${{ secrets.QUAY_USERNAME }}
           quay_password: ${{ secrets.QUAY_PASSWORD }}
 
+      - name: Show docker ps
+        if: always()
+        working-directory: docker-compose
+        run: |
+          docker-compose -f ${{ matrix.compose_file }} ps
+
       - name: Show alfresco logs
         if: always()
         working-directory: docker-compose

--- a/.github/workflows/docker-compose-enterprise.yml
+++ b/.github/workflows/docker-compose-enterprise.yml
@@ -59,9 +59,15 @@ jobs:
           compose_file_path: docker-compose/${{ matrix.compose_file }}
           quay_username: ${{ secrets.QUAY_USERNAME }}
           quay_password: ${{ secrets.QUAY_PASSWORD }}
-      - name: Debug alfresco on failure
+
+      - name: Show alfresco logs
         if: always()
         working-directory: docker-compose
         run: |
           docker-compose -f ${{ matrix.compose_file }} logs alfresco
+
+      - name: Show solr logs
+        if: always()
+        working-directory: docker-compose
+        run: |
           docker-compose -f ${{ matrix.compose_file }} logs solr6

--- a/.github/workflows/docker-compose-enterprise.yml
+++ b/.github/workflows/docker-compose-enterprise.yml
@@ -56,6 +56,7 @@ jobs:
           quay_username: ${{ secrets.QUAY_USERNAME }}
           quay_password: ${{ secrets.QUAY_PASSWORD }}
       - name: Debug alfresco on failure
-        if: failure() || cancelled()
+        #if: failure() || cancelled()
+        working-directory: docker-compose
         run: |
-          docker-compose logs alfresco
+          docker-compose -f ${{ matrix.compose_file }} logs alfresco

--- a/.github/workflows/docker-compose-enterprise.yml
+++ b/.github/workflows/docker-compose-enterprise.yml
@@ -60,21 +60,3 @@ jobs:
           compose_file_path: docker-compose/${{ matrix.compose_file }}
           quay_username: ${{ secrets.QUAY_USERNAME }}
           quay_password: ${{ secrets.QUAY_PASSWORD }}
-
-      - name: Show docker ps
-        if: always()
-        working-directory: docker-compose
-        run: |
-          docker-compose -f ${{ matrix.compose_file }} ps
-
-      - name: Show alfresco logs
-        if: always()
-        working-directory: docker-compose
-        run: |
-          docker-compose -f ${{ matrix.compose_file }} logs alfresco
-
-      - name: Show solr logs
-        if: always()
-        working-directory: docker-compose
-        run: |
-          docker-compose -f ${{ matrix.compose_file }} logs solr6

--- a/.github/workflows/docker-compose-enterprise.yml
+++ b/.github/workflows/docker-compose-enterprise.yml
@@ -60,3 +60,4 @@ jobs:
         working-directory: docker-compose
         run: |
           docker-compose -f ${{ matrix.compose_file }} logs alfresco
+          docker-compose -f ${{ matrix.compose_file }} logs solr6

--- a/.github/workflows/docker-compose-enterprise.yml
+++ b/.github/workflows/docker-compose-enterprise.yml
@@ -17,6 +17,10 @@ on:
       - master
       - release/**
 
+concurrency:
+  group: compose-ent-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
   build_vars:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker-compose-enterprise.yml
+++ b/.github/workflows/docker-compose-enterprise.yml
@@ -53,7 +53,7 @@ jobs:
       )
     steps:
       - uses: >-
-          Alfresco/alfresco-build-tools/.github/actions/dbp-charts/verify-compose@v5.12.0
+          Alfresco/alfresco-build-tools/.github/actions/dbp-charts/verify-compose@debug-verify-compose
         timeout-minutes: 10
         with:
           compose_file_path: docker-compose/${{ matrix.compose_file }}

--- a/.github/workflows/helm-community.yml
+++ b/.github/workflows/helm-community.yml
@@ -37,7 +37,7 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Setup cluster
-        uses: Alfresco/alfresco-build-tools/.github/actions/setup-kind@v5.12.0
+        uses: Alfresco/alfresco-build-tools/.github/actions/setup-kind@v5.13.0
         with:
           ingress-nginx-ref: controller-v1.8.2
 

--- a/.github/workflows/helm-enterprise.yml
+++ b/.github/workflows/helm-enterprise.yml
@@ -87,7 +87,7 @@ jobs:
           password: ${{ secrets.QUAY_PASSWORD }}
 
       - name: Setup cluster
-        uses: Alfresco/alfresco-build-tools/.github/actions/setup-kind@v5.12.0
+        uses: Alfresco/alfresco-build-tools/.github/actions/setup-kind@v5.13.0
         with:
           ingress-nginx-ref: controller-v1.8.2
 

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -45,7 +45,7 @@ jobs:
           ! grep -e "-alpha" -e "-SNAPSHOT" helm/${{ matrix.charts }}/Chart.yaml
       - name: Publish chart
         uses: >-
-          Alfresco/alfresco-build-tools/.github/actions/dbp-charts/publish-chart@v5.12.0
+          Alfresco/alfresco-build-tools/.github/actions/dbp-charts/publish-chart@v5.13.0
         with:
           chart_name: ${{ matrix.charts }}
           github_token: ${{ secrets.BOT_GITHUB_TOKEN }}

--- a/.github/workflows/helm-static-checks.yml
+++ b/.github/workflows/helm-static-checks.yml
@@ -39,11 +39,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - uses: >-
-          Alfresco/alfresco-build-tools/.github/actions/helm-build-chart@v5.12.0
+          Alfresco/alfresco-build-tools/.github/actions/helm-build-chart@v5.13.0
         with:
           chart-dir: helm/${{ matrix.charts.name }}
       - uses: >-
-          Alfresco/alfresco-build-tools/.github/actions/helm-plugin@v5.12.0
+          Alfresco/alfresco-build-tools/.github/actions/helm-plugin@v5.13.0
         with:
           plugin_url: https://github.com/helm-unittest/helm-unittest
       - run: |
@@ -58,11 +58,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - uses: >-
-          Alfresco/alfresco-build-tools/.github/actions/helm-build-chart@v5.12.0
+          Alfresco/alfresco-build-tools/.github/actions/helm-build-chart@v5.13.0
         with:
           chart-dir: helm/${{ matrix.charts.name }}
       - uses: >-
-          Alfresco/alfresco-build-tools/.github/actions/helm-template-yamllint@v5.12.0
+          Alfresco/alfresco-build-tools/.github/actions/helm-template-yamllint@v5.13.0
         with:
           chart-dir: helm/${{ matrix.charts.name }}
           helm-options: --values tests/values/test_values.yaml

--- a/.github/workflows/pre-commit-compose.yml
+++ b/.github/workflows/pre-commit-compose.yml
@@ -24,4 +24,4 @@ jobs:
     name: Run pre-commit
     runs-on: ubuntu-latest
     steps:
-      - uses: Alfresco/alfresco-build-tools/.github/actions/pre-commit@v5.12.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/pre-commit@v5.13.0

--- a/.github/workflows/pre-commit-helm.yml
+++ b/.github/workflows/pre-commit-helm.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-helm-docs@v5.12.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-helm-docs@v5.13.0
       - name: Add dependency chart repos
         run: |
           helm repo add alfresco-helm-charts https://alfresco.github.io/alfresco-helm-charts

--- a/docker-compose/7.0.N-docker-compose.yml
+++ b/docker-compose/7.0.N-docker-compose.yml
@@ -15,6 +15,9 @@
 #
 # Using version 2 as 3 does not support resource constraint options
 # (cpu_*, mem_* limits) for non swarm mode in Compose
+#
+# Java processes requires setting -XX:MaxRAM= due to cgroupv2 changes in recent Linux kernels
+# https://hub.alfresco.com/t5/alfresco-content-services-blog/acs-containers-and-cgroup-v2-in-acs-up-to-7-2/ba-p/318039
 version: "2"
 services:
   alfresco:
@@ -55,6 +58,7 @@ services:
         -Ddsync.service.uris=http://localhost:9090/alfresco
         -XX:MinRAMPercentage=50
         -XX:MaxRAMPercentage=80
+        -XX:MaxRAM=1700m
   transform-router:
     mem_limit: 512m
     image: quay.io/alfresco/alfresco-transform-router:1.4.1
@@ -62,6 +66,7 @@ services:
       JAVA_OPTS: >-
         -XX:MinRAMPercentage=50
         -XX:MaxRAMPercentage=80
+        -XX:MaxRAM=512m
       ACTIVEMQ_URL: nio://activemq:61616
       CORE_AIO_URL: http://transform-core-aio:8090
       FILE_STORE_URL: >-
@@ -77,6 +82,7 @@ services:
       JAVA_OPTS: >-
         -XX:MinRAMPercentage=50
         -XX:MaxRAMPercentage=80
+        -XX:MaxRAM=1536m
       ACTIVEMQ_URL: "nio://activemq:61616"
       FILE_STORE_URL: >-
         http://shared-file-store:8099/alfresco/api/-default-/private/sfs/versions/1/file
@@ -91,6 +97,7 @@ services:
       JAVA_OPTS: >-
         -XX:MinRAMPercentage=50
         -XX:MaxRAMPercentage=80
+        -XX:MaxRAM=512m
       scheduler.content.age.millis: 86400000
       scheduler.cleanup.interval: 86400000
     ports:
@@ -106,6 +113,7 @@ services:
       JAVA_OPTS: >-
         -XX:MinRAMPercentage=50
         -XX:MaxRAMPercentage=80
+        -XX:MaxRAM=1g
         -Dalfresco.host=localhost
         -Dalfresco.port=8080
         -Dalfresco.context=alfresco
@@ -177,6 +185,7 @@ services:
         -Ddw.server.applicationConnectors[0].type=http
         -XX:MinRAMPercentage=50
         -XX:MaxRAMPercentage=80
+        -XX:MaxRAM=1g
     ports:
       - "9090:9090"
 volumes:

--- a/docker-compose/7.1.N-docker-compose.yml
+++ b/docker-compose/7.1.N-docker-compose.yml
@@ -15,6 +15,9 @@
 #
 # Using version 2 as 3 does not support resource constraint options
 # (cpu_*, mem_* limits) for non swarm mode in Compose
+#
+# Java processes requires setting -XX:MaxRAM= due to cgroupv2 changes in recent Linux kernels
+# https://hub.alfresco.com/t5/alfresco-content-services-blog/acs-containers-and-cgroup-v2-in-acs-up-to-7-2/ba-p/318039
 version: "2"
 services:
   alfresco:
@@ -55,6 +58,7 @@ services:
         -Ddsync.service.uris=http://localhost:9090/alfresco
         -XX:MinRAMPercentage=50
         -XX:MaxRAMPercentage=80
+        -XX:MaxRAM=1900m
   transform-router:
     mem_limit: 512m
     image: quay.io/alfresco/alfresco-transform-router:2.1.1
@@ -62,6 +66,7 @@ services:
       JAVA_OPTS: >-
         -XX:MinRAMPercentage=50
         -XX:MaxRAMPercentage=80
+        -XX:MaxRAM=512m
       ACTIVEMQ_URL: nio://activemq:61616
       CORE_AIO_URL: http://transform-core-aio:8090
       FILE_STORE_URL: >-
@@ -77,6 +82,7 @@ services:
       JAVA_OPTS: >-
         -XX:MinRAMPercentage=50
         -XX:MaxRAMPercentage=80
+        -XX:MaxRAM=1536m
       ACTIVEMQ_URL: nio://activemq:61616
       FILE_STORE_URL: >-
         http://shared-file-store:8099/alfresco/api/-default-/private/sfs/versions/1/file
@@ -91,6 +97,7 @@ services:
       JAVA_OPTS: >-
         -XX:MinRAMPercentage=50
         -XX:MaxRAMPercentage=80
+        -XX:MaxRAM=512m
       scheduler.content.age.millis: 86400000
       scheduler.cleanup.interval: 86400000
     ports:
@@ -106,6 +113,7 @@ services:
       JAVA_OPTS: >-
         -XX:MinRAMPercentage=50
         -XX:MaxRAMPercentage=80
+        -XX:MaxRAM=1g
         -Dalfresco.host=localhost
         -Dalfresco.port=8080
         -Dalfresco.context=alfresco
@@ -178,6 +186,7 @@ services:
         -Ddw.server.applicationConnectors[0].type=http
         -XX:MinRAMPercentage=50
         -XX:MaxRAMPercentage=80
+        -XX:MaxRAM=1g
     ports:
       - "9090:9090"
 volumes:

--- a/docker-compose/7.2.N-docker-compose.yml
+++ b/docker-compose/7.2.N-docker-compose.yml
@@ -15,6 +15,9 @@
 #
 # Using version 2 as 3 does not support resource constraint options
 # (cpu_*, mem_* limits) for non swarm mode in Compose
+#
+# Java processes requires setting -XX:MaxRAM= due to cgroupv2 changes in recent Linux kernels
+# https://hub.alfresco.com/t5/alfresco-content-services-blog/acs-containers-and-cgroup-v2-in-acs-up-to-7-2/ba-p/318039
 version: "2"
 services:
   alfresco:
@@ -56,6 +59,7 @@ services:
         -Ddsync.service.uris=http://localhost:9090/alfresco
         -XX:MinRAMPercentage=50
         -XX:MaxRAMPercentage=80
+        -XX:MaxRAM=1900m
   transform-router:
     mem_limit: 512m
     image: quay.io/alfresco/alfresco-transform-router:2.1.1
@@ -63,6 +67,7 @@ services:
       JAVA_OPTS: >-
         -XX:MinRAMPercentage=50
         -XX:MaxRAMPercentage=80
+        -XX:MaxRAM=512m
       ACTIVEMQ_URL: nio://activemq:61616
       CORE_AIO_URL: http://transform-core-aio:8090
       FILE_STORE_URL: >-
@@ -78,6 +83,7 @@ services:
       JAVA_OPTS: >-
         -XX:MinRAMPercentage=50
         -XX:MaxRAMPercentage=80
+        -XX:MaxRAM=1536m
       ACTIVEMQ_URL: nio://activemq:61616
       FILE_STORE_URL: >-
         http://shared-file-store:8099/alfresco/api/-default-/private/sfs/versions/1/file
@@ -92,6 +98,7 @@ services:
       JAVA_OPTS: >-
         -XX:MinRAMPercentage=50
         -XX:MaxRAMPercentage=80
+        -XX:MaxRAM=512m
       scheduler.content.age.millis: 86400000
       scheduler.cleanup.interval: 86400000
     ports:
@@ -107,6 +114,7 @@ services:
       JAVA_OPTS: >-
         -XX:MinRAMPercentage=50
         -XX:MaxRAMPercentage=80
+        -XX:MaxRAM=1g
         -Dalfresco.host=localhost
         -Dalfresco.port=8080
         -Dalfresco.context=alfresco
@@ -191,6 +199,7 @@ services:
         -Ddw.server.applicationConnectors[0].type=http
         -XX:MinRAMPercentage=50
         -XX:MaxRAMPercentage=80
+        -XX:MaxRAM=1g
     ports:
       - "9090:9090"
 volumes:


### PR DESCRIPTION
* Add docker compose enterprise timeout and containers debug
* Add -XX:MaxRAM workaround [ACS containers and cgroup v2 in ACS up to 7.2](https://hub.alfresco.com/t5/alfresco-content-services-blog/acs-containers-and-cgroup-v2-in-acs-up-to-7-2/ba-p/318039)

Ref: OPSEXP-2445
Requires: https://github.com/Alfresco/alfresco-build-tools/pull/478