### PR TITLE
Add community-specific dtas configuration to integration values

### DIFF
--- a/test/community-integration-test-values.yaml
+++ b/test/community-integration-test-values.yaml
@@ -92,3 +92,8 @@ postgresql:
         memory: "1Gi"
 dtas:
   enabled: true
+  config:
+    assertions:
+      acs:
+        edition: Community
+      adw: null


### PR DESCRIPTION
basic assertions would fail otherwise with community edition