### PR TITLE
OPSEXP-4095 Update support.hyland.com and docs.alfresco.com references to docs.hyland.com

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -6,8 +6,8 @@ color_scheme: alfresco
 url: https://alfresco.github.io
 
 aux_links:
-  Hyland Support: https://support.hyland.com/p/alfresco
-  Docs: https://docs.alfresco.com/
+  Hyland Support: https://docs.hyland.com/p/alfresco
+  Docs: https://docs.hyland.com/
   GitHub Repository: https://github.com/Alfresco/acs-deployment
 
 aux_links_new_tab: true

--- a/docs/docker-compose/README.md
+++ b/docs/docker-compose/README.md
@@ -604,4 +604,4 @@ The list below shows the location of the publicly available `Dockerfile` for the
 * [transform-core-aio](https://github.com/Alfresco/alfresco-transform-core/blob/master/engines/aio/Dockerfile)
 * [activemq](https://github.com/Alfresco/alfresco-docker-activemq/blob/master/Dockerfile)
 
-[alfresco-docs-site]: https://support.hyland.com/r/alfresco
+[alfresco-docs-site]: https://docs.hyland.com/p/alfresco

--- a/docs/docker-compose/examples/customisation-guidelines.md
+++ b/docs/docker-compose/examples/customisation-guidelines.md
@@ -71,7 +71,7 @@ You will now need to install the AMP files into the Alfresco Content Repository 
     USER alfresco
     ```
 
-    > **NOTE:** In the above example RUN docker command, alfresco-mmt jar is run with -directory, -nobackup and -verbose options. You must make sure these are suitable for your requirements. Documentation on alfresco-mmt can be found [here](https://docs.hyland.com/r/Alfresco/Alfresco-Content-Services/7.4/Alfresco-Content-Services/Alfresco-Content-Services/Develop/Extension-packaging-modules/Module-package-formats/Alfresco-Module-Package-AMP/Using-the-Module-Management-Tool-MMT).
+    > **NOTE:** In the above example RUN docker command, alfresco-mmt jar is run with -directory, -nobackup and -verbose options. You must make sure these are suitable for your requirements. Documentation on alfresco-mmt can be found [here](https://docs.hyland.com/r/Alfresco/Alfresco-Content-Services/26.1/Alfresco-Content-Services/Develop/Extension-Packaging-Modules/Module-Package-Formats/Alfresco-Module-Package-AMP/Using-the-Module-Management-Tool-MMT).
 
 4. Build the image, make sure you give the image an appropriate name and tag so you can easily identify the image afterwards. In the below example, you will want to replace `myregistrydomain/my-custom-alfresco-content-repository:7.4.0.1` and `myregistrydomain/my-custom-alfresco-content-repository:latest` with your own Docker registry, image name and tag as per your requirements
 
@@ -114,7 +114,7 @@ We will now repeat the process for the Alfresco Share image.
         ${TOMCAT_DIR}/amps_share ${TOMCAT_DIR}/webapps/share -directory -nobackup -verbose
     ```
 
-    > **NOTE:** In the above example RUN docker command, alfresco-mmt jar is run with -directory, -nobackup and -verbose options. You must make sure these are suitable for your requirements. Documentation on alfresco-mmt can be found [here](https://docs.hyland.com/r/Alfresco/Alfresco-Content-Services/7.4/Alfresco-Content-Services/Alfresco-Content-Services/Develop/Extension-packaging-modules/Module-package-formats/Alfresco-Module-Package-AMP/Using-the-Module-Management-Tool-MMT).
+    > **NOTE:** In the above example RUN docker command, alfresco-mmt jar is run with -directory, -nobackup and -verbose options. You must make sure these are suitable for your requirements. Documentation on alfresco-mmt can be found [here](https://docs.hyland.com/r/Alfresco/Alfresco-Content-Services/26.1/Alfresco-Content-Services/Develop/Extension-Packaging-Modules/Module-Package-Formats/Alfresco-Module-Package-AMP/Using-the-Module-Management-Tool-MMT).
 
 3. Build the image, make sure you give the image an appropriate name and tag so you can easily identify the image afterwards. In the below command, you will want to replace `myregistrydomain/my-custom-alfresco-share:7.4.0` and `myregistrydomain/my-custom-alfresco-share:latest` with your own Docker registry, image name and tag as per your requirements
 

--- a/docs/docker-compose/examples/customisation-guidelines.md
+++ b/docs/docker-compose/examples/customisation-guidelines.md
@@ -71,7 +71,7 @@ You will now need to install the AMP files into the Alfresco Content Repository 
     USER alfresco
     ```
 
-    > **NOTE:** In the above example RUN docker command, alfresco-mmt jar is run with -directory, -nobackup and -verbose options. You must make sure these are suitable for your requirements. Documentation on alfresco-mmt can be found [here](https://docs.alfresco.com/7.4/concepts/dev-extensions-modules-management-tool.html).
+    > **NOTE:** In the above example RUN docker command, alfresco-mmt jar is run with -directory, -nobackup and -verbose options. You must make sure these are suitable for your requirements. Documentation on alfresco-mmt can be found [here](https://docs.hyland.com/r/Alfresco/Alfresco-Content-Services/7.4/Alfresco-Content-Services/Alfresco-Content-Services/Develop/Extension-packaging-modules/Module-package-formats/Alfresco-Module-Package-AMP/Using-the-Module-Management-Tool-MMT).
 
 4. Build the image, make sure you give the image an appropriate name and tag so you can easily identify the image afterwards. In the below example, you will want to replace `myregistrydomain/my-custom-alfresco-content-repository:7.4.0.1` and `myregistrydomain/my-custom-alfresco-content-repository:latest` with your own Docker registry, image name and tag as per your requirements
 
@@ -114,7 +114,7 @@ We will now repeat the process for the Alfresco Share image.
         ${TOMCAT_DIR}/amps_share ${TOMCAT_DIR}/webapps/share -directory -nobackup -verbose
     ```
 
-    > **NOTE:** In the above example RUN docker command, alfresco-mmt jar is run with -directory, -nobackup and -verbose options. You must make sure these are suitable for your requirements. Documentation on alfresco-mmt can be found [here](https://docs.alfresco.com/7.4/concepts/dev-extensions-modules-management-tool.html).
+    > **NOTE:** In the above example RUN docker command, alfresco-mmt jar is run with -directory, -nobackup and -verbose options. You must make sure these are suitable for your requirements. Documentation on alfresco-mmt can be found [here](https://docs.hyland.com/r/Alfresco/Alfresco-Content-Services/7.4/Alfresco-Content-Services/Alfresco-Content-Services/Develop/Extension-packaging-modules/Module-package-formats/Alfresco-Module-Package-AMP/Using-the-Module-Management-Tool-MMT).
 
 3. Build the image, make sure you give the image an appropriate name and tag so you can easily identify the image afterwards. In the below command, you will want to replace `myregistrydomain/my-custom-alfresco-share:7.4.0` and `myregistrydomain/my-custom-alfresco-share:latest` with your own Docker registry, image name and tag as per your requirements
 

--- a/docs/helm/README.md
+++ b/docs/helm/README.md
@@ -224,7 +224,7 @@ Deployment_solr --> PersistentVolumeClaim_solr-default-pvc --> pv4
 Alfresco provides tested Helm charts as a "template" to accelerate deployment
 and configuration for customers who want to take advantage of Kubernetes
 orchestration capabilities. Please remember that as stated in our [support
-policies](https://docs.hyland.com/r/Alfresco/Alfresco-Content-Services/23.7/Alfresco-Content-Services/Install/Overview/Install-and-deploy-methods),
+policies](https://docs.hyland.com/r/Alfresco/Alfresco-Content-Services/26.1/Alfresco-Content-Services/Install/Overview/Install-and-deploy-methods),
 similarly to other deployment artifacts, they are not meant to be used 'as-is'
 in production. Our goal is to save you time and effort deploying Alfresco
 Content Services for your organization.

--- a/docs/helm/README.md
+++ b/docs/helm/README.md
@@ -224,7 +224,7 @@ Deployment_solr --> PersistentVolumeClaim_solr-default-pvc --> pv4
 Alfresco provides tested Helm charts as a "template" to accelerate deployment
 and configuration for customers who want to take advantage of Kubernetes
 orchestration capabilities. Please remember that as stated in our [support
-policies](https://docs.alfresco.com/support/latest/policies/deployment/),
+policies](https://docs.hyland.com/r/Alfresco/Alfresco-Content-Services/23.7/Alfresco-Content-Services/Install/Overview/Install-and-deploy-methods),
 similarly to other deployment artifacts, they are not meant to be used 'as-is'
 in production. Our goal is to save you time and effort deploying Alfresco
 Content Services for your organization.

--- a/docs/helm/eks-deployment.md
+++ b/docs/helm/eks-deployment.md
@@ -732,4 +732,4 @@ Finally, delete the EKS cluster:
 eksctl delete cluster --name $EKS_CLUSTER_NAME
 ```
 
-[alfresco-docs-site]: https://support.hyland.com/r/alfresco
+[alfresco-docs-site]: https://docs.hyland.com/p/alfresco

--- a/docs/helm/examples/external-hazelcast.md
+++ b/docs/helm/examples/external-hazelcast.md
@@ -183,4 +183,4 @@ grand_parent: Helm
     ????????admin????(92023d8ea10294a2e32b238963e67d8013342e30
     ```
 
-[alfresco-docs-site]: https://support.hyland.com/r/alfresco
+[alfresco-docs-site]: https://docs.hyland.com/p/alfresco

--- a/docs/helm/examples/search-services.md
+++ b/docs/helm/examples/search-services.md
@@ -29,7 +29,7 @@ Solr instance outside of the kubernetes cluster.
 
 Installing Solr instance(s) is out of the scope of this document, but it can be
 done following the [Search service
-documentation](https://docs.alfresco.com/insight-engine/latest/install/options/#install-without-mutual-tls---http-with-secret-word-zip),
+documentation](https://docs.hyland.com/r/Alfresco/Alfresco-Search-and-Insight-Engine/2.0/Alfresco-Search-and-Insight-Engine/Install/Installation-options/Install-without-mutual-TLS-HTTP-with-secret-word-zip),
 or by using the Ansible playbook (replication setup require an additional
 load-balancer), as explained
 [here](https://github.com/Alfresco/alfresco-ansible-deployment/blob/master/docs/search-services-deployment-guide.md).

--- a/docs/helm/examples/with-ai.md
+++ b/docs/helm/examples/with-ai.md
@@ -7,7 +7,7 @@ grand_parent: Helm
 # ACS Helm Deployment with Intelligence Services
 
 By default, [Alfresco Intelligence
-Services](https://docs.alfresco.com/intelligence/concepts/ai-welcome.html)
+Services](https://docs.hyland.com/r/Alfresco/Alfresco-Intelligence-Services/1.5/Alfresco-Intelligence-Services/Alfresco-Intelligence-Services)
 feature is disabled, this example describes how to deploy ACS onto
 [EKS](https://aws.amazon.com/eks) with AIS enabled.
 
@@ -51,7 +51,7 @@ Follow the [AWS Services](with-aws-services.md) example up until the
 ## Setup S3 Bucket
 
 Follow the steps in the official documentation to [setup an IAM user and an S3
-bucket](https://docs.alfresco.com/intelligence/concepts/aws-setup.html) for use
+bucket](https://docs.hyland.com/r/Alfresco/Alfresco-Intelligence-Services/1.0/Alfresco-Intelligence-Services/Alfresco-Intelligence-Services/Configure-Intelligence-Services) for use
 by AIS.
 
 ## Deploy

--- a/docs/helm/examples/with-ai.md
+++ b/docs/helm/examples/with-ai.md
@@ -7,7 +7,7 @@ grand_parent: Helm
 # ACS Helm Deployment with Intelligence Services
 
 By default, [Alfresco Intelligence
-Services](https://docs.hyland.com/r/Alfresco/Alfresco-Intelligence-Services/1.5/Alfresco-Intelligence-Services/Alfresco-Intelligence-Services)
+Services](https://docs.hyland.com/r/Alfresco/Alfresco-Intelligence-Services/3.4/Alfresco-Intelligence-Services/Introduction/Introduction)
 feature is disabled, this example describes how to deploy ACS onto
 [EKS](https://aws.amazon.com/eks) with AIS enabled.
 
@@ -51,7 +51,7 @@ Follow the [AWS Services](with-aws-services.md) example up until the
 ## Setup S3 Bucket
 
 Follow the steps in the official documentation to [setup an IAM user and an S3
-bucket](https://docs.hyland.com/r/Alfresco/Alfresco-Intelligence-Services/1.0/Alfresco-Intelligence-Services/Alfresco-Intelligence-Services/Configure-Intelligence-Services) for use
+bucket](https://docs.hyland.com/r/Alfresco/Alfresco-Intelligence-Services/3.4/Alfresco-Intelligence-Services/Configure/Configure-Intelligence-Services) for use
 by AIS.
 
 ## Deploy

--- a/docs/helm/examples/with-keycloak.md
+++ b/docs/helm/examples/with-keycloak.md
@@ -99,4 +99,4 @@ alfresco-control-center:
 Please search the [Alfresco Products Official Documentation][alfresco-docs-site]
 for more configuration options.
 
-[alfresco-docs-site]: https://support.hyland.com/r/alfresco
+[alfresco-docs-site]: https://docs.hyland.com/p/alfresco

--- a/docs/helm/examples/with-ms-teams.md
+++ b/docs/helm/examples/with-ms-teams.md
@@ -6,7 +6,7 @@ grand_parent: Helm
 
 # ACS Helm Deployment with Microsoft Teams Connector
 
-The [Alfresco Microsoft Teams Connector](https://support.hyland.com/p/alfresco) enables
+The [Alfresco Microsoft Teams Connector](https://docs.hyland.com/p/alfresco) enables
 Microsoft Teams clients to be used to search content within ACS and send
 messages to Teams Chat / Channels with preview links to Alfresco Digital
 Workspace. By default, this feature is disabled.

--- a/docs/helm/examples/with-ooi.md
+++ b/docs/helm/examples/with-ooi.md
@@ -7,7 +7,7 @@ grand_parent: Helm
 # ACS Helm Deployment with Microsoft 365 Connector
 
 The [Alfresco Microsoft 365
-Connector](https://docs.hyland.com/r/Alfresco/Alfresco-Collaboration-Connector-for-Microsoft-365/1.1/Alfresco-Collaboration-Connector-for-Microsoft-365/Alfresco-Collaboration-Connector-for-Microsoft-365)
+Connector](https://docs.hyland.com/r/Alfresco/Alfresco-Collaboration-Connector-for-Microsoft-365/2.1/Alfresco-Collaboration-Connector-for-Microsoft-365/Introduction)
 enables Office Online Integration (OOI) within Alfresco Digital Workspace such
 that users can share and co-author Office documents stored within ACS using the
 Microsoft 365. By default, this feature is disabled.

--- a/docs/helm/examples/with-ooi.md
+++ b/docs/helm/examples/with-ooi.md
@@ -7,7 +7,7 @@ grand_parent: Helm
 # ACS Helm Deployment with Microsoft 365 Connector
 
 The [Alfresco Microsoft 365
-Connector](https://docs.alfresco.com/officeonline/concepts/office-online-intro.html)
+Connector](https://docs.hyland.com/r/Alfresco/Alfresco-Collaboration-Connector-for-Microsoft-365/1.1/Alfresco-Collaboration-Connector-for-Microsoft-365/Alfresco-Collaboration-Connector-for-Microsoft-365)
 enables Office Online Integration (OOI) within Alfresco Digital Workspace such
 that users can share and co-author Office documents stored within ACS using the
 Microsoft 365. By default, this feature is disabled.

--- a/helm/alfresco-content-services/README.md
+++ b/helm/alfresco-content-services/README.md
@@ -272,7 +272,7 @@ Please refer to the [documentation](https://github.com/Alfresco/acs-deployment/b
 | global.auditIndex.username | string | `nil` | set usernname for authentication against the external elasticsearch service for audit indexing |
 | global.ingressClassName | string | `"nginx"` | Ingress class name to be used for all ingresses created by this chart. You can override it for each sub-chart if needed, usually via `ingress.className` value in the corresponding sub-chart. Default is still set to `nginx` for backward compatibility, but it is recommended to set it to `traefik` or whatever ingress controller you are using in your cluster. |
 | global.known_urls | list | `["https://localhost","http://localhost"]` | list of trusted URLs. URLs a re used to configure Cross-origin protections Also the first entry is considered the main hosting domain of the platform. |
-| global.mail | object | `{"host":null,"password":null,"port":587,"protocol":"smtp","smtp":{"auth":true,"starttls":{"enable":true}},"smtps":{"auth":true},"username":"anonymous"}` | For a full information of configuring the outbound email system, please search this topic in https://support.hyland.com/r/alfresco |
+| global.mail | object | `{"host":null,"password":null,"port":587,"protocol":"smtp","smtp":{"auth":true,"starttls":{"enable":true}},"smtps":{"auth":true},"username":"anonymous"}` | For a full information of configuring the outbound email system, please search this topic in https://docs.hyland.com/p/alfresco |
 | global.mail.host | string | `nil` | SMTP server to use for the system to send outgoing email |
 | global.mail.port | int | `587` | SMTP server port |
 | global.mail.protocol | string | `"smtp"` | SMTP protocol to use. Either smtp or smtps |

--- a/helm/alfresco-content-services/values.yaml
+++ b/helm/alfresco-content-services/values.yaml
@@ -28,7 +28,7 @@ global:
     - https://localhost
     - http://localhost
   # -- For a full information of configuring the outbound email system, please
-  # search this topic in https://support.hyland.com/r/alfresco
+  # search this topic in https://docs.hyland.com/p/alfresco
   mail:
     # -- SMTP server to use for the system to send outgoing email
     host: null


### PR DESCRIPTION
[OPSEXP-4095](https://hyland.atlassian.net/browse/OPSEXP-4095)
Updated documentation references to use the consolidated Hyland documentation portal:

Replaced https://support.hyland.com/
Replaced https://docs.alfresco.com/

with: https://docs.hyland.com/

[OPSEXP-4095]: https://hyland.atlassian.net/browse/OPSEXP-4095?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ