### PR TITLE
OPSEXP-3109 Drop unused named volumes in compose

### DIFF
--- a/docker-compose/7.2.N-compose.yaml
+++ b/docker-compose/7.2.N-compose.yaml
@@ -336,8 +336,3 @@ services:
       - "traefik.http.middlewares.syncservice.replacepathregex.regex=^/syncservice/(.*)"
       - "traefik.http.middlewares.syncservice.replacepathregex.replacement=/alfresco/$$1"
       - "traefik.http.routers.syncservice.middlewares=syncservice@docker"
-volumes:
-  shared-file-store-volume:
-    driver_opts:
-      type: tmpfs
-      device: tmpfs

--- a/docker-compose/7.3.N-compose.yaml
+++ b/docker-compose/7.3.N-compose.yaml
@@ -327,8 +327,3 @@ services:
       - "traefik.http.middlewares.syncservice.replacepathregex.regex=^/syncservice/(.*)"
       - "traefik.http.middlewares.syncservice.replacepathregex.replacement=/alfresco/$$1"
       - "traefik.http.routers.syncservice.middlewares=syncservice@docker"
-volumes:
-  shared-file-store-volume:
-    driver_opts:
-      type: tmpfs
-      device: tmpfs

--- a/docker-compose/7.4.N-compose.yaml
+++ b/docker-compose/7.4.N-compose.yaml
@@ -327,8 +327,3 @@ services:
       - "traefik.http.middlewares.syncservice.replacepathregex.regex=^/syncservice/(.*)"
       - "traefik.http.middlewares.syncservice.replacepathregex.replacement=/alfresco/$$1"
       - "traefik.http.routers.syncservice.middlewares=syncservice@docker"
-volumes:
-  shared-file-store-volume:
-    driver_opts:
-      type: tmpfs
-      device: tmpfs

--- a/docker-compose/compose.yaml
+++ b/docker-compose/compose.yaml
@@ -407,8 +407,3 @@ services:
       - "traefik.http.middlewares.syncservice.replacepathregex.regex=^/syncservice/(.*)"
       - "traefik.http.middlewares.syncservice.replacepathregex.replacement=/alfresco/$$1"
       - "traefik.http.routers.syncservice.middlewares=syncservice@docker"
-volumes:
-  shared-file-store-volume:
-    driver_opts:
-      type: tmpfs
-      device: tmpfs

--- a/docker-compose/pre-release-compose.yaml
+++ b/docker-compose/pre-release-compose.yaml
@@ -407,8 +407,3 @@ services:
       - "traefik.http.middlewares.syncservice.replacepathregex.regex=^/syncservice/(.*)"
       - "traefik.http.middlewares.syncservice.replacepathregex.replacement=/alfresco/$$1"
       - "traefik.http.routers.syncservice.middlewares=syncservice@docker"
-volumes:
-  shared-file-store-volume:
-    driver_opts:
-      type: tmpfs
-      device: tmpfs


### PR DESCRIPTION
Forgot to remove them in https://github.com/Alfresco/acs-deployment/pull/1301

OPSEXP-3109