### PR TITLE
OPSEXP-3622 Ensure CI pipelines support EKS 1.32 upgrade

### DIFF
--- a/.github/workflows/helm-community.yml
+++ b/.github/workflows/helm-community.yml
@@ -72,7 +72,7 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Setup cluster
-        uses: Alfresco/alfresco-build-tools/.github/actions/setup-kind@OPSEXP-3622
+        uses: Alfresco/alfresco-build-tools/.github/actions/setup-kind@v9.5.0
         with:
           ingress-nginx-ref: controller-v1.12.1
           import-docker-credentials-secret-name: ${{ env.REGISTRY_SECRET_NAME }}

--- a/.github/workflows/helm-enterprise.yml
+++ b/.github/workflows/helm-enterprise.yml
@@ -85,7 +85,7 @@ jobs:
           password: ${{ secrets.QUAY_PASSWORD }}
 
       - name: Setup cluster
-        uses: Alfresco/alfresco-build-tools/.github/actions/setup-kind@OPSEXP-3622
+        uses: Alfresco/alfresco-build-tools/.github/actions/setup-kind@v9.5.0
         with:
           ingress-nginx-ref: controller-v1.12.1
           metrics: "true"


### PR DESCRIPTION
##OPSEXP-3622

This PR updates the setup-kind GitHub Action to v9.5.0 from the alfresco-build-tools repository.
