### PR TITLE
💅 Fail template on missing 'sharedSecret' when Solr is enabled & uses "secret" to secure communication

### DIFF
--- a/.github/workflows/helm-community.yml
+++ b/.github/workflows/helm-community.yml
@@ -50,7 +50,7 @@ jobs:
     needs:
       - build_vars
     env:
-      REGISTRY_SECRET_NAME: ${{ ! github.event.repository.fork && 'regcred' || '' }}
+      REGISTRY_SECRET_NAME: ${{ github.event.pull_request.head.repo.fork && '' || 'regcred' }}
     strategy:
       fail-fast: false
       matrix:
@@ -64,7 +64,8 @@ jobs:
 
       - name: Login to Docker Hub
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772  # v3.4.0
-        if: ${{ ! github.event.repository.fork }}
+        if: >-
+          ! github.event.pull_request.head.repo.fork
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/helm-enterprise.yml
+++ b/.github/workflows/helm-enterprise.yml
@@ -25,7 +25,7 @@ jobs:
     if: >-
       github.event_name == 'push'
       || (
-        ! github.event.repository.fork
+        ! github.event.pull_request.head.repo.fork
         && github.actor != 'dependabot[bot]'
       )
     outputs:

--- a/helm/alfresco-content-services/community_values.yaml
+++ b/helm/alfresco-content-services/community_values.yaml
@@ -1,5 +1,19 @@
 # This values file can be used to install the latest ACS Community version using
 # the latest version of the chart
+global:
+  search:
+    # === Communication Security Mode ===
+    # Set the security level used with the external search service
+    # Options:
+    #   - none  : No secure communication (HTTP)
+    #   - https : Use mTLS
+    #   - secret: Use a shared secret (REQUIRES setting 'sharedSecret' below)
+    securecoms: secret
+    # === SHARED SECRET ===
+    # !!! REQUIRED IF securecoms: secret !!!
+    # Set this to a strong, unique string if using 'secret' mode above.
+    # Example: "my-shared-secret-key"
+    sharedSecret: "CHANGE_ME_SECRET_REQUIRED_IF_SECURECOMS_IS_SECRET"
 alfresco-repository:
   autoscaling:
     enabled: false

--- a/helm/alfresco-content-services/community_values.yaml
+++ b/helm/alfresco-content-services/community_values.yaml
@@ -1,19 +1,5 @@
 # This values file can be used to install the latest ACS Community version using
 # the latest version of the chart
-global:
-  search:
-    # === Communication Security Mode ===
-    # Set the security level used with the external search service
-    # Options:
-    #   - none  : No secure communication (HTTP)
-    #   - https : Use mTLS
-    #   - secret: Use a shared secret (REQUIRES setting 'sharedSecret' below)
-    securecoms: secret
-    # === SHARED SECRET ===
-    # !!! REQUIRED IF securecoms: secret !!!
-    # Set this to a strong, unique string if using 'secret' mode above.
-    # Example: "my-shared-secret-key"
-    sharedSecret: "CHANGE_ME_SECRET_REQUIRED_IF_SECURECOMS_IS_SECRET"
 alfresco-repository:
   autoscaling:
     enabled: false

--- a/helm/alfresco-content-services/templates/secret-search.yaml
+++ b/helm/alfresco-content-services/templates/secret-search.yaml
@@ -10,8 +10,11 @@ metadata:
     {{- include "alfresco-content-services.labels" $ | nindent 4 }}
 type: Opaque
 data:
-{{- if eq "solr6" $search_flavor }}
-  SOLR_SECRET: {{ .sharedSecret | default "" | b64enc | quote }}
+{{- if and (eq "solr6" $search_flavor) (eq "secret" .securecomms) }}
+  {{- $reqMsg := "You have selected 'secret' mode of communication for global.search.securecomms, but did not provide a secret value for global.search.sharedSecret - see https://alfresco.github.io/acs-deployment/docs/helm/desktop-deployment.html" }}
+  SOLR_SECRET: {{ required $reqMsg .sharedSecret | b64enc | quote }}
+{{- else if and (eq "solr6" $search_flavor) (ne "secret" .securecomms) }}
+  SOLR_SECRET: {{ "" | b64enc | quote }}
 {{- else if eq "elasticsearch" $search_flavor }}
   SEARCH_USERNAME: {{ .username | default "" | b64enc | quote }}
   SEARCH_PASSWORD: {{ .password | default "" | b64enc | quote }}

--- a/helm/alfresco-content-services/tests/search_test.yaml
+++ b/helm/alfresco-content-services/tests/search_test.yaml
@@ -5,6 +5,29 @@ templates:
   - secret-search.yaml
   - secret-audit-elasticsearch.yaml
 tests:
+  - it: should fail to render a secret when search is not given a secret
+    set:
+      global:
+        search:
+          securecomms: secret
+          sharedSecret: ""
+      alfresco-search:
+        enabled: true
+      alfresco-search-enterprise:
+        enabled: false
+      alfresco-repository:
+        configuration:
+          search:
+            flavor: solr6
+    template: secret-search.yaml
+    asserts:
+      - failedTemplate:
+          errorMessage: >-
+            You have selected 'secret' mode of communication for
+            global.search.securecomms, but did not provide a secret value for
+            global.search.sharedSecret - see
+            https://alfresco.github.io/acs-deployment/docs/helm/desktop-deployment.html
+        template: secret-search.yaml
   - it: should render solr6 with secret
     values: &testvalues
       - values/test_values.yaml


### PR DESCRIPTION
This PR updates `community_values.yaml` to include a note about the `global.search.sharedSecret`, and that there are three modes of communication, with `secret` mode of communication being the default.

While deploying ACM to EKS, I noticed some pods were crashing when using the `community_values.yaml`. After some investigation, I found that the issue was due to the `sharedSecret` being set to `null`, however, this option was not available in the `community_values.yaml`, and it took some time to find out that this existed - especially for someone trying Alfresco ACM the first time. Hopefully, adding this information to the `community_values.yaml` will save some time for others 😊