### PR TITLE
Bump pre-release with RC versions

### DIFF
--- a/docker-compose/pre-release-compose.yaml
+++ b/docker-compose/pre-release-compose.yaml
@@ -15,7 +15,7 @@
 #
 services:
   alfresco:
-    image: quay.io/alfresco/alfresco-content-repository:25.3.0-A.14
+    image: quay.io/alfresco/alfresco-content-repository:25.3.0-A.17
     mem_limit: 1900m
     environment:
       JAVA_TOOL_OPTIONS: >-
@@ -64,7 +64,7 @@ services:
       service: alfresco
   transform-router:
     mem_limit: 512m
-    image: quay.io/alfresco/alfresco-transform-router:4.2.2
+    image: quay.io/alfresco/alfresco-transform-router:4.2.3-A.3
     environment:
       JAVA_OPTS: >-
         -XX:MinRAMPercentage=50
@@ -87,7 +87,7 @@ services:
       shared-file-store:
         condition: service_healthy
   transform-core-aio:
-    image: quay.io/alfresco/alfresco-transform-core-aio:5.2.3-A.1
+    image: quay.io/alfresco/alfresco-transform-core-aio:5.2.3-A.3
     mem_limit: 1536m
     environment:
       JAVA_OPTS: >-
@@ -110,7 +110,7 @@ services:
       shared-file-store:
         condition: service_healthy
   shared-file-store:
-    image: quay.io/alfresco/alfresco-shared-file-store:4.2.2
+    image: quay.io/alfresco/alfresco-shared-file-store:4.2.3-A.3
     mem_limit: 512m
     environment:
       JAVA_OPTS: >-
@@ -129,7 +129,7 @@ services:
     volumes:
       - /tmp/Alfresco
   share:
-    image: quay.io/alfresco/alfresco-share:25.3.0-A.14
+    image: quay.io/alfresco/alfresco-share:25.3.0-A.17
     mem_limit: 1g
     environment:
       CSRF_FILTER_ORIGIN: http://localhost:8080
@@ -211,7 +211,7 @@ services:
       retries: 5
       start_period: 30s
   search:
-    image: quay.io/alfresco/alfresco-elasticsearch-live-indexing:5.2.0
+    image: quay.io/alfresco/alfresco-elasticsearch-live-indexing:5.2.1-A.2
     mem_limit: 1g
     environment:
       ALFRESCO_ACCEPTED_CONTENT_MEDIA_TYPES_CACHE_BASE_URL: >-
@@ -234,7 +234,7 @@ services:
       shared-file-store:
         condition: service_healthy
   search-reindexing:
-    image: quay.io/alfresco/alfresco-elasticsearch-reindexing:5.2.0
+    image: quay.io/alfresco/alfresco-elasticsearch-reindexing:5.2.1-A.2
     mem_limit: 1g
     restart: on-failure:5
     environment:
@@ -267,7 +267,7 @@ services:
       retries: 5
       start_period: 5s
   digital-workspace:
-    image: quay.io/alfresco/alfresco-digital-workspace:7.2.0-18589055923
+    image: quay.io/alfresco/alfresco-digital-workspace:7.2.0-19296222727
     mem_limit: 128m
     environment:
       APP_CONFIG_PROVIDER: "ECM"
@@ -286,7 +286,7 @@ services:
       file: commons/base.yaml
       service: digital-workspace
   audit-storage:
-    image: quay.io/alfresco/alfresco-audit-storage:1.1.1-A.9
+    image: quay.io/alfresco/alfresco-audit-storage:1.2.0-A.1
     mem_limit: 512m
     environment:
       SPRING_ACTIVEMQ_BROKERURL: failover:(nio://activemq:61616)?timeout=3000
@@ -306,7 +306,7 @@ services:
       elasticsearch:
         condition: service_healthy
   control-center:
-    image: quay.io/alfresco/alfresco-control-center:10.2.0-18676902791
+    image: quay.io/alfresco/alfresco-control-center:10.2.0-19296222727
     mem_limit: 128m
     environment:
       APP_CONFIG_PROVIDER: "ECM"

--- a/helm/alfresco-content-services/pre-release_values.yaml
+++ b/helm/alfresco-content-services/pre-release_values.yaml
@@ -2,7 +2,7 @@
 # the chart
 alfresco-repository:
   image:
-    tag: 25.3.0-A.14
+    tag: 25.3.0-A.17
 activemq:
   image:
     repository: quay.io/alfresco/alfresco-activemq
@@ -10,31 +10,31 @@ activemq:
 alfresco-transform-service:
   transformrouter:
     image:
-      tag: 4.2.2
+      tag: 4.2.3-A.3
   pdfrenderer:
     image:
-      tag: 5.2.3-A.1
+      tag: 5.2.3-A.3
   imagemagick:
     image:
-      tag: 5.2.3-A.1
+      tag: 5.2.3-A.3
   libreoffice:
     image:
-      tag: 5.2.3-A.1
+      tag: 5.2.3-A.3
   tika:
     image:
-      tag: 5.2.3-A.1
+      tag: 5.2.3-A.3
   transformmisc:
     image:
-      tag: 5.2.3-A.1
+      tag: 5.2.3-A.3
   filestore:
     image:
-      tag: 4.2.2
+      tag: 4.2.3-A.3
 alfresco-ai-transformer:
   image:
-    tag: 3.2.2
+    tag: 3.2.3-A.2
 share:
   image:
-    tag: 25.3.0-A.14
+    tag: 25.3.0-A.17
 alfresco-search:
   searchServicesImage:
     tag: 2.1.0-A9
@@ -44,25 +44,25 @@ alfresco-search-enterprise:
   liveIndexing:
     mediation:
       image:
-        tag: 5.2.0
+        tag: 5.2.1-A.2
     content:
       image:
-        tag: 5.2.0
+        tag: 5.2.1-A.2
     metadata:
       image:
-        tag: 5.2.0
+        tag: 5.2.1-A.2
     path:
       image:
-        tag: 5.2.0
+        tag: 5.2.1-A.2
   reindexing:
     image:
-      tag: 5.2.0
+      tag: 5.2.1-A.2
 alfresco-digital-workspace:
   image:
-    tag: 7.2.0-18589055923
+    tag: 7.2.0-19296222727
 alfresco-control-center:
   image:
-    tag: 10.2.0-18676902791
+    tag: 10.2.0-19296222727
 postgresql:
   image:
     tag: 16.5
@@ -87,7 +87,7 @@ elasticsearch:
       tag: 8.17.1
 alfresco-audit-storage:
   image:
-    tag: 1.1.1-A.9
+    tag: 1.2.0-A.1
 dtas:
   config:
     assertions:


### PR DESCRIPTION
Updates the pre-release Docker Compose and Helm chart configuration files to use the latest pre-release images for several Alfresco Content Services components.