### PR TITLE
Enable pre-release versions in helm autodiscovery

### DIFF
--- a/.github/workflows/bumpVersions.yml
+++ b/.github/workflows/bumpVersions.yml
@@ -23,7 +23,7 @@ on:
         default: master
 
 env:
-  UPDATE_CLI_VERSION: v0.71.0
+  UPDATE_CLI_VERSION: v0.84.1
   DEFAULT_BRANCH_NAME: master
 
 jobs:

--- a/updatecli.d/helm-autodiscovery.yaml
+++ b/updatecli.d/helm-autodiscovery.yaml
@@ -7,6 +7,9 @@ autodiscovery:
       versionincrement: none
       # Tags in values are handled separately via uber-manifest.tpl
       ignorecontainer: true
+      versionfilter:
+        kind: semver
+        pattern: '>= 0.0.0-0'
 
       ignore:
         # Skip dependencies we are not interested to bump automatically (testing dependencies)


### PR DESCRIPTION
requires:
* https://github.com/updatecli/updatecli/pull/2736

tested in https://github.com/Alfresco/acs-deployment/actions/runs/11165106641 (will raise another PR for the actual bump)