### PR TITLE
OPSEXP-3069 Switch to latest default runners

### DIFF
--- a/.github/workflows/helm-enterprise.yml
+++ b/.github/workflows/helm-enterprise.yml
@@ -134,7 +134,7 @@ jobs:
           ${{ steps.configurable-extra-values.outputs.helm_install_params }}
 
       - name: Wait for pods to be ready
-        uses: Alfresco/alfresco-build-tools/.github/actions/kubectl-wait@OPSEXP-3069-kubectl-wait
+        uses: Alfresco/alfresco-build-tools/.github/actions/kubectl-wait@v8.15.0
 
       - name: Spit cluster status after install
         if: always()

--- a/.github/workflows/helm-enterprise.yml
+++ b/.github/workflows/helm-enterprise.yml
@@ -54,8 +54,8 @@ jobs:
           echo "json=$VERS" >> $GITHUB_OUTPUT
 
   helm_integration:
-    runs-on: alfrescoPub-ubuntu2204-16G-4CPU
-    timeout-minutes: 12
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
     needs:
       - build_vars
     name: ${{ matrix.values }} on ${{ matrix.name }}

--- a/.github/workflows/helm-enterprise.yml
+++ b/.github/workflows/helm-enterprise.yml
@@ -136,15 +136,15 @@ jobs:
       - name: Watch Helm deployment
         env:
           VALUES_FILE: ${{ matrix.values }}
-          WAIT_TIMEOUT: 7m
+          WAIT_TIMEOUT: 10m
           WAIT_TIMEOUT_REINDEXING: 7m
         run: |
           kubectl get pods --watch &
           KWPID=$!
-          kubectl wait --timeout=${{ env.WAIT_TIMEOUT }} --all=true --for=condition=Available deploy && kill $KWPID
+          kubectl wait --timeout=${{ env.WAIT_TIMEOUT }} --all=true --for=condition=Ready pods
+          kill $KWPID
           if [ "${VALUES_FILE:0:2}" != "7." ] ; then echo -n "Waiting for ESC Reindexing job to complete... "
             kubectl wait --timeout=${{ env.WAIT_TIMEOUT_REINDEXING }} --for=condition=complete job/acs-alfresco-search-enterprise-reindexing
-            echo "Completed."
           fi
 
       - name: Spit cluster status after install

--- a/.github/workflows/helm-enterprise.yml
+++ b/.github/workflows/helm-enterprise.yml
@@ -136,14 +136,13 @@ jobs:
       - name: Wait for pods to be ready
         uses: Alfresco/alfresco-build-tools/.github/actions/kubectl-wait@OPSEXP-3069-kubectl-wait
 
-      - name: Wait for reindexing job to complete
-        env:
-          VALUES_FILE: ${{ matrix.values }}
-          WAIT_TIMEOUT_REINDEXING: 5m
-        run: |
-          if [ "${VALUES_FILE:0:2}" != "7." ] ; then echo -n "Waiting for ESC Reindexing job to complete... "
-            kubectl wait --timeout=${{ env.WAIT_TIMEOUT_REINDEXING }} --for=condition=complete job/acs-alfresco-search-enterprise-reindexing
-          fi
+      - name: Wait for reindex job
+        uses: Alfresco/alfresco-build-tools/.github/actions/kubectl-wait@OPSEXP-3069-kubectl-wait
+        if: ! startsWith(matrix.values, '7.')
+        with:
+          wait-condition: complete
+          wait-resource: job/acs-alfresco-search-enterprise-reindexing
+          wait-timeout: 5m
 
       - name: Spit cluster status after install
         if: always()

--- a/.github/workflows/helm-enterprise.yml
+++ b/.github/workflows/helm-enterprise.yml
@@ -136,12 +136,14 @@ jobs:
       - name: Watch Helm deployment
         env:
           VALUES_FILE: ${{ matrix.values }}
+          WAIT_TIMEOUT: 7m
+          WAIT_TIMEOUT_REINDEXING: 7m
         run: |
           kubectl get pods --watch &
           KWPID=$!
-          kubectl wait --timeout=7m --all=true --for=condition=Available deploy && kill $KWPID
+          kubectl wait --timeout=${{ env.WAIT_TIMEOUT }} --all=true --for=condition=Available deploy && kill $KWPID
           if [ "${VALUES_FILE:0:2}" != "7." ] ; then echo -n "Waiting for ESC Reindexing job to complete... "
-            kubectl wait --timeout=5m --for=condition=complete job/acs-alfresco-search-enterprise-reindexing
+            kubectl wait --timeout=${{ env.WAIT_TIMEOUT_REINDEXING }} --for=condition=complete job/acs-alfresco-search-enterprise-reindexing
             echo "Completed."
           fi
 

--- a/.github/workflows/helm-enterprise.yml
+++ b/.github/workflows/helm-enterprise.yml
@@ -133,16 +133,14 @@ jobs:
           ${{ steps.cgroupv2-workaround-extra-values.outputs.helm_install_params }}
           ${{ steps.configurable-extra-values.outputs.helm_install_params }}
 
-      - name: Watch Helm deployment
+      - name: Wait for pods to be ready
+        uses: Alfresco/alfresco-build-tools/.github/actions/kubectl-wait@OPSEXP-3069-kubectl-wait
+
+      - name: Wait for reindexing job to complete
         env:
           VALUES_FILE: ${{ matrix.values }}
-          WAIT_TIMEOUT: 10m
-          WAIT_TIMEOUT_REINDEXING: 7m
+          WAIT_TIMEOUT_REINDEXING: 5m
         run: |
-          kubectl get pods --watch &
-          KWPID=$!
-          kubectl wait --timeout=${{ env.WAIT_TIMEOUT }} --all=true --for=condition=Ready pods
-          kill $KWPID
           if [ "${VALUES_FILE:0:2}" != "7." ] ; then echo -n "Waiting for ESC Reindexing job to complete... "
             kubectl wait --timeout=${{ env.WAIT_TIMEOUT_REINDEXING }} --for=condition=complete job/acs-alfresco-search-enterprise-reindexing
           fi
@@ -152,7 +150,6 @@ jobs:
         run: |
           helm ls --all-namespaces --all
           helm status acs --show-resources
-          kubectl describe pod
 
       - name: Run Newman tests
         uses: nick-fields/retry@c97818ca39074beaea45180dba704f92496a0082 # v3.0.1

--- a/.github/workflows/helm-enterprise.yml
+++ b/.github/workflows/helm-enterprise.yml
@@ -136,14 +136,6 @@ jobs:
       - name: Wait for pods to be ready
         uses: Alfresco/alfresco-build-tools/.github/actions/kubectl-wait@OPSEXP-3069-kubectl-wait
 
-      - name: Wait for reindex job
-        uses: Alfresco/alfresco-build-tools/.github/actions/kubectl-wait@OPSEXP-3069-kubectl-wait
-        if: ! startsWith(matrix.values, '7.')
-        with:
-          wait-condition: complete
-          wait-resource: job/acs-alfresco-search-enterprise-reindexing
-          wait-timeout: 5m
-
       - name: Spit cluster status after install
         if: always()
         run: |

--- a/test/enterprise-integration-test-values.yaml
+++ b/test/enterprise-integration-test-values.yaml
@@ -2,7 +2,7 @@
 alfresco-repository:
   resources:
     requests:
-      cpu: "0.5"
+      cpu: "0.01"
       memory: "1024Mi"
     limits:
       cpu: "2"
@@ -31,7 +31,7 @@ share:
 alfresco-search:
   resources:
     requests:
-      cpu: "0.25"
+      cpu: "0.01"
       memory: "512Mi"
     limits:
       cpu: "2"
@@ -40,7 +40,7 @@ elasticsearch:
   master:
     resources:
       requests:
-        cpu: "0.25"
+        cpu: "0.01"
         memory: "512Mi"
       limits:
         cpu: "1"
@@ -48,7 +48,7 @@ elasticsearch:
   kibana:
     resources:
       requests:
-        cpu: "0.25"
+        cpu: "0.01"
         memory: "512Mi"
       limits:
         cpu: "1"
@@ -58,7 +58,7 @@ alfresco-search-enterprise:
     hookExecution: false
   resources:
     requests:
-      cpu: "0.1"
+      cpu: "0.01"
       memory: "128Mi"
     limits:
       cpu: "1"
@@ -102,7 +102,7 @@ alfresco-transform-service:
       initialDelaySeconds: 30
     resources:
       requests:
-        cpu: "0.25"
+        cpu: "0.01"
         memory: "256Mi"
       limits:
         cpu: "2"
@@ -124,6 +124,9 @@ alfresco-transform-service:
   transformrouter:
     replicaCount: 1
     resources:
+      requests:
+        cpu: "0.01"
+        memory: "256Mi"
       limits:
         cpu: "2"
         memory: "800Mi"
@@ -137,7 +140,7 @@ postgresql:
   primary:
     resources:
       requests:
-        cpu: "0.5"
+        cpu: "0.01"
         memory: "1Gi"
       limits:
         cpu: "2"
@@ -163,7 +166,7 @@ alfresco-sync-service:
 activemq:
   resources:
     requests:
-      cpu: "0.1"
+      cpu: "0.01"
       memory: "512Mi"
 alfresco-digital-workspace:
   resources:

--- a/test/enterprise-integration-test-values.yaml
+++ b/test/enterprise-integration-test-values.yaml
@@ -66,7 +66,7 @@ alfresco-search-enterprise:
 alfresco-transform-service:
   pdfrenderer:
     livenessProbe:
-      initialDelaySeconds: 90
+      initialDelaySeconds: 120
     resources:
       requests:
         cpu: "0.01"
@@ -77,7 +77,7 @@ alfresco-transform-service:
     replicaCount: 1
   imagemagick:
     livenessProbe:
-      initialDelaySeconds: 90
+      initialDelaySeconds: 120
     resources:
       requests:
         cpu: "0.01"
@@ -88,7 +88,7 @@ alfresco-transform-service:
     replicaCount: 1
   libreoffice:
     livenessProbe:
-      initialDelaySeconds: 90
+      initialDelaySeconds: 120
     resources:
       requests:
         cpu: "0.01"
@@ -99,7 +99,7 @@ alfresco-transform-service:
     replicaCount: 1
   tika:
     livenessProbe:
-      initialDelaySeconds: 30
+      initialDelaySeconds: 120
     resources:
       requests:
         cpu: "0.01"
@@ -110,9 +110,7 @@ alfresco-transform-service:
     replicaCount: 1
   transformmisc:
     livenessProbe:
-      initialDelaySeconds: 30
-      periodSeconds: 60
-      timeoutSeconds: 15
+      initialDelaySeconds: 120
     resources:
       requests:
         cpu: "0.01"
@@ -122,7 +120,8 @@ alfresco-transform-service:
         memory: "512Mi"
     replicaCount: 1
   transformrouter:
-    replicaCount: 1
+    livenessProbe:
+      initialDelaySeconds: 60
     resources:
       requests:
         cpu: "0.01"
@@ -130,12 +129,7 @@ alfresco-transform-service:
       limits:
         cpu: "2"
         memory: "800Mi"
-    readinessProbe:
-      initialDelaySeconds: 40
-      timeoutSeconds: 20
-    livenessProbe:
-      initialDelaySeconds: 40
-      timeoutSeconds: 20
+    replicaCount: 1
 postgresql:
   primary:
     resources:
@@ -155,6 +149,8 @@ postgresql-sync: &postgresql-sync
         cpu: "2"
         memory: "1Gi"
 alfresco-sync-service:
+  livenessProbe:
+    initialDelaySeconds: 90
   resources:
     requests:
       cpu: "0.01"

--- a/test/enterprise-integration-test-values.yaml
+++ b/test/enterprise-integration-test-values.yaml
@@ -121,7 +121,7 @@ alfresco-transform-service:
     replicaCount: 1
   transformrouter:
     livenessProbe:
-      initialDelaySeconds: 60
+      initialDelaySeconds: 120
     resources:
       requests:
         cpu: "0.01"
@@ -150,7 +150,7 @@ postgresql-sync: &postgresql-sync
         memory: "1Gi"
 alfresco-sync-service:
   livenessProbe:
-    initialDelaySeconds: 90
+    initialDelaySeconds: 120
   resources:
     requests:
       cpu: "0.01"
@@ -188,6 +188,8 @@ alfresco-ai-transformer:
   livenessProbe:
     initialDelaySeconds: 120
 alfresco-audit-storage:
+  livenessProbe:
+    initialDelaySeconds: 120
   resources:
     requests:
       cpu: "0.01"


### PR DESCRIPTION
Makes test jobs reliable again.

Requires:
* https://github.com/Alfresco/alfresco-build-tools/pull/930

OPSEXP-3069