### PR TITLE
OPSEXP-3702: Support ActiveMQ 6.2 in pre-release with credentials

### DIFF
--- a/docker-compose/23.N-compose.yaml
+++ b/docker-compose/23.N-compose.yaml
@@ -270,7 +270,7 @@ services:
     image: quay.io/alfresco/alfresco-audit-storage:1.2.0
     mem_limit: 512m
     environment:
-      SPRING_ACTIVEMQ_BROKERURL: activemq
+      SPRING_ACTIVEMQ_BROKERURL: failover:(nio://activemq:61616)?timeout=3000
       AUDIT_ENTRYSTORAGE_OPENSEARCH_CONNECTOR_URI: http://elasticsearch:9200
       AUDIT_ENTRYSTORAGE_OPENSEARCH_CONNECTOR_USERNAME: admin
       AUDIT_ENTRYSTORAGE_OPENSEARCH_CONNECTOR_PASSWORD: admin

--- a/docker-compose/compose.yaml
+++ b/docker-compose/compose.yaml
@@ -336,6 +336,7 @@ services:
         -Dsql.db.username=alfresco
         -Dsql.db.password=alfresco
         -Dmessaging.broker.host=activemq
+        -Drepo.hostname=alfresco
         -Drepo.port=8080
         -Ddw.server.applicationConnectors[0].type=http
         -XX:MinRAMPercentage=50


### PR DESCRIPTION
Ref: OPSEXP-3702
This PR adds support for Activemq 6.2 in the pre-release Docker compose and Helm charts.
It also configures ActiveMQ broker authentication across multiple services( as we have enabled jaas authentication on activemq)