### PR TITLE
OPSEXP-2439 Document how to deploy with KinD

### DIFF
--- a/docs/helm/README.md
+++ b/docs/helm/README.md
@@ -63,7 +63,11 @@ the installation.
 
 ## Deploy
 
-For the best results we recommend [deploying ACS to AWS EKS](./eks-deployment.md). If you have a machine with at least 16GB of memory you can also [deploy using Docker for Desktop](./docker-desktop-deployment.md).
+For the best results we recommend [deploying ACS to AWS
+EKS](./eks-deployment.md). If you have a machine with at least 16GB of memory
+you can [deploy using Docker Desktop](./desktop-deployment.md) (or similar apps
+like Rancher and Podman Desktop) or via [KinD](kind-deployment.md) which just
+requires a working Docker install on any OS.
 
 The recommended cluster resources for the Enterprise version with the components enabled by default are:
 at least 3 nodes with 12 cpu cores and 32 GB of memory in total. You can install with lower

--- a/docs/helm/desktop-deployment.md
+++ b/docs/helm/desktop-deployment.md
@@ -176,7 +176,7 @@ To deploy a previous version of ACS Enterprise follow the steps below.
 
 > NOTE: The command will wait until the deployment is ready so please be
 patient. See below for
-[troubleshooting](./docker-desktop-deployment.md#troubleshooting) tips.
+[troubleshooting](#troubleshooting) tips.
 
 ## Access
 

--- a/docs/helm/kind-deployment.md
+++ b/docs/helm/kind-deployment.md
@@ -1,0 +1,60 @@
+# Setting up Kind for Helm Chart Installation
+
+## Prerequisites
+
+- Docker installed on your machine
+- Kubernetes CLI (kubectl) installed on your machine
+- Helm CLI installed on your machine
+
+## Step 1: Install Kind
+
+## Step 2: Create a Kind Cluster
+
+1. Open a terminal window.
+2. Run the following command to create a Kind cluster:
+
+    ```shell
+    cat <<EOF | kind create cluster -n acs-testing --config=-
+    kind: Cluster
+    apiVersion: kind.x-k8s.io/v1alpha4
+    nodes:
+    - role: control-plane
+    kubeadmConfigPatches:
+    - |
+        kind: InitConfiguration
+        nodeRegistration:
+        kubeletExtraArgs:
+            node-labels: "ingress-ready=true"
+    extraPortMappings:
+    - containerPort: 80
+        hostPort: 80
+        protocol: TCP
+    - containerPort: 443
+        hostPort: 443
+        protocol: TCP
+    EOF
+    ```
+
+3. Wait for the Kind cluster to be created. This may take a few minutes.
+
+## Install ingress-nginx
+
+[install kind](https://kind.sigs.k8s.io/docs/user/ingress/#ingress-nginx)
+
+kubectl wait --namespace ingress-nginx \
+  --for=condition=ready pod \
+  --selector=app.kubernetes.io/component=controller \
+  --timeout=90s
+
+## Install metrics server
+
+[install metrics server](https://github.com/kubernetes-sigs/metrics-server#installation)
+
+```sh
+kubectl patch -n kube-system deployment metrics-server --type=json \
+  -p '[{"op":"add","path":"/spec/template/spec/containers/0/args/-","value":"--kubelet-insecure-tls"}]'
+```
+
+## Conclusion
+
+You have successfully set up Kind and Helm for installing Helm charts. You can now proceed with installing your desired Helm charts on the Kind cluster.

--- a/docs/helm/kind-deployment.md
+++ b/docs/helm/kind-deployment.md
@@ -41,10 +41,17 @@
 
 [install kind](https://kind.sigs.k8s.io/docs/user/ingress/#ingress-nginx)
 
+```sh
+kubectl -n ingress-nginx patch cm ingress-nginx-controller \
+  -p '{"data": {"allow-snippet-annotations":"true"}}'
+```
+
+```sh
 kubectl wait --namespace ingress-nginx \
   --for=condition=ready pod \
   --selector=app.kubernetes.io/component=controller \
   --timeout=90s
+```
 
 ## Install metrics server
 

--- a/docs/helm/kind-deployment.md
+++ b/docs/helm/kind-deployment.md
@@ -1,50 +1,67 @@
-# Setting up Kind for Helm Chart Installation
+# Alfresco Content Services Helm Deployment on KinD cluster
+
+This page describe how to get ACS up and running on a [Kubernetes In
+Docker](https://kind.sigs.k8s.io/) (KinD) cluster.
+
+KinD is better suited to run helm workloads inside CI environments but works
+well also for local development because it just requires a working Docker
+server.
 
 ## Prerequisites
 
-- Docker installed on your machine
+- Docker installed on your machine (Docker Desktop, Rancher Desktop, Podman and similar)
 - Kubernetes CLI (kubectl) installed on your machine
 - Helm CLI installed on your machine
 
 ## Step 1: Install Kind
 
+Take a look to the [KinD
+quickstart](https://kind.sigs.k8s.io/docs/user/quick-start/) to learn how to
+install the binary cli on your machine and to learn briefly the main commands
+that you can run.
+
 ## Step 2: Create a Kind Cluster
 
-1. Open a terminal window.
-2. Run the following command to create a Kind cluster:
+Run the following command to create a Kind cluster:
 
-    ```shell
-    cat <<EOF | kind create cluster -n acs-testing --config=-
-    kind: Cluster
-    apiVersion: kind.x-k8s.io/v1alpha4
-    nodes:
-    - role: control-plane
-    kubeadmConfigPatches:
-    - |
-        kind: InitConfiguration
-        nodeRegistration:
-        kubeletExtraArgs:
-            node-labels: "ingress-ready=true"
-    extraPortMappings:
-    - containerPort: 80
-        hostPort: 80
-        protocol: TCP
-    - containerPort: 443
-        hostPort: 443
-        protocol: TCP
-    EOF
-    ```
+```shell
+cat <<EOF | kind create cluster -n acs-testing --config=-
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+kubeadmConfigPatches:
+- |
+    kind: InitConfiguration
+    nodeRegistration:
+    kubeletExtraArgs:
+        node-labels: "ingress-ready=true"
+extraPortMappings:
+- containerPort: 80
+    hostPort: 80
+    protocol: TCP
+- containerPort: 443
+    hostPort: 443
+    protocol: TCP
+EOF
+```
 
-3. Wait for the Kind cluster to be created. This may take a few minutes.
+Wait for the Kind cluster to be created. This may take a few minutes.
 
-## Install ingress-nginx
+## Step 3: Install patched ingress-nginx
 
-[install kind](https://kind.sigs.k8s.io/docs/user/ingress/#ingress-nginx)
+Follow the instructions for
+[deploying nginx ingress on KinD](https://kind.sigs.k8s.io/docs/user/ingress/#ingress-nginx).
+
+Reconfigure ingress-nginx to allow snippet annotations that are still required
+when using our search services chart:
 
 ```sh
 kubectl -n ingress-nginx patch cm ingress-nginx-controller \
   -p '{"data": {"allow-snippet-annotations":"true"}}'
 ```
+
+Wait for the ingress-nginx controller to be up again after the configuration change:
 
 ```sh
 kubectl wait --namespace ingress-nginx \
@@ -55,13 +72,31 @@ kubectl wait --namespace ingress-nginx \
 
 ## Install metrics server
 
-[install metrics server](https://github.com/kubernetes-sigs/metrics-server#installation)
+Optionally, you can [install metrics
+server](https://github.com/kubernetes-sigs/metrics-server#installation) to
+gather metrics from node and pods.
+
+Make sure to enable insecure tls option otherwise metrics collection would not work under KinD:
 
 ```sh
 kubectl patch -n kube-system deployment metrics-server --type=json \
   -p '[{"op":"add","path":"/spec/template/spec/containers/0/args/-","value":"--kubelet-insecure-tls"}]'
 ```
 
+Wait for a few minutes and then try to run:
+
+```sh
+kubectl top node
+```
+
+Upon installing ACS, you can check current cpu and memory usage via:
+
+```sh
+kubectl top pods
+```
+
 ## Conclusion
 
-You have successfully set up Kind and Helm for installing Helm charts. You can now proceed with installing your desired Helm charts on the Kind cluster.
+Now that you have successfully set up a Kind cluster with ingress-nginx and
+metrics-server, you can now proceed with installing ACS via helm charts as per
+[Desktop deployment](desktop-deployment.md#acs).


### PR DESCRIPTION
We started using KinD for the CI and eventually can be useful to run it locally because it's a more portable K8s than other alternatives (Rancher Desktop, minikube, ...)

Ref: OPSEXP-2439