### PR TITLE
OPSEXP-2487 Align postgres versions to supported platforms

### DIFF
--- a/helm/alfresco-content-services/7.0.N_values.yaml
+++ b/helm/alfresco-content-services/7.0.N_values.yaml
@@ -44,13 +44,12 @@ alfresco-digital-workspace:
 postgresql:
   image:
     tag: 13.1.0
+postgresql-sync:
+  image:
+    tag: 13.1.0
 alfresco-sync-service:
   image:
     tag: 3.7.2
-  postgresql:
-    primary:
-      image:
-        tag: 13.1.0
 alfresco-connector-ms365:
   image:
     tag: 1.1.0.1

--- a/helm/alfresco-content-services/7.1.N_values.yaml
+++ b/helm/alfresco-content-services/7.1.N_values.yaml
@@ -58,16 +58,15 @@ alfresco-search-enterprise:
 postgresql:
   image:
     tag: 13.3.0
+postgresql-sync:
+  image:
+    tag: 13.3.0
 alfresco-digital-workspace:
   image:
     tag: 2.6.2
 alfresco-sync-service:
   image:
     tag: 3.11.1
-  postgresql:
-    primary:
-      image:
-        tag: 13.3.0
 alfresco-connector-msteams:
   image:
     tag: 1.1.0

--- a/helm/alfresco-content-services/7.2.N_values.yaml
+++ b/helm/alfresco-content-services/7.2.N_values.yaml
@@ -62,13 +62,12 @@ alfresco-control-center:
 postgresql:
   image:
     tag: 13.3.0
+postgresql-sync:
+  image:
+    tag: 13.3.0
 alfresco-sync-service:
   image:
     tag: 3.11.1
-  postgresql:
-    primary:
-      image:
-        tag: 13.3.0
 alfresco-connector-ms365:
   image:
     tag: 1.1.3.2

--- a/helm/alfresco-content-services/7.3.N_values.yaml
+++ b/helm/alfresco-content-services/7.3.N_values.yaml
@@ -62,10 +62,10 @@ alfresco-control-center:
     tag: 7.9.0
 postgresql:
   image:
-    tag: 14.4.0
-postgresql-syncservice:
+    tag: 14.10.0
+postgresql-sync:
   image:
-    tag: 14.4.0
+    tag: 14.10.0
 alfresco-sync-service:
   image:
     tag: 3.11.1

--- a/helm/alfresco-content-services/7.4.N_values.yaml
+++ b/helm/alfresco-content-services/7.4.N_values.yaml
@@ -62,10 +62,10 @@ alfresco-control-center:
     tag: 8.2.0
 postgresql:
   image:
-    tag: 14.4.0
-postgresql-syncservice:
+    tag: 14.10.0
+postgresql-sync:
   image:
-    tag: 14.4.0
+    tag: 14.10.0
 alfresco-sync-service:
   image:
     tag: 3.11.1

--- a/helm/alfresco-content-services/README.md
+++ b/helm/alfresco-content-services/README.md
@@ -256,7 +256,7 @@ Please refer to the [documentation](https://github.com/Alfresco/acs-deployment/b
 | postgresql-sync.auth.password | string | `"admin"` |  |
 | postgresql-sync.auth.username | string | `"alfresco"` |  |
 | postgresql-sync.enabled | bool | `true` | Toggle creation of the "in-cluster" test postgresql instance for Alfresco Sync service |
-| postgresql-sync.image.tag | string | `"14.4.0"` |  |
+| postgresql-sync.image.tag | string | `"15.5.0"` |  |
 | postgresql-sync.nameOverride | string | `"postgresql-sync"` |  |
 | postgresql-sync.primary.extendedConfiguration | string | `"max_connections = 150\nshared_buffers = 512MB\neffective_cache_size = 2GB\nwal_level = minimal\nmax_wal_senders = 0\nmax_replication_slots = 0\nlog_min_messages = LOG\n"` |  |
 | postgresql-sync.primary.resources.limits.cpu | string | `"4"` |  |
@@ -270,7 +270,7 @@ Please refer to the [documentation](https://github.com/Alfresco/acs-deployment/b
 | postgresql.commonAnnotations.application | string | `"alfresco-content-services"` |  |
 | postgresql.enabled | bool | `true` | Toggle embedded postgres for Alfresco Content Services repository Check [PostgreSQL Bitnami chart Documentation](https://github.com/bitnami/charts/tree/main/bitnami/postgresql) |
 | postgresql.image.pullPolicy | string | `"IfNotPresent"` |  |
-| postgresql.image.tag | string | `"14.4.0"` |  |
+| postgresql.image.tag | string | `"15.5.0"` |  |
 | postgresql.nameOverride | string | `"postgresql-acs"` |  |
 | postgresql.primary.extendedConfiguration | string | `"max_connections = 250\nshared_buffers = 512MB\neffective_cache_size = 2GB\nwal_level = minimal\nmax_wal_senders = 0\nmax_replication_slots = 0\nlog_min_messages = LOG\n"` |  |
 | postgresql.primary.persistence.existingClaim | string | `nil` | provide an existing persistent volume claim name to persist SQL data Make sure the root folder has the appropriate permissions/ownership set. |

--- a/helm/alfresco-content-services/values.yaml
+++ b/helm/alfresco-content-services/values.yaml
@@ -421,7 +421,7 @@ postgresql:
   enabled: true
   nameOverride: postgresql-acs
   image:
-    tag: 14.4.0
+    tag: 15.5.0
     pullPolicy: IfNotPresent
   commonAnnotations:
     application: alfresco-content-services
@@ -484,7 +484,7 @@ postgresql-sync:
   enabled: true
   nameOverride: postgresql-sync
   image:
-    tag: 14.4.0
+    tag: 15.5.0
   auth:
     enablePostgresUser: false
     username: alfresco


### PR DESCRIPTION
* Latest version is now graviton compatible
* Fix wrong postgres versions used in previous acs versions (7.2, 7.1, 7.0)

Ref: OPSEXP-2487