### PR TITLE
Fix sfs volume path in docker compose

### DIFF
--- a/docker-compose/7.2.N-compose.yaml
+++ b/docker-compose/7.2.N-compose.yaml
@@ -143,7 +143,7 @@ services:
       retries: 3
       start_period: 10s
     volumes:
-      - shared-file-store-volume:/tmp/Alfresco/sfs
+      - shared-file-store-volume:/tmp/Alfresco
   share:
     image: quay.io/alfresco/alfresco-share:7.2.2.5
     mem_limit: 1g

--- a/docker-compose/7.3.N-compose.yaml
+++ b/docker-compose/7.3.N-compose.yaml
@@ -136,7 +136,7 @@ services:
       retries: 3
       start_period: 10s
     volumes:
-      - shared-file-store-volume:/tmp/Alfresco/sfs
+      - shared-file-store-volume:/tmp/Alfresco
   share:
     image: quay.io/alfresco/alfresco-share:7.3.2.3
     mem_limit: 1g

--- a/docker-compose/7.4.N-compose.yaml
+++ b/docker-compose/7.4.N-compose.yaml
@@ -136,7 +136,7 @@ services:
       retries: 3
       start_period: 10s
     volumes:
-      - shared-file-store-volume:/tmp/Alfresco/sfs
+      - shared-file-store-volume:/tmp/Alfresco
   share:
     image: quay.io/alfresco/alfresco-share:7.4.2.4
     mem_limit: 1g

--- a/docker-compose/compose.yaml
+++ b/docker-compose/compose.yaml
@@ -134,7 +134,7 @@ services:
       retries: 3
       start_period: 10s
     volumes:
-      - shared-file-store-volume:/tmp/Alfresco/sfs
+      - shared-file-store-volume:/tmp/Alfresco
   share:
     image: quay.io/alfresco/alfresco-share:23.4.1
     mem_limit: 1g

--- a/docker-compose/pre-release-compose.yaml
+++ b/docker-compose/pre-release-compose.yaml
@@ -134,7 +134,7 @@ services:
       retries: 3
       start_period: 10s
     volumes:
-      - shared-file-store-volume:/tmp/Alfresco/sfs
+      - shared-file-store-volume:/tmp/Alfresco
   share:
     image: quay.io/alfresco/alfresco-share:25.1.0-M1
     mem_limit: 1g


### PR DESCRIPTION
align sfs volume path in docker compose to: https://github.com/Alfresco/acs-deployment/blob/8d5070d624c2a660b960859852853d48310e465c/helm/alfresco-content-services/values.yaml#L288

Fix #625