### PR TITLE
OPSEXP-3293 Explicit load balancer ports for adf apps

### DIFF
--- a/docker-compose/commons/base.yaml
+++ b/docker-compose/commons/base.yaml
@@ -33,6 +33,7 @@ services:
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.adw.rule=PathPrefix(`/workspace`)"
+      - "traefik.http.services.digital-workspace.loadbalancer.server.port=8080"
       - "traefik.http.middlewares.adwforceslash.redirectregex.regex=^(.*/workspace)$$"
       - "traefik.http.middlewares.adwforceslash.redirectregex.replacement=$${1}/"
       - "traefik.http.middlewares.adwroot.stripprefix.prefixes=/workspace"
@@ -42,6 +43,7 @@ services:
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.aca.rule=PathPrefix(`/content-app`)"
+      - "traefik.http.services.content-app.loadbalancer.server.port=8080"
       - "traefik.http.middlewares.acaroot.stripprefix.prefixes=/content-app"
       - "traefik.http.middlewares.acaforceslash.redirectregex.regex=^(.*/content-app)$$"
       - "traefik.http.middlewares.acaforceslash.redirectregex.replacement=$${1}/"
@@ -51,6 +53,7 @@ services:
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.acc.rule=PathPrefix(`/control-center`) || PathPrefix(`/admin`)"
+      - "traefik.http.services.control-center.loadbalancer.server.port=8080"
       - "traefik.http.middlewares.accroot.stripprefix.prefixes=/admin,/control-center"
       - "traefik.http.middlewares.accforceslash.redirectregex.regex=^(.*/(admin|control-center))$$"
       - "traefik.http.middlewares.accforceslash.redirectregex.replacement=$${1}/"


### PR DESCRIPTION
Fix for:

```
2025-06-16T14:04:02Z ERR error="service \"digital-workspace-docker-compose\" error: port is missing" container=digital-workspace-docker-compose-d84519803cc63924463c6bfb7944e52bf3a89f622e5afd3ebaa106874ff500dd providerName=docker
2025-06-16T14:04:02Z ERR error="service \"control-center-docker-compose\" error: port is missing" container=control-center-docker-compose-6a338cd4178b0d8bdeeefcf620cc6b5ade7c1237fb0cb1d986c5a7f9de4d6f9e providerName=docker
```

which was causing:

```
172.18.0.1 - - [16/Jun/2025:12:07:31 +0000] "GET /workspace/ HTTP/1.1" 404 431 "-" "-" 72 "alfresco@docker" "http://172.18.0.8:8080" 4ms
172.18.0.1 - - [16/Jun/2025:12:37:13 +0000] "GET /control-center/ HTTP/1.1" 404 431 "-" "-" 73 "alfresco@docker" "http://172.18.0.8:8080" 14ms
```

ref OPSEXP-3293