### PR TITLE
OPSEXP-2439 Exclude linter_values.yaml from helm ent workflow

### DIFF
--- a/.github/actions/charts-as-json/action.yml
+++ b/.github/actions/charts-as-json/action.yml
@@ -27,7 +27,7 @@ runs:
       run: |
         for CHART_ROOT in ${{ inputs.charts-root }}/*/; do
           CHART=$(basename $CHART_ROOT)
-          VALUES_FILES=$(find ${{ inputs.charts-root }}/"${CHART}" -type f -depth 1 -name "*values.yaml" ! -name "linter_values.yaml" || true)
+          VALUES_FILES=$(find ${{ inputs.charts-root }}/"${CHART}" -type f -name "*values.yaml" ! -name "linter_values.yaml" -depth 1)
           VALUES=${VALUES_FILES//${CHART_ROOT}/}
           yq e "$YQ_FILTER" "${{ inputs.charts-root }}/${CHART}/Chart.yaml" | \
           jq -c --arg v "${VALUES}" '.values=($v | split("\n"))' > /tmp/outputs_${CHART}.json

--- a/.github/actions/charts-as-json/action.yml
+++ b/.github/actions/charts-as-json/action.yml
@@ -27,7 +27,7 @@ runs:
       run: |
         for CHART_ROOT in ${{ inputs.charts-root }}/*/; do
           CHART=$(basename $CHART_ROOT)
-          VALUES_FILES=$(find ${{ inputs.charts-root }}/"${CHART}" -type f -name "*values.yaml" ! -name "linter_values.yaml" || true)
+          VALUES_FILES=$(find ${{ inputs.charts-root }}/"${CHART}" -type f -depth 1 -name "*values.yaml" ! -name "linter_values.yaml" || true)
           VALUES=${VALUES_FILES//${CHART_ROOT}/}
           yq e "$YQ_FILTER" "${{ inputs.charts-root }}/${CHART}/Chart.yaml" | \
           jq -c --arg v "${VALUES}" '.values=($v | split("\n"))' > /tmp/outputs_${CHART}.json

--- a/.github/actions/charts-as-json/action.yml
+++ b/.github/actions/charts-as-json/action.yml
@@ -27,7 +27,7 @@ runs:
       run: |
         for CHART_ROOT in ${{ inputs.charts-root }}/*/; do
           CHART=$(basename $CHART_ROOT)
-          VALUES_FILES=$(ls -r ${{ inputs.charts-root }}/"${CHART}"/*values.yaml || true)
+          VALUES_FILES=$(find ${{ inputs.charts-root }}/"${CHART}" -type f -name "*values.yaml" ! -name "linter_values.yaml" || true)
           VALUES=${VALUES_FILES//${CHART_ROOT}/}
           yq e "$YQ_FILTER" "${{ inputs.charts-root }}/${CHART}/Chart.yaml" | \
           jq -c --arg v "${VALUES}" '.values=($v | split("\n"))' > /tmp/outputs_${CHART}.json

--- a/.github/actions/charts-as-json/action.yml
+++ b/.github/actions/charts-as-json/action.yml
@@ -27,7 +27,7 @@ runs:
       run: |
         for CHART_ROOT in ${{ inputs.charts-root }}/*/; do
           CHART=$(basename $CHART_ROOT)
-          VALUES_FILES=$(find ${{ inputs.charts-root }}/"${CHART}" -type f -name "*values.yaml" ! -name "linter_values.yaml" -depth 1)
+          VALUES_FILES=$(find ${{ inputs.charts-root }}/"${CHART}" -type f -name "*values.yaml" ! -name "linter_values.yaml" -maxdepth 1)
           VALUES=${VALUES_FILES//${CHART_ROOT}/}
           yq e "$YQ_FILTER" "${{ inputs.charts-root }}/${CHART}/Chart.yaml" | \
           jq -c --arg v "${VALUES}" '.values=($v | split("\n"))' > /tmp/outputs_${CHART}.json

--- a/.github/workflows/helm-enterprise.yml
+++ b/.github/workflows/helm-enterprise.yml
@@ -62,7 +62,7 @@ jobs:
     timeout-minutes: 10
     needs:
       - build_vars
-    name: Helm ${{ matrix.name }} ${{ matrix.values }}
+    name: ${{ matrix.values }} on ${{ matrix.name }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/helm-enterprise.yml
+++ b/.github/workflows/helm-enterprise.yml
@@ -10,6 +10,7 @@ on:
       - helm/**
       - test/postman/helm/**
       - .github/workflows/helm*
+      - .github/actions/charts-as-json/**
   push:
     branches:
       - master

--- a/helm/alfresco-content-services/linter_values.yaml
+++ b/helm/alfresco-content-services/linter_values.yaml
@@ -11,3 +11,4 @@ alfresco-ai-transformer:
     s3Bucket: somebucket
     region: us-east-1
     comprehendRoleARN: arn:aws:iam::000000000000:user/comprehend
+# test me

--- a/helm/alfresco-content-services/linter_values.yaml
+++ b/helm/alfresco-content-services/linter_values.yaml
@@ -11,4 +11,3 @@ alfresco-ai-transformer:
     s3Bucket: somebucket
     region: us-east-1
     comprehendRoleARN: arn:aws:iam::000000000000:user/comprehend
-# test me


### PR DESCRIPTION
It was introduced for the new helmlint pre-commit hook and got well hidden by long job names

Ref: OPSEXP-2439