### PR TITLE
OPSEXP-3005 Document using specific version of ingress-nginx to avoid breakage

### DIFF
--- a/docs/helm/ingress-nginx.md
+++ b/docs/helm/ingress-nginx.md
@@ -31,7 +31,7 @@ kubectl -n ingress-nginx patch cm ingress-nginx-controller \
 ```
 
 :warning: For latests versions of nginx it is required to use
-`"annotations-risk-level":"Critical"`, see: this
+`"annotations-risk-level":"Critical"`, see this
 [issue](https://github.com/kubernetes/ingress-nginx/issues/12618)
 
 Wait for the ingress-nginx controller to be up again after the configuration change:

--- a/docs/helm/ingress-nginx.md
+++ b/docs/helm/ingress-nginx.md
@@ -18,8 +18,11 @@ Install the ingress-nginx controller namespace:
 ```bash
 helm upgrade --install ingress-nginx ingress-nginx \
 --repo https://kubernetes.github.io/ingress-nginx \
---namespace ingress-nginx --create-namespace
+--namespace ingress-nginx --create-namespace \
+--version 4.7.2
 ```
+
+### Ingress configmap patch
 
 Enable snippet annotations which is disabled by default for security reasons, but
 we still requires it for `alfresco-search-services` while still filtering only
@@ -27,10 +30,10 @@ the ones we strictly need.
 
 ```bash
 kubectl -n ingress-nginx patch cm ingress-nginx-controller \
--p '{"data": {"annotations-risk-level":"Critical", "allow-snippet-annotations":"true"}}'
+-p '{"data": {"allow-snippet-annotations":"true"}}'
 ```
 
-:warning: Since nginx controller v1.12 or ingress-nginx helm chart v4.12 use
+:warning: Since nginx controller v1.12 or ingress-nginx helm chart v4.12.0 use
 `"annotations-risk-level":"Critical"`. For versions prior to that use
 `"allow-snippet-annotations":"true"`
 

--- a/docs/helm/ingress-nginx.md
+++ b/docs/helm/ingress-nginx.md
@@ -24,9 +24,12 @@ helm upgrade --install ingress-nginx ingress-nginx \
 
 ### Ingress configmap patch
 
-Enable snippet annotations which is disabled by default for security reasons, but
-we still requires it for `alfresco-search-services` while still filtering only
-the ones we strictly need.
+:warning: With ingress chart version 4.7.2 snippet annotations are enabled by default. You
+can skip patching.
+
+Enable snippet annotations which are disabled by default in newer versions of
+ingress chart for security reasons, but we still require it for
+`alfresco-search-services` while still filtering only the ones we strictly need.
 
 ```bash
 kubectl -n ingress-nginx patch cm ingress-nginx-controller \

--- a/docs/helm/ingress-nginx.md
+++ b/docs/helm/ingress-nginx.md
@@ -19,7 +19,8 @@ Install the ingress-nginx controller namespace:
 helm upgrade --install ingress-nginx ingress-nginx \
 --repo https://kubernetes.github.io/ingress-nginx \
 --namespace ingress-nginx --create-namespace \
---version 4.7.2
+--version 4.7.2 \
+--set controller.allowSnippetAnnotations=true
 ```
 
 Wait for the ingress-nginx controller:
@@ -35,16 +36,6 @@ Verify the newly created pod under the ingress-nginx namespace:
 
 ```sh
 kubectl get pods --namespace=ingress-nginx
-```
-
-### Optional patching
-
-Since nginx controller v1.12 or ingress-nginx helm chart v4.12.0 use
-`"annotations-risk-level":"Critical"`.
-
-```bash
-kubectl -n ingress-nginx patch cm ingress-nginx-controller \
--p '{"data": {"annotations-risk-level":"Critical"}}'
 ```
 
 More information can be found in the

--- a/docs/helm/ingress-nginx.md
+++ b/docs/helm/ingress-nginx.md
@@ -27,8 +27,12 @@ the ones we strictly need.
 
 ```bash
 kubectl -n ingress-nginx patch cm ingress-nginx-controller \
--p '{"data": {"allow-snippet-annotations":"true"}}'
+-p '{"data": {"annotations-risk-level":"Critical", "allow-snippet-annotations":"true"}}'
 ```
+
+:warning: For latests versions of nginx it is required to use
+`"annotations-risk-level":"Critical"`, see: this
+[issue](https://github.com/kubernetes/ingress-nginx/issues/12618)
 
 Wait for the ingress-nginx controller to be up again after the configuration change:
 

--- a/docs/helm/ingress-nginx.md
+++ b/docs/helm/ingress-nginx.md
@@ -22,25 +22,7 @@ helm upgrade --install ingress-nginx ingress-nginx \
 --version 4.7.2
 ```
 
-### Ingress configmap patch
-
-:warning: With ingress chart version 4.7.2 snippet annotations are enabled by default. You
-can skip patching.
-
-Enable snippet annotations which are disabled by default in newer versions of
-ingress chart for security reasons, but we still require it for
-`alfresco-search-services` while still filtering only the ones we strictly need.
-
-```bash
-kubectl -n ingress-nginx patch cm ingress-nginx-controller \
--p '{"data": {"allow-snippet-annotations":"true"}}'
-```
-
-:warning: Since nginx controller v1.12 or ingress-nginx helm chart v4.12.0 use
-`"annotations-risk-level":"Critical"`. For versions prior to that use
-`"allow-snippet-annotations":"true"`
-
-Wait for the ingress-nginx controller to be up again after the configuration change:
+Wait for the ingress-nginx controller:
 
 ```sh
 kubectl wait --namespace ingress-nginx \
@@ -53,6 +35,16 @@ Verify the newly created pod under the ingress-nginx namespace:
 
 ```sh
 kubectl get pods --namespace=ingress-nginx
+```
+
+### Optional patching
+
+Since nginx controller v1.12 or ingress-nginx helm chart v4.12.0 use
+`"annotations-risk-level":"Critical"`.
+
+```bash
+kubectl -n ingress-nginx patch cm ingress-nginx-controller \
+-p '{"data": {"annotations-risk-level":"Critical"}}'
 ```
 
 More information can be found in the

--- a/docs/helm/ingress-nginx.md
+++ b/docs/helm/ingress-nginx.md
@@ -30,7 +30,7 @@ kubectl -n ingress-nginx patch cm ingress-nginx-controller \
 -p '{"data": {"annotations-risk-level":"Critical", "allow-snippet-annotations":"true"}}'
 ```
 
-:warning: For latests versions of nginx it is required to use
+:warning: For latest versions of nginx it is required to use
 `"annotations-risk-level":"Critical"`, see this
 [issue](https://github.com/kubernetes/ingress-nginx/issues/12618)
 

--- a/docs/helm/ingress-nginx.md
+++ b/docs/helm/ingress-nginx.md
@@ -30,9 +30,9 @@ kubectl -n ingress-nginx patch cm ingress-nginx-controller \
 -p '{"data": {"annotations-risk-level":"Critical", "allow-snippet-annotations":"true"}}'
 ```
 
-:warning: For latest versions of nginx it is required to use
-`"annotations-risk-level":"Critical"`, see this
-[issue](https://github.com/kubernetes/ingress-nginx/issues/12618)
+:warning: Since nginx controller v1.12 or ingress-nginx helm chart v4.12 use
+`"annotations-risk-level":"Critical"`. For versions prior to that use
+`"allow-snippet-annotations":"true"`
 
 Wait for the ingress-nginx controller to be up again after the configuration change:
 

--- a/docs/helm/kind-deployment.md
+++ b/docs/helm/kind-deployment.md
@@ -56,16 +56,25 @@ Wait for the Kind cluster to be created. This may take a few minutes.
 
 ## Step 3: Install patched ingress-nginx
 
-Follow the instructions for
-[deploying nginx ingress on KinD](https://kind.sigs.k8s.io/docs/user/ingress/#ingress-nginx).
+Install the ingress-nginx controller namespace:
+
+```bash
+helm upgrade --install ingress-nginx ingress-nginx \
+--repo https://kubernetes.github.io/ingress-nginx \
+--namespace ingress-nginx --create-namespace
+```
 
 Reconfigure ingress-nginx to allow snippet annotations that are still required
 when using our search services chart:
 
 ```sh
 kubectl -n ingress-nginx patch cm ingress-nginx-controller \
-  -p '{"data": {"annotations-risk-level":"Critical"}}'
+  -p '{"data": {"annotations-risk-level":"Critical", "allow-snippet-annotations":"true"}}'
 ```
+
+:warning: For latests versions of nginx it is required to use
+`"annotations-risk-level":"Critical"`, see: this
+[issue](https://github.com/kubernetes/ingress-nginx/issues/12618)
 
 Wait for the ingress-nginx controller to be up again after the configuration change:
 

--- a/docs/helm/kind-deployment.md
+++ b/docs/helm/kind-deployment.md
@@ -67,8 +67,8 @@ annotations are allowed by default. You can skip below steps. Verify if ingress
 configmap has those settings when running different versions.
 
 Reconfigure ingress-nginx to allow snippet annotations that are still required
-when using our search services chart. Follow steps from [ingress-nginx
-docs](./ingress-nginx.md#ingress-configmap-patch)
+when using our search services chart. Follow steps from
+[ingress-nginx docs](./ingress-nginx.md#ingress-configmap-patch)
 
 ## Install metrics server
 

--- a/docs/helm/kind-deployment.md
+++ b/docs/helm/kind-deployment.md
@@ -54,7 +54,7 @@ EOF
 
 Wait for the Kind cluster to be created. This may take a few minutes.
 
-## Step 3: Install patched ingress-nginx
+## Step 3: Install ingress-nginx
 
 Install the ingress-nginx controller namespace:
 
@@ -62,13 +62,8 @@ Install the ingress-nginx controller namespace:
 kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.8.2/deploy/static/provider/kind/deploy.yaml
 ```
 
-:warning: When running above command with version controller-v1.8.2 snippet
-annotations are allowed by default. You can skip below steps. Verify if ingress
-configmap has those settings when running different versions.
-
-Reconfigure ingress-nginx to allow snippet annotations that are still required
-when using our search services chart. Follow steps from
-[ingress-nginx docs](./ingress-nginx.md#ingress-configmap-patch)
+Check [optional patching](./ingress-nginx.md#optional-patching) when applying
+controller with version v1.12 or newer.
 
 ## Install metrics server
 

--- a/docs/helm/kind-deployment.md
+++ b/docs/helm/kind-deployment.md
@@ -72,7 +72,7 @@ kubectl -n ingress-nginx patch cm ingress-nginx-controller \
   -p '{"data": {"annotations-risk-level":"Critical", "allow-snippet-annotations":"true"}}'
 ```
 
-:warning: For latests versions of nginx it is required to use
+:warning: For latest versions of nginx it is required to use
 `"annotations-risk-level":"Critical"`, see this
 [issue](https://github.com/kubernetes/ingress-nginx/issues/12618)
 

--- a/docs/helm/kind-deployment.md
+++ b/docs/helm/kind-deployment.md
@@ -59,9 +59,7 @@ Wait for the Kind cluster to be created. This may take a few minutes.
 Install the ingress-nginx controller namespace:
 
 ```bash
-helm upgrade --install ingress-nginx ingress-nginx \
---repo https://kubernetes.github.io/ingress-nginx \
---namespace ingress-nginx --create-namespace
+kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.8.2/deploy/static/provider/kind/deploy.yaml
 ```
 
 Reconfigure ingress-nginx to allow snippet annotations that are still required
@@ -69,12 +67,12 @@ when using our search services chart:
 
 ```sh
 kubectl -n ingress-nginx patch cm ingress-nginx-controller \
-  -p '{"data": {"annotations-risk-level":"Critical", "allow-snippet-annotations":"true"}}'
+  -p '{"data": {"allow-snippet-annotations":"true"}}'
 ```
 
-:warning: For latest versions of nginx it is required to use
-`"annotations-risk-level":"Critical"`, see this
-[issue](https://github.com/kubernetes/ingress-nginx/issues/12618)
+:warning: Since nginx controller v1.12 use
+`"annotations-risk-level":"Critical"`. For versions prior to that use
+`"allow-snippet-annotations":"true"`
 
 Wait for the ingress-nginx controller to be up again after the configuration change:
 

--- a/docs/helm/kind-deployment.md
+++ b/docs/helm/kind-deployment.md
@@ -62,26 +62,13 @@ Install the ingress-nginx controller namespace:
 kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.8.2/deploy/static/provider/kind/deploy.yaml
 ```
 
+:warning: When running above command with version controller-v1.8.2 snippet
+annotations are allowed by default. You can skip below steps. Verify if ingress
+configmap has those settings when running different versions.
+
 Reconfigure ingress-nginx to allow snippet annotations that are still required
-when using our search services chart:
-
-```sh
-kubectl -n ingress-nginx patch cm ingress-nginx-controller \
-  -p '{"data": {"allow-snippet-annotations":"true"}}'
-```
-
-:warning: Since nginx controller v1.12 use
-`"annotations-risk-level":"Critical"`. For versions prior to that use
-`"allow-snippet-annotations":"true"`
-
-Wait for the ingress-nginx controller to be up again after the configuration change:
-
-```sh
-kubectl wait --namespace ingress-nginx \
-  --for=condition=ready pod \
-  --selector=app.kubernetes.io/component=controller \
-  --timeout=90s
-```
+when using our search services chart. Follow steps from [ingress-nginx
+docs](./ingress-nginx.md#ingress-configmap-patch)
 
 ## Install metrics server
 

--- a/docs/helm/kind-deployment.md
+++ b/docs/helm/kind-deployment.md
@@ -64,7 +64,7 @@ when using our search services chart:
 
 ```sh
 kubectl -n ingress-nginx patch cm ingress-nginx-controller \
-  -p '{"data": {"allow-snippet-annotations":"true"}}'
+  -p '{"data": {"annotations-risk-level":"Critical"}}'
 ```
 
 Wait for the ingress-nginx controller to be up again after the configuration change:

--- a/docs/helm/kind-deployment.md
+++ b/docs/helm/kind-deployment.md
@@ -73,7 +73,7 @@ kubectl -n ingress-nginx patch cm ingress-nginx-controller \
 ```
 
 :warning: For latests versions of nginx it is required to use
-`"annotations-risk-level":"Critical"`, see: this
+`"annotations-risk-level":"Critical"`, see this
 [issue](https://github.com/kubernetes/ingress-nginx/issues/12618)
 
 Wait for the ingress-nginx controller to be up again after the configuration change:

--- a/docs/helm/kind-deployment.md
+++ b/docs/helm/kind-deployment.md
@@ -62,8 +62,14 @@ Install the ingress-nginx controller namespace:
 kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.8.2/deploy/static/provider/kind/deploy.yaml
 ```
 
-Check [optional patching](./ingress-nginx.md#optional-patching) when applying
-controller with version v1.12 or newer.
+Wait for the ingress-nginx controller:
+
+```sh
+kubectl wait --namespace ingress-nginx \
+--for=condition=ready pod \
+--selector=app.kubernetes.io/component=controller \
+--timeout=90s
+```
 
 ## Install metrics server
 


### PR DESCRIPTION
Ref: OPSEXP-3005 
https://github.com/kubernetes/ingress-nginx/issues/12618

They changed the behavior of `{"allow-snippet-annotations":"true"}}'` - it seems like it doesn't work anymore
Currently even with this set to true we will get: 
```
        * admission webhook "validate.nginx.ingress.kubernetes.io" denied the request: annotation group ServerSnippet contains risky annotation based on ingress configuration
        * admission webhook "validate.nginx.ingress.kubernetes.io" denied the request: annotation group ServerSnippet contains risky annotation based on ingress configuration
```
It is required to change it to ` {"annotations-risk-level":"Critical"}}' `