### PR TITLE
OPSEXP-2488 Bump alfresco connector charts to use stable version of ingress apiVersion and fix extraAnnotations

### DIFF
--- a/helm/alfresco-content-services/Chart.lock
+++ b/helm/alfresco-content-services/Chart.lock
@@ -34,18 +34,18 @@ dependencies:
   version: 3.2.4
 - name: alfresco-connector-msteams
   repository: https://alfresco.github.io/alfresco-helm-charts/
-  version: 0.4.1
+  version: 0.5.0
 - name: alfresco-share
   repository: https://alfresco.github.io/alfresco-helm-charts/
   version: 0.6.0
 - name: alfresco-connector-ms365
   repository: https://alfresco.github.io/alfresco-helm-charts/
-  version: 0.6.1
+  version: 0.7.0
 - name: alfresco-ai-transformer
   repository: https://alfresco.github.io/alfresco-helm-charts/
   version: 1.2.0
 - name: elasticsearch
   repository: https://helm.elastic.co
   version: 7.17.3
-digest: sha256:9605cb1e24d4b8f42f32e853c1de162316544d9fb4ed6996e751a090266b2fd9
-generated: "2024-03-14T09:26:08.606229+01:00"
+digest: sha256:b395454280a70e7c3525dabfaeb5bd6417d7ccab663247500926365f3995317f
+generated: "2024-03-14T14:44:47.280329+01:00"

--- a/helm/alfresco-content-services/Chart.yaml
+++ b/helm/alfresco-content-services/Chart.yaml
@@ -65,7 +65,7 @@ dependencies:
     repository: https://alfresco.github.io/alfresco-helm-charts/
     condition: alfresco-search-enterprise.enabled
   - name: alfresco-connector-msteams
-    version: 0.4.1
+    version: 0.5.0
     repository: https://alfresco.github.io/alfresco-helm-charts/
     condition: alfresco-connector-msteams.enabled
   - name: alfresco-share
@@ -74,7 +74,7 @@ dependencies:
     repository: https://alfresco.github.io/alfresco-helm-charts/
     condition: share.enabled
   - name: alfresco-connector-ms365
-    version: 0.6.1
+    version: 0.7.0
     repository: https://alfresco.github.io/alfresco-helm-charts/
     condition: alfresco-connector-ms365.enabled
   - name: alfresco-ai-transformer

--- a/helm/alfresco-content-services/README.md
+++ b/helm/alfresco-content-services/README.md
@@ -21,8 +21,8 @@ Please refer to the [documentation](https://github.com/Alfresco/acs-deployment/b
 | https://alfresco.github.io/alfresco-helm-charts/ | alfresco-digital-workspace(alfresco-adf-app) | 0.1.0 |
 | https://alfresco.github.io/alfresco-helm-charts/ | alfresco-ai-transformer | 1.2.0 |
 | https://alfresco.github.io/alfresco-helm-charts/ | alfresco-common | 3.1.2 |
-| https://alfresco.github.io/alfresco-helm-charts/ | alfresco-connector-ms365 | 0.6.1 |
-| https://alfresco.github.io/alfresco-helm-charts/ | alfresco-connector-msteams | 0.4.1 |
+| https://alfresco.github.io/alfresco-helm-charts/ | alfresco-connector-ms365 | 0.7.0 |
+| https://alfresco.github.io/alfresco-helm-charts/ | alfresco-connector-msteams | 0.5.0 |
 | https://alfresco.github.io/alfresco-helm-charts/ | alfresco-repository | 0.4.1 |
 | https://alfresco.github.io/alfresco-helm-charts/ | alfresco-search-enterprise | 3.2.4 |
 | https://alfresco.github.io/alfresco-helm-charts/ | alfresco-search(alfresco-search-service) | 3.3.0 |


### PR DESCRIPTION
Ref: OPSEXP-2488