### PR TITLE
Fix enterprise compose/helm not using quay.io for docker images

### DIFF
--- a/docker-compose/7.2.N-compose.yaml
+++ b/docker-compose/7.2.N-compose.yaml
@@ -214,7 +214,7 @@ services:
     ports:
       - "8083:8983" # Browser port
   activemq:
-    image: alfresco/alfresco-activemq:5.17-jre17-rockylinux8
+    image: quay.io/alfresco/alfresco-activemq:5.17-jre17-rockylinux8
     mem_limit: 1g
     ports:
       - "8161:8161" # Web Console

--- a/docker-compose/7.2.N-compose.yaml
+++ b/docker-compose/7.2.N-compose.yaml
@@ -101,7 +101,7 @@ services:
       shared-file-store:
         condition: service_healthy
   transform-core-aio:
-    image: alfresco/alfresco-transform-core-aio:5.1.6
+    image: quay.io/alfresco/alfresco-transform-core-aio:5.1.6
     mem_limit: 1536m
     environment:
       JAVA_OPTS: >-

--- a/docker-compose/7.3.N-compose.yaml
+++ b/docker-compose/7.3.N-compose.yaml
@@ -206,7 +206,7 @@ services:
     ports:
       - "8083:8983" # Browser port
   activemq:
-    image: alfresco/alfresco-activemq:5.17-jre17-rockylinux8
+    image: quay.io/alfresco/alfresco-activemq:5.17-jre17-rockylinux8
     mem_limit: 1g
     ports:
       - "8161:8161" # Web Console

--- a/docker-compose/7.3.N-compose.yaml
+++ b/docker-compose/7.3.N-compose.yaml
@@ -96,7 +96,7 @@ services:
       shared-file-store:
         condition: service_healthy
   transform-core-aio:
-    image: alfresco/alfresco-transform-core-aio:5.1.6
+    image: quay.io/alfresco/alfresco-transform-core-aio:5.1.6
     mem_limit: 1536m
     environment:
       JAVA_OPTS: >-

--- a/docker-compose/7.4.N-compose.yaml
+++ b/docker-compose/7.4.N-compose.yaml
@@ -206,7 +206,7 @@ services:
     ports:
       - "8083:8983" # Browser port
   activemq:
-    image: alfresco/alfresco-activemq:5.17-jre17-rockylinux8
+    image: quay.io/alfresco/alfresco-activemq:5.17-jre17-rockylinux8
     mem_limit: 1g
     ports:
       - "8161:8161" # Web Console

--- a/docker-compose/7.4.N-compose.yaml
+++ b/docker-compose/7.4.N-compose.yaml
@@ -96,7 +96,7 @@ services:
       shared-file-store:
         condition: service_healthy
   transform-core-aio:
-    image: alfresco/alfresco-transform-core-aio:5.1.6
+    image: quay.io/alfresco/alfresco-transform-core-aio:5.1.6
     mem_limit: 1536m
     environment:
       JAVA_OPTS: >-

--- a/docker-compose/compose.yaml
+++ b/docker-compose/compose.yaml
@@ -94,7 +94,7 @@ services:
       shared-file-store:
         condition: service_healthy
   transform-core-aio:
-    image: alfresco/alfresco-transform-core-aio:5.1.6
+    image: quay.io/alfresco/alfresco-transform-core-aio:5.1.6
     mem_limit: 1536m
     environment:
       JAVA_OPTS: >-

--- a/docker-compose/compose.yaml
+++ b/docker-compose/compose.yaml
@@ -266,7 +266,7 @@ services:
       alfresco:
         condition: service_healthy
   activemq:
-    image: alfresco/alfresco-activemq:5.18-jre17-rockylinux8
+    image: quay.io/alfresco/alfresco-activemq:5.18-jre17-rockylinux8
     mem_limit: 1g
     ports:
       - "8161:8161" # Web Console

--- a/docker-compose/pre-release-compose.yaml
+++ b/docker-compose/pre-release-compose.yaml
@@ -94,7 +94,7 @@ services:
       shared-file-store:
         condition: service_healthy
   transform-core-aio:
-    image: alfresco/alfresco-transform-core-aio:5.1.6
+    image: quay.io/alfresco/alfresco-transform-core-aio:5.1.6
     mem_limit: 1536m
     environment:
       JAVA_OPTS: >-

--- a/docker-compose/pre-release-compose.yaml
+++ b/docker-compose/pre-release-compose.yaml
@@ -266,7 +266,7 @@ services:
       alfresco:
         condition: service_healthy
   activemq:
-    image: alfresco/alfresco-activemq:5.18-jre17-rockylinux8
+    image: quay.io/alfresco/alfresco-activemq:5.18-jre17-rockylinux8
     mem_limit: 1g
     ports:
       - "8161:8161" # Web Console

--- a/helm/alfresco-content-services/README.md
+++ b/helm/alfresco-content-services/README.md
@@ -179,22 +179,22 @@ Please refer to the [documentation](https://github.com/Alfresco/acs-deployment/b
 | alfresco-transform-service.filestore.replicaCount | int | `1` | To have more than 1 replica persistence should support `ReadWriteMany` access mode |
 | alfresco-transform-service.filestore.strategy.type | string | `"Recreate"` | Strategy must be set to Recreate when persistence supports only `ReadWriteOnce` access mode. If `ReadWriteMany` is supported, then it can be set to RollingUpdate. |
 | alfresco-transform-service.imagemagick.enabled | bool | `true` | Declares the alfresco-imagemagick service used by the content repository to transform image files |
-| alfresco-transform-service.imagemagick.image.repository | string | `"alfresco/alfresco-imagemagick"` |  |
+| alfresco-transform-service.imagemagick.image.repository | string | `"quay.io/alfresco/alfresco-imagemagick"` |  |
 | alfresco-transform-service.imagemagick.image.tag | string | `"5.1.6"` |  |
 | alfresco-transform-service.libreoffice.enabled | bool | `true` | Declares the alfresco-libreoffice service used by the content repository to transform office files |
-| alfresco-transform-service.libreoffice.image.repository | string | `"alfresco/alfresco-libreoffice"` |  |
+| alfresco-transform-service.libreoffice.image.repository | string | `"quay.io/alfresco/alfresco-libreoffice"` |  |
 | alfresco-transform-service.libreoffice.image.tag | string | `"5.1.6"` |  |
 | alfresco-transform-service.messageBroker.existingConfigMap.name | string | `"alfresco-infrastructure"` | Name of the configmap which holds the ATS shared filestore URL |
 | alfresco-transform-service.messageBroker.existingSecret.name | string | `"acs-alfresco-cs-brokersecret"` |  |
 | alfresco-transform-service.nameOverride | string | `"alfresco-transform-service"` |  |
 | alfresco-transform-service.pdfrenderer.enabled | bool | `true` | Declares the alfresco-pdf-renderer service used by the content repository to transform pdf files |
-| alfresco-transform-service.pdfrenderer.image.repository | string | `"alfresco/alfresco-pdf-renderer"` |  |
+| alfresco-transform-service.pdfrenderer.image.repository | string | `"quay.io/alfresco/alfresco-pdf-renderer"` |  |
 | alfresco-transform-service.pdfrenderer.image.tag | string | `"5.1.6"` |  |
 | alfresco-transform-service.tika.enabled | bool | `true` | Declares the alfresco-tika service used by the content repository to transform office files |
-| alfresco-transform-service.tika.image.repository | string | `"alfresco/alfresco-tika"` |  |
+| alfresco-transform-service.tika.image.repository | string | `"quay.io/alfresco/alfresco-tika"` |  |
 | alfresco-transform-service.tika.image.tag | string | `"5.1.6"` |  |
 | alfresco-transform-service.transformmisc.enabled | bool | `true` | Declares the alfresco-tika service used by the content repository to transform office files |
-| alfresco-transform-service.transformmisc.image.repository | string | `"alfresco/alfresco-transform-misc"` |  |
+| alfresco-transform-service.transformmisc.image.repository | string | `"quay.io/alfresco/alfresco-transform-misc"` |  |
 | alfresco-transform-service.transformmisc.image.tag | string | `"5.1.6"` |  |
 | alfresco-transform-service.transformrouter.enabled | bool | `true` | Declares the alfresco-transform-router service used by the content repository to route transformation requests |
 | alfresco-transform-service.transformrouter.image.repository | string | `"quay.io/alfresco/alfresco-transform-router"` |  |

--- a/helm/alfresco-content-services/community_values.yaml
+++ b/helm/alfresco-content-services/community_values.yaml
@@ -37,14 +37,24 @@ alfresco-transform-service:
     enabled: false
   pdfrenderer:
     replicaCount: 1
+    image:
+      repository: alfresco/alfresco-pdf-renderer
   imagemagick:
     replicaCount: 1
+    image:
+      repository: alfresco/alfresco-imagemagick
   libreoffice:
     replicaCount: 1
+    image:
+      repository: alfresco/alfresco-libreoffice
   tika:
     replicaCount: 1
+    image:
+      repository: alfresco/alfresco-tika
   transformmisc:
     replicaCount: 1
+    image:
+      repository: alfresco/alfresco-transform-misc
   filestore:
     enabled: false
 alfresco-digital-workspace:

--- a/helm/alfresco-content-services/values.yaml
+++ b/helm/alfresco-content-services/values.yaml
@@ -242,35 +242,35 @@ alfresco-transform-service:
     # to transform pdf files
     enabled: true
     image:
-      repository: alfresco/alfresco-pdf-renderer
+      repository: quay.io/alfresco/alfresco-pdf-renderer
       tag: 5.1.6
   imagemagick:
     # -- Declares the alfresco-imagemagick service used by the content repository
     # to transform image files
     enabled: true
     image:
-      repository: alfresco/alfresco-imagemagick
+      repository: quay.io/alfresco/alfresco-imagemagick
       tag: 5.1.6
   libreoffice:
     # -- Declares the alfresco-libreoffice service used by the content repository
     # to transform office files
     enabled: true
     image:
-      repository: alfresco/alfresco-libreoffice
+      repository: quay.io/alfresco/alfresco-libreoffice
       tag: 5.1.6
   tika:
     # -- Declares the alfresco-tika service used by the content repository
     # to transform office files
     enabled: true
     image:
-      repository: alfresco/alfresco-tika
+      repository: quay.io/alfresco/alfresco-tika
       tag: 5.1.6
   transformmisc:
     # -- Declares the alfresco-tika service used by the content repository
     # to transform office files
     enabled: true
     image:
-      repository: alfresco/alfresco-transform-misc
+      repository: quay.io/alfresco/alfresco-transform-misc
       tag: 5.1.6
   filestore:
     # -- Declares the alfresco-shared-file-store used by the content repository


### PR DESCRIPTION
Avoid using Docker Hub for enterprise flavors of compose/helm.