### PR TITLE
OPSEXP-4042: Bump Helm chart versions

### DIFF
--- a/helm/acs-sso-example/Chart.lock
+++ b/helm/acs-sso-example/Chart.lock
@@ -7,7 +7,7 @@ dependencies:
   version: 7.1.6
 - name: alfresco-repository
   repository: https://alfresco.github.io/alfresco-helm-charts/
-  version: 1.6.0-alpha.0
+  version: 1.6.0-alpha.1
 - name: activemq
   repository: https://alfresco.github.io/alfresco-helm-charts/
   version: 4.1.0
@@ -17,5 +17,5 @@ dependencies:
 - name: alfresco-adf-app
   repository: https://alfresco.github.io/alfresco-helm-charts/
   version: 0.7.0
-digest: sha256:3957d7b8a6a528e4a7e34f4be2ed30c1de4c6678979e181fb413641325ffeb1a
-generated: "2026-05-19T09:04:50.886522557Z"
+digest: sha256:f468e0e96275b70f64cd8bbd441efabf454024fc70d1b1cce3bd87b848754c0e
+generated: "2026-05-21T17:18:12.573322965Z"

--- a/helm/acs-sso-example/Chart.yaml
+++ b/helm/acs-sso-example/Chart.yaml
@@ -35,7 +35,7 @@ dependencies:
     version: 7.1.6
   - name: alfresco-repository
     repository: https://alfresco.github.io/alfresco-helm-charts/
-    version: 1.6.0-alpha.0
+    version: 1.6.0-alpha.1
   - name: activemq
     repository: https://alfresco.github.io/alfresco-helm-charts/
     version: 4.1.0

--- a/helm/acs-sso-example/README.md
+++ b/helm/acs-sso-example/README.md
@@ -39,7 +39,7 @@ deployment is destroyed or rolled back!
 |------------|------|---------|
 | https://alfresco.github.io/alfresco-helm-charts/ | activemq | 4.1.0 |
 | https://alfresco.github.io/alfresco-helm-charts/ | alfresco-content-app(alfresco-adf-app) | 0.7.0 |
-| https://alfresco.github.io/alfresco-helm-charts/ | alfresco-repository | 1.6.0-alpha.0 |
+| https://alfresco.github.io/alfresco-helm-charts/ | alfresco-repository | 1.6.0-alpha.1 |
 | https://alfresco.github.io/alfresco-helm-charts/ | alfresco-share | 2.3.0 |
 | https://codecentric.github.io/helm-charts | keycloakx | 7.1.6 |
 | oci://registry-1.docker.io/bitnamicharts | repository-database(postgresql) | 13.4.0 |

--- a/helm/alfresco-content-services/Chart.lock
+++ b/helm/alfresco-content-services/Chart.lock
@@ -16,7 +16,7 @@ dependencies:
   version: 0.7.0
 - name: alfresco-repository
   repository: https://alfresco.github.io/alfresco-helm-charts/
-  version: 1.6.0-alpha.0
+  version: 1.6.0-alpha.1
 - name: activemq
   repository: https://alfresco.github.io/alfresco-helm-charts/
   version: 4.1.0
@@ -53,5 +53,5 @@ dependencies:
 - name: alfresco-connector-hxi
   repository: https://alfresco.github.io/alfresco-helm-charts/
   version: 0.7.0
-digest: sha256:59e180c7bc91a3ce8af60d1b2ec26ebab9b41e64395d9b6c5e1a1a955b424ea5
-generated: "2026-05-19T09:06:05.006670219Z"
+digest: sha256:378d92b146685c44ff21cd9b757b23d6ce0f5fde5e36f3b40c47bcdc598a5d6e
+generated: "2026-05-21T17:18:44.178659046Z"

--- a/helm/alfresco-content-services/Chart.yaml
+++ b/helm/alfresco-content-services/Chart.yaml
@@ -42,7 +42,7 @@ dependencies:
     condition: >-
       alfresco-digital-workspace.enabled
   - name: alfresco-repository
-    version: 1.6.0-alpha.0
+    version: 1.6.0-alpha.1
     repository: https://alfresco.github.io/alfresco-helm-charts/
   - name: activemq
     version: 4.1.0

--- a/helm/alfresco-content-services/README.md
+++ b/helm/alfresco-content-services/README.md
@@ -31,7 +31,7 @@ Please refer to the [documentation](https://github.com/Alfresco/acs-deployment/b
 | https://alfresco.github.io/alfresco-helm-charts/ | alfresco-knowledge-retrieval(alfresco-connector-hxi) | 0.7.0 |
 | https://alfresco.github.io/alfresco-helm-charts/ | alfresco-connector-ms365 | 3.7.0 |
 | https://alfresco.github.io/alfresco-helm-charts/ | alfresco-connector-msteams | 2.7.0 |
-| https://alfresco.github.io/alfresco-helm-charts/ | alfresco-repository | 1.6.0-alpha.0 |
+| https://alfresco.github.io/alfresco-helm-charts/ | alfresco-repository | 1.6.0-alpha.1 |
 | https://alfresco.github.io/alfresco-helm-charts/ | alfresco-search-enterprise | 4.14.0 |
 | https://alfresco.github.io/alfresco-helm-charts/ | alfresco-search(alfresco-search-service) | 6.2.0 |
 | https://alfresco.github.io/alfresco-helm-charts/ | share(alfresco-share) | 2.3.0 |


### PR DESCRIPTION
OPSEXP-4042
Bump charts to alfresco-repository chart 1.6.0-alpha.1