### PR TITLE
OPSEXP-3637 Fix Traefik incompatibility with Docker 29.0.0

### DIFF
--- a/docker-compose/commons/base.yaml
+++ b/docker-compose/commons/base.yaml
@@ -60,7 +60,7 @@ services:
       - "traefik.http.middlewares.accchain.chain.middlewares=accforceslash,accroot"
       - "traefik.http.routers.acc.middlewares=accchain@docker"
   proxy:
-    image: traefik:3.6.1
+    image: traefik:3.6
     mem_limit: 128m
     command:
       - "--api.insecure=true"


### PR DESCRIPTION
ref: OPSEXP-3637 https://github.com/Alfresco/acs-deployment/issues/1419