### PR TITLE
OPSEXP-3109 Provide anonymous volumes for alfresco content store and sfs

### DIFF
--- a/docker-compose/7.2.N-compose.yaml
+++ b/docker-compose/7.2.N-compose.yaml
@@ -145,7 +145,7 @@ services:
       retries: 3
       start_period: 10s
     volumes:
-      - shared-file-store-volume:/tmp/Alfresco
+      - /tmp/Alfresco
   share:
     image: quay.io/alfresco/alfresco-share:7.2.2.5
     mem_limit: 1g

--- a/docker-compose/7.2.N-compose.yaml
+++ b/docker-compose/7.2.N-compose.yaml
@@ -75,6 +75,8 @@ services:
       - "traefik.http.routers.alfrescomicrometer.rule=PathRegexp(`^/alfresco/(wc)?s(ervice)?/prometheus`)"
       - "traefik.http.middlewares.prometheusipfilter.ipallowlist.sourcerange=127.0.0.0/8"
       - "traefik.http.routers.alfrescomicrometer.middlewares=prometheusipfilter@docker"
+    volumes:
+      - /usr/local/tomcat/alf_data
   transform-router:
     mem_limit: 512m
     image: quay.io/alfresco/alfresco-transform-router:4.1.6

--- a/docker-compose/7.3.N-compose.yaml
+++ b/docker-compose/7.3.N-compose.yaml
@@ -138,7 +138,7 @@ services:
       retries: 3
       start_period: 10s
     volumes:
-      - shared-file-store-volume:/tmp/Alfresco
+      - /tmp/Alfresco
   share:
     image: quay.io/alfresco/alfresco-share:7.3.2.3
     mem_limit: 1g

--- a/docker-compose/7.3.N-compose.yaml
+++ b/docker-compose/7.3.N-compose.yaml
@@ -71,6 +71,8 @@ services:
       - "traefik.http.routers.alfrescomicrometer.rule=PathRegexp(`^/alfresco/(wc)?s(ervice)?/prometheus`)"
       - "traefik.http.middlewares.prometheusipfilter.ipallowlist.sourcerange=127.0.0.0/8"
       - "traefik.http.routers.alfrescomicrometer.middlewares=prometheusipfilter@docker"
+    volumes:
+      - /usr/local/tomcat/alf_data
   transform-router:
     mem_limit: 512m
     image: quay.io/alfresco/alfresco-transform-router:4.1.6

--- a/docker-compose/7.4.N-compose.yaml
+++ b/docker-compose/7.4.N-compose.yaml
@@ -71,6 +71,8 @@ services:
       - "traefik.http.routers.alfrescomicrometer.rule=PathRegexp(`^/alfresco/(wc)?s(ervice)?/prometheus`)"
       - "traefik.http.middlewares.prometheusipfilter.ipallowlist.sourcerange=127.0.0.0/8"
       - "traefik.http.routers.alfrescomicrometer.middlewares=prometheusipfilter@docker"
+    volumes:
+      - /usr/local/tomcat/alf_data
   transform-router:
     mem_limit: 512m
     image: quay.io/alfresco/alfresco-transform-router:4.1.6

--- a/docker-compose/7.4.N-compose.yaml
+++ b/docker-compose/7.4.N-compose.yaml
@@ -138,7 +138,7 @@ services:
       retries: 3
       start_period: 10s
     volumes:
-      - shared-file-store-volume:/tmp/Alfresco
+      - /tmp/Alfresco
   share:
     image: quay.io/alfresco/alfresco-share:7.4.2.4
     mem_limit: 1g

--- a/docker-compose/community-compose.yaml
+++ b/docker-compose/community-compose.yaml
@@ -59,6 +59,8 @@ services:
       - "traefik.http.routers.solrapideny.rule=PathRegexp(`^/alfresco/(wc)?s(ervice)?/api/solr/.*$`)"
       - "traefik.http.middlewares.acsfakeauth.basicauth.users=fake:"
       - "traefik.http.routers.solrapideny.middlewares=acsfakeauth@docker"
+    volumes:
+      - /usr/local/tomcat/alf_data
   transform-core-aio:
     image: alfresco/alfresco-transform-core-aio:5.1.6
     mem_limit: 1536m

--- a/docker-compose/compose.yaml
+++ b/docker-compose/compose.yaml
@@ -136,7 +136,7 @@ services:
       retries: 3
       start_period: 10s
     volumes:
-      - shared-file-store-volume:/tmp/Alfresco
+      - /tmp/Alfresco
   share:
     image: quay.io/alfresco/alfresco-share:23.4.1
     mem_limit: 1g

--- a/docker-compose/compose.yaml
+++ b/docker-compose/compose.yaml
@@ -69,6 +69,8 @@ services:
       - "traefik.http.routers.alfrescomicrometer.rule=PathRegexp(`^/alfresco/(wc)?s(ervice)?/prometheus`)"
       - "traefik.http.middlewares.prometheusipfilter.ipallowlist.sourcerange=127.0.0.0/8"
       - "traefik.http.routers.alfrescomicrometer.middlewares=prometheusipfilter@docker"
+    volumes:
+      - /usr/local/tomcat/alf_data
   transform-router:
     mem_limit: 512m
     image: quay.io/alfresco/alfresco-transform-router:4.1.6

--- a/docker-compose/pre-release-compose.yaml
+++ b/docker-compose/pre-release-compose.yaml
@@ -69,6 +69,8 @@ services:
       - "traefik.http.routers.alfrescomicrometer.rule=PathRegexp(`^/alfresco/(wc)?s(ervice)?/prometheus`)"
       - "traefik.http.middlewares.prometheusipfilter.ipallowlist.sourcerange=127.0.0.0/8"
       - "traefik.http.routers.alfrescomicrometer.middlewares=prometheusipfilter@docker"
+    volumes:
+      - /usr/local/tomcat/alf_data
   transform-router:
     mem_limit: 512m
     image: quay.io/alfresco/alfresco-transform-router:4.1.6

--- a/docker-compose/pre-release-compose.yaml
+++ b/docker-compose/pre-release-compose.yaml
@@ -136,7 +136,7 @@ services:
       retries: 3
       start_period: 10s
     volumes:
-      - shared-file-store-volume:/tmp/Alfresco
+      - /tmp/Alfresco
   share:
     image: quay.io/alfresco/alfresco-share:25.1.0-M1
     mem_limit: 1g


### PR DESCRIPTION
* Enable restarting the alfresco container without data loss

Now it's possible to run consecutive `compose up` without getting:

```
2025-02-26T14:08:49,603 [] ERROR [repo.admin.ConfigurationChecker] [main] CONTENT INTEGRITY ERROR: System content not found in content store: 'store://2025/2/26/13/49/a07593db-c44b-4edb-b593-dbc44bfedb5e.bin'
2025-02-26T14:08:49,603 [] ERROR [repo.admin.ConfigurationChecker] [main] Ensure that the 'dir.root' property './alf_data' is pointing to the correct data location.
2025-02-26T14:08:49,605 [] WARN  [context.support.XmlWebApplicationContext] [main] Exception encountered during context initialization - cancelling refresh attempt: org.alfresco.error.AlfrescoRuntimeException: 01260036 Ensure that the 'dir.root' property './alf_data' is pointing to the correct data location.
2025-02-26T14:08:49,953 [] ERROR [web.context.ContextLoader] [main] Context initialization failed
org.alfresco.error.AlfrescoRuntimeException: 01260036 Ensure that the 'dir.root' property './alf_data' is pointing to the correct data location.
	at org.alfresco.repo.admin.ConfigurationChecker.check(ConfigurationChecker.java:212) ~[alfresco-repository-23.4.1.1.jar:23.4.1.1]
	at org.alfresco.repo.admin.ConfigurationChecker.access$0(ConfigurationChecker.java:167) ~[alfresco-repository-23.4.1.1.jar:23.4.1.1]
	at org.alfresco.repo.admin.ConfigurationChecker$1$1.doWork(ConfigurationChecker.java:155) ~[alfresco-repository-23.4.1.1.jar:23.4.1.1]
```

Anonymous volumes still need to be cleaned up to recover space with `docker volume prune`.

Switching to anonymous volumes for sfs service for uniformity and because we don't really need a named tmpfs volume for it.

Fix #649

OPSEXP-3109