### PR TITLE
Bump Helm chart versions

### DIFF
--- a/helm/acs-sso-example/Chart.lock
+++ b/helm/acs-sso-example/Chart.lock
@@ -7,7 +7,7 @@ dependencies:
   version: 7.1.6
 - name: alfresco-repository
   repository: https://alfresco.github.io/alfresco-helm-charts/
-  version: 1.6.0-alpha.1
+  version: 1.6.1
 - name: activemq
   repository: https://alfresco.github.io/alfresco-helm-charts/
   version: 4.1.0
@@ -17,5 +17,5 @@ dependencies:
 - name: alfresco-adf-app
   repository: https://alfresco.github.io/alfresco-helm-charts/
   version: 0.7.0
-digest: sha256:f468e0e96275b70f64cd8bbd441efabf454024fc70d1b1cce3bd87b848754c0e
-generated: "2026-05-21T17:18:12.573322965Z"
+digest: sha256:e980d3d922446f1ea1bc6990f7eaec9f25f552ca79546b8bea60ba8fc30b89bb
+generated: "2026-05-28T06:06:44.891429462Z"

--- a/helm/acs-sso-example/Chart.yaml
+++ b/helm/acs-sso-example/Chart.yaml
@@ -35,7 +35,7 @@ dependencies:
     version: 7.1.6
   - name: alfresco-repository
     repository: https://alfresco.github.io/alfresco-helm-charts/
-    version: 1.6.0-alpha.1
+    version: 1.6.1
   - name: activemq
     repository: https://alfresco.github.io/alfresco-helm-charts/
     version: 4.1.0

--- a/helm/acs-sso-example/README.md
+++ b/helm/acs-sso-example/README.md
@@ -39,7 +39,7 @@ deployment is destroyed or rolled back!
 |------------|------|---------|
 | https://alfresco.github.io/alfresco-helm-charts/ | activemq | 4.1.0 |
 | https://alfresco.github.io/alfresco-helm-charts/ | alfresco-content-app(alfresco-adf-app) | 0.7.0 |
-| https://alfresco.github.io/alfresco-helm-charts/ | alfresco-repository | 1.6.0-alpha.1 |
+| https://alfresco.github.io/alfresco-helm-charts/ | alfresco-repository | 1.6.1 |
 | https://alfresco.github.io/alfresco-helm-charts/ | alfresco-share | 2.3.0 |
 | https://codecentric.github.io/helm-charts | keycloakx | 7.1.6 |
 | oci://registry-1.docker.io/bitnamicharts | repository-database(postgresql) | 13.4.0 |

--- a/helm/alfresco-content-services/Chart.lock
+++ b/helm/alfresco-content-services/Chart.lock
@@ -16,7 +16,7 @@ dependencies:
   version: 0.7.0
 - name: alfresco-repository
   repository: https://alfresco.github.io/alfresco-helm-charts/
-  version: 1.6.0-alpha.1
+  version: 1.6.1
 - name: activemq
   repository: https://alfresco.github.io/alfresco-helm-charts/
   version: 4.1.0
@@ -31,7 +31,7 @@ dependencies:
   version: 7.11.0
 - name: alfresco-search-enterprise
   repository: https://alfresco.github.io/alfresco-helm-charts/
-  version: 4.14.0
+  version: 5.0.0-alpha.0
 - name: alfresco-connector-msteams
   repository: https://alfresco.github.io/alfresco-helm-charts/
   version: 2.7.0
@@ -53,5 +53,5 @@ dependencies:
 - name: alfresco-connector-hxi
   repository: https://alfresco.github.io/alfresco-helm-charts/
   version: 0.7.0
-digest: sha256:378d92b146685c44ff21cd9b757b23d6ce0f5fde5e36f3b40c47bcdc598a5d6e
-generated: "2026-05-21T17:18:44.178659046Z"
+digest: sha256:0aa2fb76a03104dc62508f7e2cd6ab5e6e1e3be2f2007ec71d5fde352859a780
+generated: "2026-05-28T06:07:31.509075546Z"

--- a/helm/alfresco-content-services/Chart.yaml
+++ b/helm/alfresco-content-services/Chart.yaml
@@ -42,7 +42,7 @@ dependencies:
     condition: >-
       alfresco-digital-workspace.enabled
   - name: alfresco-repository
-    version: 1.6.0-alpha.1
+    version: 1.6.1
     repository: https://alfresco.github.io/alfresco-helm-charts/
   - name: activemq
     version: 4.1.0
@@ -62,7 +62,7 @@ dependencies:
     version: 7.11.0
     condition: alfresco-sync-service.enabled
   - name: alfresco-search-enterprise
-    version: 4.14.0
+    version: 5.0.0-alpha.0
     repository: https://alfresco.github.io/alfresco-helm-charts/
     condition: alfresco-search-enterprise.enabled
   - name: alfresco-connector-msteams

--- a/helm/alfresco-content-services/README.md
+++ b/helm/alfresco-content-services/README.md
@@ -31,8 +31,8 @@ Please refer to the [documentation](https://github.com/Alfresco/acs-deployment/b
 | https://alfresco.github.io/alfresco-helm-charts/ | alfresco-knowledge-retrieval(alfresco-connector-hxi) | 0.7.0 |
 | https://alfresco.github.io/alfresco-helm-charts/ | alfresco-connector-ms365 | 3.7.0 |
 | https://alfresco.github.io/alfresco-helm-charts/ | alfresco-connector-msteams | 2.7.0 |
-| https://alfresco.github.io/alfresco-helm-charts/ | alfresco-repository | 1.6.0-alpha.1 |
-| https://alfresco.github.io/alfresco-helm-charts/ | alfresco-search-enterprise | 4.14.0 |
+| https://alfresco.github.io/alfresco-helm-charts/ | alfresco-repository | 1.6.1 |
+| https://alfresco.github.io/alfresco-helm-charts/ | alfresco-search-enterprise | 5.0.0-alpha.0 |
 | https://alfresco.github.io/alfresco-helm-charts/ | alfresco-search(alfresco-search-service) | 6.2.0 |
 | https://alfresco.github.io/alfresco-helm-charts/ | share(alfresco-share) | 2.3.0 |
 | https://alfresco.github.io/alfresco-helm-charts/ | alfresco-sync-service | 7.11.0 |


### PR DESCRIPTION
[OPSEXP-4042](https://hyland.atlassian.net/browse/OPSEXP-4042)
Bump charts to alfresco-repository chart 1.6.1
Bump charts to alfresco-search-enterprise chart 5.0.0-alpha.0

[OPSEXP-4042]: https://hyland.atlassian.net/browse/OPSEXP-4042?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ