### PR TITLE
OPSEXP-2391 Move ingress-nginx to a dedicated section

### DIFF
--- a/docs/helm/desktop-deployment.md
+++ b/docs/helm/desktop-deployment.md
@@ -60,40 +60,7 @@ kubectl create namespace alfresco
 
 ### Ingress
 
-Add the ingress-nginx chart repository:
-
-```bash
-helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
-helm repo update
-```
-
-Install an ingress-nginx controller within the 'alfresco' namespace:
-
-```bash
-helm install acs-ingress ingress-nginx/ingress-nginx --version=4.4.0 \
-  --set controller.scope.enabled=true \
-  --set controller.scope.namespace=alfresco \
-  --set rbac.create=true \
-  --atomic \
-  --namespace alfresco
-```
-
-> NOTE: The command will wait until the deployment is ready so please be patient.
-
-```bash
-# Verify NGINX is up and running
-kubectl get pods --namespace alfresco
-
-NAME                                                   READY   STATUS    RESTARTS   AGE
-acs-ingress-ingress-nginx-controller-5647c976f-f7b6q   1/1     Running   0          98m
-
-# Verify expose localhost:80
-kubectl get svc --namespace alfresco
-
-NAME                                             TYPE           CLUSTER-IP     EXTERNAL-IP     PORT(S)                      AGE
-acs-ingress-ingress-nginx-controller-admission   ClusterIP      10.43.42.230   <none>          443/TCP                      98m
-acs-ingress-ingress-nginx-controller             LoadBalancer   10.43.90.117   192.168.29.69   80:31363/TCP,443:30980/TCP   98m
-```
+See [ingress-nginx](ingress-nginx.md) section.
 
 ### ACS
 

--- a/docs/helm/ingress-nginx.md
+++ b/docs/helm/ingress-nginx.md
@@ -1,0 +1,33 @@
+# Install ingress-nginx
+
+We currently support and test only
+[ingress-nginx](https://github.com/kubernetes/ingress-nginx), but all of our
+charts supports overriding via values the `ingressSourceClass` and `annotations`
+which allows to use your preferred ingress controller.
+
+## Install on a generic Kubernetes cluster
+
+Install the ingress-nginx controller namespace:
+
+```bash
+helm upgrade --install ingress-nginx ingress-nginx \
+  --repo https://kubernetes.github.io/ingress-nginx \
+  --namespace ingress-nginx --create-namespace
+```
+
+Enable snippet annotations which is disabled by default for security reasons but
+we still requires it for `alfresco-search-services`.
+
+```bash
+kubectl -n ingress-nginx patch cm ingress-nginx-controller \
+  -p '{"data": {"allow-snippet-annotations":"true"}}'
+```
+
+Wait for the ingress-nginx controller to be up again after the configuration change:
+
+```sh
+kubectl wait --namespace ingress-nginx \
+  --for=condition=ready pod \
+  --selector=app.kubernetes.io/component=controller \
+  --timeout=90s
+```

--- a/docs/helm/ingress-nginx.md
+++ b/docs/helm/ingress-nginx.md
@@ -15,8 +15,9 @@ helm upgrade --install ingress-nginx ingress-nginx \
   --namespace ingress-nginx --create-namespace
 ```
 
-Enable snippet annotations which is disabled by default for security reasons but
-we still requires it for `alfresco-search-services`.
+Enable snippet annotations which is disabled by default for security reasons, but
+we still requires it for `alfresco-search-services` while still filtering only
+the ones we strictly need.
 
 ```bash
 kubectl -n ingress-nginx patch cm ingress-nginx-controller \


### PR DESCRIPTION
so we can link to it more easily

not sure for the [eks flavour](https://github.com/Alfresco/acs-deployment/blob/master/docs/helm/eks-deployment.md#ingress) what it's really need to be kept so not touching it now unless someone advice

Ref: OPSEXP-2391