### PR TITLE
OPSEXP-2411 Drop privileged for traefik containers

### DIFF
--- a/.github/kics.yml
+++ b/.github/kics.yml
@@ -4,3 +4,6 @@ exclude-queries:
   - d6355c88-1e8d-49e9-b2f2-f8a1ca12c75b # Docker Socket Mounted In Container
   - 1c1325ff-831d-43a1-973e-839ae57dfcc0 # Volume Has Sensitive Host Directory
   - ce76b7d0-9e77-464d-b86f-c5c48e03e22d # Container Capabilities Unrestricted
+  - 451d79dc-0588-476a-ad03-3c7f0320abb3 # Container Traffic Not Bound To Host Interface
+  - 698ed579-b239-4f8f-a388-baa4bcb13ef8 # Healthcheck Not Set
+  - 8c978947-0ff6-485c-b0c2-0bfca6026466 # Shared Volumes Between Containers

--- a/.github/kics.yml
+++ b/.github/kics.yml
@@ -1,0 +1,6 @@
+exclude-queries:
+  - 610e266e-6c12-4bca-9925-1ed0cd29742b # Security Opt Not Set
+  - 27fcc7d6-c49b-46e0-98f1-6c082a6a2750 # No New Privileges Not Set
+  - d6355c88-1e8d-49e9-b2f2-f8a1ca12c75b # Docker Socket Mounted In Container
+  - 1c1325ff-831d-43a1-973e-839ae57dfcc0 # Volume Has Sensitive Host Directory
+  - ce76b7d0-9e77-464d-b86f-c5c48e03e22d # Container Capabilities Unrestricted

--- a/.github/workflows/kics.yml
+++ b/.github/workflows/kics.yml
@@ -33,6 +33,7 @@ jobs:
           enable_jobs_summary: true
           platform_type: 'dockercompose,kubernetes'
           disable_secrets: true
+          config_path: .github/kics.yml
       - name: Upload SARIF file
         uses: github/codeql-action/upload-sarif@323f5ef653b88011bf10e9a0a56d70d742463c9a # v3.26.8
         with:

--- a/docker-compose/7.1.N-docker-compose.yml
+++ b/docker-compose/7.1.N-docker-compose.yml
@@ -184,7 +184,7 @@ services:
       - "traefik.http.middlewares.adwchain.chain.middlewares=adwforceslash,adwroot"
       - "traefik.http.routers.adw.middlewares=adwchain@docker"
   proxy:
-    image: traefik:v3
+    image: traefik:3.1
     mem_limit: 128m
     command:
       - "--api.insecure=true"

--- a/docker-compose/7.1.N-docker-compose.yml
+++ b/docker-compose/7.1.N-docker-compose.yml
@@ -197,7 +197,7 @@ services:
       - "8080:8080"
       - "8888:8888"
     security_opt:
-      - label=disable
+      - label=disable # Required for accessing the Docker socket on Selinux enabled systems
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
   sync-service:

--- a/docker-compose/7.1.N-docker-compose.yml
+++ b/docker-compose/7.1.N-docker-compose.yml
@@ -187,7 +187,7 @@ services:
       - "traefik.http.middlewares.adwchain.chain.middlewares=adwforceslash,adwroot"
       - "traefik.http.routers.adw.middlewares=adwchain@docker"
   proxy:
-    image: traefik:v3.1.3
+    image: traefik:v3
     mem_limit: 128m
     command:
       - "--api.insecure=true"
@@ -199,9 +199,10 @@ services:
     ports:
       - "8080:8080"
       - "8888:8888"
-    privileged: true
+    security_opt:
+      - label=disable
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
+      - /var/run/docker.sock:/var/run/docker.sock:ro
   sync-service:
     image: quay.io/alfresco/service-sync:3.11.3
     mem_limit: 1g

--- a/docker-compose/7.1.N-docker-compose.yml
+++ b/docker-compose/7.1.N-docker-compose.yml
@@ -13,12 +13,9 @@
 # download page at:
 # https://www.alfresco.com/platform/content-services-ecm/trial/download
 #
-# Using version 2 as 3 does not support resource constraint options
-# (cpu_*, mem_* limits) for non swarm mode in Compose
-#
 # Java processes requires setting -XX:MaxRAM= due to cgroupv2 changes in recent Linux kernels
 # https://hub.alfresco.com/t5/alfresco-content-services-blog/acs-containers-and-cgroup-v2-in-acs-up-to-7-2/ba-p/318039
-version: "2"
+# 
 services:
   alfresco:
     image: quay.io/alfresco/alfresco-content-repository:7.1.1.10

--- a/docker-compose/7.2.N-docker-compose.yml
+++ b/docker-compose/7.2.N-docker-compose.yml
@@ -207,7 +207,7 @@ services:
       - "traefik.http.middlewares.accchain.chain.middlewares=accforceslash,accroot"
       - "traefik.http.routers.acc.middlewares=accchain@docker"
   proxy:
-    image: traefik:v3.1.3
+    image: traefik:v3
     mem_limit: 128m
     command:
       - "--api.insecure=true"
@@ -219,9 +219,10 @@ services:
     ports:
       - "8080:8080"
       - "8888:8888"
-    privileged: true
+    security_opt:
+      - label=disable
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
+      - /var/run/docker.sock:/var/run/docker.sock:ro
   sync-service:
     image: quay.io/alfresco/service-sync:3.11.3
     mem_limit: 1g

--- a/docker-compose/7.2.N-docker-compose.yml
+++ b/docker-compose/7.2.N-docker-compose.yml
@@ -217,7 +217,7 @@ services:
       - "8080:8080"
       - "8888:8888"
     security_opt:
-      - label=disable
+      - label=disable # Required for accessing the Docker socket on Selinux enabled systems
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
   sync-service:

--- a/docker-compose/7.2.N-docker-compose.yml
+++ b/docker-compose/7.2.N-docker-compose.yml
@@ -204,7 +204,7 @@ services:
       - "traefik.http.middlewares.accchain.chain.middlewares=accforceslash,accroot"
       - "traefik.http.routers.acc.middlewares=accchain@docker"
   proxy:
-    image: traefik:v3
+    image: traefik:3.1
     mem_limit: 128m
     command:
       - "--api.insecure=true"

--- a/docker-compose/7.2.N-docker-compose.yml
+++ b/docker-compose/7.2.N-docker-compose.yml
@@ -13,12 +13,9 @@
 # download page at:
 # https://www.alfresco.com/platform/content-services-ecm/trial/download
 #
-# Using version 2 as 3 does not support resource constraint options
-# (cpu_*, mem_* limits) for non swarm mode in Compose
-#
 # Java processes requires setting -XX:MaxRAM= due to cgroupv2 changes in recent Linux kernels
 # https://hub.alfresco.com/t5/alfresco-content-services-blog/acs-containers-and-cgroup-v2-in-acs-up-to-7-2/ba-p/318039
-version: "2"
+#
 services:
   alfresco:
     image: quay.io/alfresco/alfresco-content-repository:7.2.2.5

--- a/docker-compose/7.3.N-docker-compose.yml
+++ b/docker-compose/7.3.N-docker-compose.yml
@@ -195,7 +195,7 @@ services:
       - "traefik.http.middlewares.accchain.chain.middlewares=accforceslash,accroot"
       - "traefik.http.routers.acc.middlewares=accchain@docker"
   proxy:
-    image: traefik:v3
+    image: traefik:3.1
     mem_limit: 128m
     command:
       - "--api.insecure=true"

--- a/docker-compose/7.3.N-docker-compose.yml
+++ b/docker-compose/7.3.N-docker-compose.yml
@@ -13,9 +13,6 @@
 # download page at:
 # https://www.alfresco.com/platform/content-services-ecm/trial/download
 #
-# Using version 2 as 3 does not support resource constraint options
-# (cpu_*, mem_* limits) for non swarm mode in Compose
-version: "2"
 services:
   alfresco:
     image: quay.io/alfresco/alfresco-content-repository:7.3.2.1

--- a/docker-compose/7.3.N-docker-compose.yml
+++ b/docker-compose/7.3.N-docker-compose.yml
@@ -198,7 +198,7 @@ services:
       - "traefik.http.middlewares.accchain.chain.middlewares=accforceslash,accroot"
       - "traefik.http.routers.acc.middlewares=accchain@docker"
   proxy:
-    image: traefik:v3.1.3
+    image: traefik:v3
     mem_limit: 128m
     command:
       - "--api.insecure=true"
@@ -210,9 +210,10 @@ services:
     ports:
       - "8080:8080"
       - "8888:8888"
-    privileged: true
+    security_opt:
+      - label=disable
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
+      - /var/run/docker.sock:/var/run/docker.sock:ro
   sync-service:
     image: quay.io/alfresco/service-sync:3.11.3
     mem_limit: 1g

--- a/docker-compose/7.3.N-docker-compose.yml
+++ b/docker-compose/7.3.N-docker-compose.yml
@@ -208,7 +208,7 @@ services:
       - "8080:8080"
       - "8888:8888"
     security_opt:
-      - label=disable
+      - label=disable # Required for accessing the Docker socket on Selinux enabled systems
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
   sync-service:

--- a/docker-compose/7.4.N-docker-compose.yml
+++ b/docker-compose/7.4.N-docker-compose.yml
@@ -196,7 +196,7 @@ services:
       - "traefik.http.middlewares.accchain.chain.middlewares=accforceslash,accroot"
       - "traefik.http.routers.acc.middlewares=accchain@docker"
   proxy:
-    image: traefik:v3
+    image: traefik:3.1
     mem_limit: 128m
     command:
       - "--api.insecure=true"

--- a/docker-compose/7.4.N-docker-compose.yml
+++ b/docker-compose/7.4.N-docker-compose.yml
@@ -199,7 +199,7 @@ services:
       - "traefik.http.middlewares.accchain.chain.middlewares=accforceslash,accroot"
       - "traefik.http.routers.acc.middlewares=accchain@docker"
   proxy:
-    image: traefik:v3.1.3
+    image: traefik:v3
     mem_limit: 128m
     command:
       - "--api.insecure=true"
@@ -211,9 +211,10 @@ services:
     ports:
       - "8080:8080"
       - "8888:8888"
-    privileged: true
+    security_opt:
+      - label=disable
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
+      - /var/run/docker.sock:/var/run/docker.sock:ro
   sync-service:
     image: quay.io/alfresco/service-sync:3.11.3
     mem_limit: 1g

--- a/docker-compose/7.4.N-docker-compose.yml
+++ b/docker-compose/7.4.N-docker-compose.yml
@@ -13,9 +13,6 @@
 # download page at:
 # https://www.alfresco.com/platform/content-services-ecm/trial/download
 #
-# Using version 2 as 3 does not support resource constraint options
-# (cpu_*, mem_* limits) for non swarm mode in Compose
-version: "2"
 services:
   alfresco:
     image: quay.io/alfresco/alfresco-content-repository:7.4.2.1

--- a/docker-compose/7.4.N-docker-compose.yml
+++ b/docker-compose/7.4.N-docker-compose.yml
@@ -209,7 +209,7 @@ services:
       - "8080:8080"
       - "8888:8888"
     security_opt:
-      - label=disable
+      - label=disable # Required for accessing the Docker socket on Selinux enabled systems
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
   sync-service:

--- a/docker-compose/community-docker-compose.yml
+++ b/docker-compose/community-docker-compose.yml
@@ -151,7 +151,7 @@ services:
       - "traefik.http.middlewares.accchain.chain.middlewares=accforceslash,accroot"
       - "traefik.http.routers.acc.middlewares=accchain@docker"
   proxy:
-    image: traefik:v3.1.3
+    image: traefik:v3
     mem_limit: 128m
     command:
       - "--api.insecure=true"
@@ -163,6 +163,7 @@ services:
     ports:
       - "8080:8080"
       - "8888:8888"
-    privileged: true
+    security_opt:
+      - label=disable
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
+      - /var/run/docker.sock:/var/run/docker.sock:ro

--- a/docker-compose/community-docker-compose.yml
+++ b/docker-compose/community-docker-compose.yml
@@ -161,6 +161,6 @@ services:
       - "8080:8080"
       - "8888:8888"
     security_opt:
-      - label=disable
+      - label=disable # Required for accessing the Docker socket on Selinux enabled systems
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro

--- a/docker-compose/community-docker-compose.yml
+++ b/docker-compose/community-docker-compose.yml
@@ -7,9 +7,6 @@
 # More details here:
 # https://www.oracle.com/technetwork/java/javase/10-relnote-issues-4108729.html
 #
-# Using version 2 as 3 does not support resource constraint options
-# (cpu_*, mem_* limits) for non swarm mode in Compose
-version: "2"
 services:
   alfresco:
     image: docker.io/alfresco/alfresco-content-repository-community:23.3.0

--- a/docker-compose/community-docker-compose.yml
+++ b/docker-compose/community-docker-compose.yml
@@ -148,7 +148,7 @@ services:
       - "traefik.http.middlewares.accchain.chain.middlewares=accforceslash,accroot"
       - "traefik.http.routers.acc.middlewares=accchain@docker"
   proxy:
-    image: traefik:v3
+    image: traefik:3.1
     mem_limit: 128m
     command:
       - "--api.insecure=true"

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -180,7 +180,7 @@ services:
   search-reindexing:
     image: quay.io/alfresco/alfresco-elasticsearch-reindexing:4.1.0
     mem_limit: 1g
-    restart: on-failure:10
+    restart: on-failure:5
     environment:
       ALFRESCO_ACCEPTED_CONTENT_MEDIA_TYPES_CACHE_BASE_URL: >-
         http://transform-core-aio:8090/transform/config

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -238,7 +238,7 @@ services:
       - "traefik.http.middlewares.accchain.chain.middlewares=accforceslash,accroot"
       - "traefik.http.routers.acc.middlewares=accchain@docker"
   proxy:
-    image: traefik:v3
+    image: traefik:3.1
     mem_limit: 128m
     command:
       - "--api.insecure=true"

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -13,9 +13,6 @@
 # download page at:
 # https://www.alfresco.com/platform/content-services-ecm/trial/download
 #
-# Using version 2 as 3 does not support resource constraint options
-# (cpu_*, mem_* limits) for non swarm mode in Compose
-version: "2"
 services:
   alfresco:
     image: quay.io/alfresco/alfresco-content-repository:23.3.2
@@ -241,7 +238,7 @@ services:
       - "traefik.http.middlewares.accchain.chain.middlewares=accforceslash,accroot"
       - "traefik.http.routers.acc.middlewares=accchain@docker"
   proxy:
-    image: traefik:v3.1.3
+    image: traefik:v3
     mem_limit: 128m
     command:
       - "--api.insecure=true"
@@ -253,9 +250,10 @@ services:
     ports:
       - "8080:8080"
       - "8888:8888"
-    privileged: true
+    security_opt:
+      - label=disable
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
+      - /var/run/docker.sock:/var/run/docker.sock:ro
   sync-service:
     image: quay.io/alfresco/service-sync:4.0.1
     mem_limit: 1g

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -251,7 +251,7 @@ services:
       - "8080:8080"
       - "8888:8888"
     security_opt:
-      - label=disable
+      - label=disable # Required for accessing the Docker socket on Selinux enabled systems
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
   sync-service:

--- a/docker-compose/pre-release-docker-compose.yml
+++ b/docker-compose/pre-release-docker-compose.yml
@@ -13,9 +13,6 @@
 # download page at:
 # https://www.alfresco.com/platform/content-services-ecm/trial/download
 #
-# Using version 2 as 3 does not support resource constraint options
-# (cpu_*, mem_* limits) for non swarm mode in Compose
-version: "2"
 services:
   alfresco:
     image: quay.io/alfresco/alfresco-content-repository:23.4.0-M1

--- a/docker-compose/pre-release-docker-compose.yml
+++ b/docker-compose/pre-release-docker-compose.yml
@@ -61,6 +61,16 @@ services:
       timeout: 3s
       retries: 3
       start_period: 1m
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.alfresco.rule=PathPrefix(`/`)"
+      - "traefik.http.services.alfresco.loadbalancer.server.port=8080"
+      - "traefik.http.routers.solrapideny.rule=PathRegexp(`^/alfresco/(wc)?s(ervice)?/api/solr/.*$`)"
+      - "traefik.http.middlewares.acsfakeauth.basicauth.users=fake:"
+      - "traefik.http.routers.solrapideny.middlewares=acsfakeauth@docker"
+      - "traefik.http.routers.alfrescomicrometer.rule=PathRegexp(`^/alfresco/(wc)?s(ervice)?/prometheus`)"
+      - "traefik.http.middlewares.prometheusipfilter.ipallowlist.sourcerange=127.0.0.0/8"
+      - "traefik.http.routers.alfrescomicrometer.middlewares=prometheusipfilter@docker"
   transform-router:
     mem_limit: 512m
     image: quay.io/alfresco/alfresco-transform-router:4.1.5-A1
@@ -107,6 +117,8 @@ services:
     image: quay.io/alfresco/alfresco-share:23.4.0-M1
     mem_limit: 1g
     environment:
+      CSRF_FILTER_ORIGIN: http://localhost:8080
+      CSRF_FILTER_REFERER: http://localhost:8080/share/.*
       REPO_HOST: "alfresco"
       REPO_PORT: "8080"
       JAVA_OPTS: >-
@@ -116,6 +128,13 @@ services:
         -Dalfresco.port=8080
         -Dalfresco.context=alfresco
         -Dalfresco.protocol=http
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.share.rule=PathPrefix(`/share`)"
+      - "traefik.http.services.share.loadbalancer.server.port=8080"
+      - "traefik.http.routers.proxiedsolrapideny.rule=PathRegexp(`^/share/proxy/alfresco(-(noauth|feed|api))?/api/solr/`)"
+      - "traefik.http.middlewares.sharefakeauth.basicauth.users=fake:"
+      - "traefik.http.routers.proxiedsolrapideny.middlewares=sharefakeauth@docker"
   postgres:
     image: postgres:14.4
     mem_limit: 512m
@@ -147,8 +166,10 @@ services:
     image: quay.io/alfresco/alfresco-elasticsearch-live-indexing:4.1.0
     mem_limit: 1g
     depends_on:
-      - elasticsearch
-      - alfresco
+      elasticsearch:
+        condition: service_started
+      search-reindexing:
+        condition: service_completed_successfully
     environment:
       ALFRESCO_ACCEPTED_CONTENT_MEDIA_TYPES_CACHE_BASE_URL: >-
         http://transform-core-aio:8090/transform/config
@@ -193,6 +214,14 @@ services:
       APP_CONFIG_PLUGIN_PROCESS_SERVICE: "false"
       APP_CONFIG_PLUGIN_MICROSOFT_ONLINE: "false"
       APP_BASE_SHARE_URL: "http://localhost:8080/workspace/#/preview/s"
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.adw.rule=PathPrefix(`/workspace`)"
+      - "traefik.http.middlewares.adwforceslash.redirectregex.regex=^(.*/workspace)$$"
+      - "traefik.http.middlewares.adwforceslash.redirectregex.replacement=$${1}/"
+      - "traefik.http.middlewares.adwroot.stripprefix.prefixes=/workspace"
+      - "traefik.http.middlewares.adwchain.chain.middlewares=adwforceslash,adwroot"
+      - "traefik.http.routers.adw.middlewares=adwchain@docker"
   control-center:
     image: quay.io/alfresco/alfresco-control-center:9.1.0-11106981658
     mem_limit: 128m
@@ -200,6 +229,14 @@ services:
       APP_CONFIG_PROVIDER: "ECM"
       APP_CONFIG_AUTH_TYPE: "BASIC"
       BASE_PATH: ./
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.acc.rule=PathPrefix(`/admin`)"
+      - "traefik.http.middlewares.accroot.stripprefix.prefixes=/admin"
+      - "traefik.http.middlewares.accforceslash.redirectregex.regex=^(.*/admin)$$"
+      - "traefik.http.middlewares.accforceslash.redirectregex.replacement=$${1}/"
+      - "traefik.http.middlewares.accchain.chain.middlewares=accforceslash,accroot"
+      - "traefik.http.routers.acc.middlewares=accchain@docker"
   proxy:
     image: traefik:v3
     mem_limit: 128m
@@ -234,6 +271,13 @@ services:
         -XX:MaxRAMPercentage=80
     ports:
       - "9090:9090"
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.syncservice.rule=PathPrefix(`/syncservice`)"
+      - "traefik.http.services.sync-service.loadbalancer.server.port=9090"
+      - "traefik.http.middlewares.syncservice.replacepathregex.regex=^/syncservice/(.*)"
+      - "traefik.http.middlewares.syncservice.replacepathregex.replacement=/alfresco/$$1"
+      - "traefik.http.routers.syncservice.middlewares=syncservice@docker"
 volumes:
   shared-file-store-volume:
     driver_opts:

--- a/docker-compose/pre-release-docker-compose.yml
+++ b/docker-compose/pre-release-docker-compose.yml
@@ -180,7 +180,7 @@ services:
   search-reindexing:
     image: quay.io/alfresco/alfresco-elasticsearch-reindexing:4.1.0
     mem_limit: 1g
-    restart: on-failure:10
+    restart: on-failure:5
     environment:
       ALFRESCO_ACCEPTED_CONTENT_MEDIA_TYPES_CACHE_BASE_URL: >-
         http://transform-core-aio:8090/transform/config

--- a/docker-compose/pre-release-docker-compose.yml
+++ b/docker-compose/pre-release-docker-compose.yml
@@ -238,7 +238,7 @@ services:
       - "traefik.http.middlewares.accchain.chain.middlewares=accforceslash,accroot"
       - "traefik.http.routers.acc.middlewares=accchain@docker"
   proxy:
-    image: traefik:v3
+    image: traefik:3.1
     mem_limit: 128m
     command:
       - "--api.insecure=true"

--- a/docker-compose/pre-release-docker-compose.yml
+++ b/docker-compose/pre-release-docker-compose.yml
@@ -204,15 +204,22 @@ services:
       APP_CONFIG_AUTH_TYPE: "BASIC"
       BASE_PATH: ./
   proxy:
-    image: alfresco/alfresco-acs-nginx:3.4.2
+    image: traefik:v3
     mem_limit: 128m
+    command:
+      - "--api.insecure=true"
+      - "--providers.docker=true"
+      - "--entrypoints.web.address=:8080"
+      - "--entryPoints.traefik.address=:8888"
+      - "--accesslog=true"
+      - "--providers.docker.exposedByDefault=false"
     ports:
       - "8080:8080"
-    depends_on:
-      - digital-workspace
-      - alfresco
-      - share
-      - control-center
+      - "8888:8888"
+    security_opt:
+      - label=disable
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
   sync-service:
     image: quay.io/alfresco/service-sync:5.1.0-M2
     mem_limit: 1g

--- a/docker-compose/pre-release-docker-compose.yml
+++ b/docker-compose/pre-release-docker-compose.yml
@@ -251,7 +251,7 @@ services:
       - "8080:8080"
       - "8888:8888"
     security_opt:
-      - label=disable
+      - label=disable # Required for accessing the Docker socket on Selinux enabled systems
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
   sync-service:

--- a/docker-compose/solr6-override-docker-compose.yml
+++ b/docker-compose/solr6-override-docker-compose.yml
@@ -1,6 +1,5 @@
 # Check documentation below if need help using this file:
 # https://github.com/Alfresco/acs-deployment/tree/master/docs/docker-compose#choosing-a-search-engine
-version: "2"
 services:
   alfresco:
     environment:


### PR DESCRIPTION
* Fix privileged requirement due to podman selinux restrictions
  * Drop selinux labeling to allow accessing /var/run/docker.sock under podman
* Fix pre-release still including old acs-nginx
* Drop deprecated version tag
* Exclude kics findings for known issues which are fine for testing environments