### PR TITLE
OPSEXP-4102 Consolidate and harden the Release Orchestrator workflow

### DIFF
--- a/.github/workflows/bumpVersions.yml
+++ b/.github/workflows/bumpVersions.yml
@@ -41,9 +41,6 @@ on:
       QUAY_PASSWORD:
         required: false
 
-env:
-  DEFAULT_BRANCH_NAME: master
-
 jobs:
   bump-charts-dependencies:
     runs-on: ubuntu-latest
@@ -52,7 +49,7 @@ jobs:
     permissions:
       contents: read
     env:
-      USE_DEDICATED_BRANCH: ${{ github.event_name == 'workflow_call' || github.ref_name == env.DEFAULT_BRANCH_NAME }}
+      USE_DEDICATED_BRANCH: ${{ github.event_name == 'workflow_call' || github.ref_name == 'master' }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
@@ -89,7 +86,7 @@ jobs:
     permissions: {}
     if: (inputs.update-type == 'values' || inputs.update-type == 'all' || github.event_name == 'push') && github.actor != 'dependabot[bot]'
     env:
-      USE_DEDICATED_BRANCH: ${{ github.event_name == 'workflow_call' || github.ref_name == env.DEFAULT_BRANCH_NAME }}
+      USE_DEDICATED_BRANCH: ${{ github.event_name == 'workflow_call' || github.ref_name == 'master' }}
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
@@ -103,7 +100,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
           repository: alfresco/alfresco-updatecli
-          ref: ${{ inputs.alfresco-updatecli-ref || env.DEFAULT_BRANCH_NAME }}
+          ref: ${{ inputs.alfresco-updatecli-ref || 'master' }}
           path: alfresco-updatecli
 
       - name: Build manifest and run Updatecli pipelines

--- a/.github/workflows/bumpVersions.yml
+++ b/.github/workflows/bumpVersions.yml
@@ -49,7 +49,7 @@ jobs:
     permissions:
       contents: read
     env:
-      USE_DEDICATED_BRANCH: ${{ github.event_name == 'workflow_call' || github.ref_name == 'master' }}
+      USE_DEDICATED_BRANCH: ${{ inputs.update-type == 'all' || github.ref_name == 'master' }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
@@ -86,7 +86,7 @@ jobs:
     permissions: {}
     if: (inputs.update-type == 'values' || inputs.update-type == 'all' || github.event_name == 'push') && github.actor != 'dependabot[bot]'
     env:
-      USE_DEDICATED_BRANCH: ${{ github.event_name == 'workflow_call' || github.ref_name == 'master' }}
+      USE_DEDICATED_BRANCH: ${{ inputs.update-type == 'all' || github.ref_name == 'master' }}
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3

--- a/.github/workflows/bumpVersions.yml
+++ b/.github/workflows/bumpVersions.yml
@@ -20,6 +20,7 @@ on:
         options:
         - charts
         - values
+        - all
       alfresco-updatecli-ref:
         description: "The version to use for alfresco/alfresco-updatecli configs (only for values update-type)"
         type: string
@@ -47,7 +48,7 @@ jobs:
   bump-charts-dependencies:
     runs-on: ubuntu-latest
     name: Helm charts dependencies
-    if: inputs.update-type == 'charts'
+    if: inputs.update-type == 'charts' || inputs.update-type == 'all'
     permissions:
       contents: read
     steps:
@@ -84,7 +85,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Image tags values dependencies
     permissions: {}
-    if: (inputs.update-type == 'values' || github.event_name == 'push') && github.actor != 'dependabot[bot]'
+    if: (inputs.update-type == 'values' || inputs.update-type == 'all' || github.event_name == 'push') && github.actor != 'dependabot[bot]'
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3

--- a/.github/workflows/bumpVersions.yml
+++ b/.github/workflows/bumpVersions.yml
@@ -51,6 +51,8 @@ jobs:
     if: inputs.update-type == 'charts' || inputs.update-type == 'all'
     permissions:
       contents: read
+    env:
+      USE_DEDICATED_BRANCH: ${{ github.event_name == 'workflow_call' || github.ref_name == env.DEFAULT_BRANCH_NAME }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
@@ -77,15 +79,17 @@ jobs:
             🛠 Updatecli pipeline charts bump
           commit_user_name: ${{ vars.BOT_GITHUB_USERNAME }}
           commit_user_email: ${{ vars.BOT_GITHUB_EMAIL }}
-          branch: ${{ github.ref_name == env.DEFAULT_BRANCH_NAME && 'updatecli-bump-helm' || github.ref_name }}
+          branch: ${{ env.USE_DEDICATED_BRANCH == 'true' && 'updatecli-bump-helm' || github.ref_name }}
           create_branch: true
-          push_options: ${{ github.ref_name == env.DEFAULT_BRANCH_NAME && '--force' || '' }}
+          push_options: ${{ env.USE_DEDICATED_BRANCH == 'true' && '--force' || '' }}
 
   bump-values-dependencies:
     runs-on: ubuntu-latest
     name: Image tags values dependencies
     permissions: {}
     if: (inputs.update-type == 'values' || inputs.update-type == 'all' || github.event_name == 'push') && github.actor != 'dependabot[bot]'
+    env:
+      USE_DEDICATED_BRANCH: ${{ github.event_name == 'workflow_call' || github.ref_name == env.DEFAULT_BRANCH_NAME }}
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
@@ -129,6 +133,6 @@ jobs:
             🛠 Updatecli pipeline values bump
           commit_user_name: ${{ vars.BOT_GITHUB_USERNAME }}
           commit_user_email: ${{ vars.BOT_GITHUB_EMAIL }}
-          branch: ${{ github.ref_name == env.DEFAULT_BRANCH_NAME && 'updatecli-bump-acs' || github.ref_name }}
+          branch: ${{ env.USE_DEDICATED_BRANCH == 'true' && 'updatecli-bump-acs' || github.ref_name }}
           create_branch: true
-          push_options: ${{ github.ref_name == env.DEFAULT_BRANCH_NAME && '--force' || '' }}
+          push_options: ${{ env.USE_DEDICATED_BRANCH == 'true' && '--force' || '' }}

--- a/.github/workflows/release-orchestrator.yml
+++ b/.github/workflows/release-orchestrator.yml
@@ -106,7 +106,7 @@ jobs:
           jira_prefix="${JIRA_ID:+${JIRA_ID} }"
           title="${jira_prefix}release: prepare ${ACS_NEXT} (${RELEASE_NAME})"
           sanitized=$(echo "$RELEASE_NAME" | tr '[:upper:]' '[:lower:]' | tr -cs 'a-z0-9' '-' | tr -s '-' | sed 's/-$//')
-          branch="release/${sanitized}"
+          branch="prepare/release-${sanitized}"
 
           git checkout -b "$branch"
           git add helm/ docker-compose/

--- a/.github/workflows/release-orchestrator.yml
+++ b/.github/workflows/release-orchestrator.yml
@@ -22,22 +22,15 @@ permissions:
   contents: read
 
 jobs:
-  bump-charts:
+  bump-versions:
     if: inputs.bump-versions
     uses: ./.github/workflows/bumpVersions.yml
     with:
-      update-type: charts
-    secrets: inherit
-
-  bump-values:
-    if: inputs.bump-versions
-    uses: ./.github/workflows/bumpVersions.yml
-    with:
-      update-type: values
+      update-type: all
     secrets: inherit
 
   prepare-release:
-    needs: [bump-charts, bump-values]
+    needs: [bump-versions]
     if: always() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled')
     runs-on: ubuntu-latest
     permissions: {}

--- a/.github/workflows/release-orchestrator.yml
+++ b/.github/workflows/release-orchestrator.yml
@@ -144,6 +144,6 @@ jobs:
             --base master \
             --head "$BRANCH" \
             --draft \
-            --label release --label automation \
+            --label release \
             --body-file /tmp/pr-body.md)
           echo "url=$url" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release-orchestrator.yml
+++ b/.github/workflows/release-orchestrator.yml
@@ -111,7 +111,7 @@ jobs:
           git checkout -b "$branch"
           git add helm/ docker-compose/
           git commit -m "$title"
-          git push origin "$branch"
+          git push --force origin "$branch"
 
           echo "title=$title"   >> "$GITHUB_OUTPUT"
           echo "branch=$branch" >> "$GITHUB_OUTPUT"

--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ Please use [this guide](CONTRIBUTING.md) to make a contribution to the project a
 
 ### Helm charts release
 
+> **Preferred method:** use the [Release Orchestrator][2] workflow. It automates the steps below (bump versions, version bump, helm-docs refresh, draft PR) in a single run. Trigger it with a release codename and optionally a Jira ticket ID. The manual steps below remain valid for cases where more control is needed.
+
 New releases are usually made from the default branch. When a bugfix release is
 necessary and master branch already received updates that are meant to be
 released at a later time, then the release must be made from a branch which
@@ -139,6 +141,7 @@ Start the release by opening a PR against the appropriate branch that will:
   Inspect the changes pushed on the branch, looking for any missing update.
 
 [1]: https://github.com/Alfresco/acs-deployment/actions/workflows/bumpVersions.yml
+[2]: https://github.com/Alfresco/acs-deployment/actions/workflows/release-orchestrator.yml
 
 Once the PR has been merged, create the release with:
 


### PR DESCRIPTION
## Summary

- Consolidates the two separate `bump-charts`/`bump-values` caller jobs in the release orchestrator into a single `bump-versions` job using a new `update-type: all` option, which triggers both internal jobs in one `workflow_call`
- Fixes updatecli pushing to the caller branch instead of the dedicated `updatecli-bump-*` branches when the orchestrator runs from a non-master branch (detects `update-type == 'all'` as the signal)
- Removes the now-unused `DEFAULT_BRANCH_NAME` workflow-level env var; hoists the repeated branch-targeting condition into a job-level `USE_DEDICATED_BRANCH` env var
- Switches the release prep branch from `release/*` (protected) to `prepare/release-*` to allow direct push
- Force-pushes the prep branch to handle re-runs cleanly
- Documents the Release Orchestrator as the preferred way to start a release in the README
- Removes the redundant `automation` label from the draft PR created by the orchestrator

OPSEXP-4102