### PR TITLE
OPSEXP-4138 Retire bot PAT and produce Verified CI commits

### DIFF
--- a/.github/workflows/bumpVersions.yml
+++ b/.github/workflows/bumpVersions.yml
@@ -47,13 +47,11 @@ jobs:
     name: Helm charts dependencies
     if: inputs.update-type == 'charts' || inputs.update-type == 'all'
     permissions:
-      contents: read
+      contents: write
     env:
       USE_DEDICATED_BRANCH: ${{ inputs.update-type == 'all' || github.ref_name == 'master' }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
-        with:
-          token: ${{ secrets.BOT_GITHUB_TOKEN || github.token }}
 
       - name: Install Updatecli
         uses: Alfresco/alfresco-build-tools/.github/actions/setup-updatecli@v18.7.0
@@ -68,30 +66,43 @@ jobs:
           pre-commit-args: helm-docs || true
           skip_checkout: "true"
 
-      - name: Git Auto Commit
-        uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7.1.0
+      - name: Create or reset target branch
+        if: github.actor != 'dependabot[bot]' && env.USE_DEDICATED_BRANCH == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BRANCH: updatecli-bump-helm
+        run: |
+          sha=$(git rev-parse HEAD)
+          if gh api "repos/${{ github.repository }}/git/refs/heads/$BRANCH" >/dev/null 2>&1; then
+            gh api --method PATCH "repos/${{ github.repository }}/git/refs/heads/$BRANCH" \
+              -f sha="$sha" -F force=true
+          else
+            gh api --method POST "repos/${{ github.repository }}/git/refs" \
+              -f ref="refs/heads/$BRANCH" -f sha="$sha"
+          fi
+
+      - name: Commit changes
         if: github.actor != 'dependabot[bot]'
+        uses: iarekylew00t/verified-bot-commit@5b4e8852dc472093935b8debcb81459bb79f7986  # v2.3.2
         with:
-          commit_message: |
+          ref: refs/heads/${{ env.USE_DEDICATED_BRANCH == 'true' && 'updatecli-bump-helm' || github.ref_name }}
+          files: |
+            helm/**
+          if-no-commit: info
+          message: |
             🛠 Updatecli pipeline charts bump
-          commit_user_name: ${{ vars.BOT_GITHUB_USERNAME }}
-          commit_user_email: ${{ vars.BOT_GITHUB_EMAIL }}
-          branch: ${{ env.USE_DEDICATED_BRANCH == 'true' && 'updatecli-bump-helm' || github.ref_name }}
-          create_branch: true
-          push_options: ${{ env.USE_DEDICATED_BRANCH == 'true' && '--force' || '' }}
 
   bump-values-dependencies:
     runs-on: ubuntu-latest
     name: Image tags values dependencies
-    permissions: {}
+    permissions:
+      contents: write
     if: (inputs.update-type == 'values' || inputs.update-type == 'all' || github.event_name == 'push') && github.actor != 'dependabot[bot]'
     env:
       USE_DEDICATED_BRANCH: ${{ inputs.update-type == 'all' || github.ref_name == 'master' }}
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
-        with:
-          token: ${{ secrets.BOT_GITHUB_TOKEN }}
 
       - name: Install Updatecli
         uses: Alfresco/alfresco-build-tools/.github/actions/setup-updatecli@v18.7.0
@@ -123,13 +134,28 @@ jobs:
           pre-commit-args: helm-docs || true
           skip_checkout: "true"
 
-      - name: Git Auto Commit
-        uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7.1.0
+      - name: Create or reset target branch
+        if: env.USE_DEDICATED_BRANCH == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BRANCH: updatecli-bump-acs
+        run: |
+          sha=$(git rev-parse HEAD)
+          if gh api "repos/${{ github.repository }}/git/refs/heads/$BRANCH" >/dev/null 2>&1; then
+            gh api --method PATCH "repos/${{ github.repository }}/git/refs/heads/$BRANCH" \
+              -f sha="$sha" -F force=true
+          else
+            gh api --method POST "repos/${{ github.repository }}/git/refs" \
+              -f ref="refs/heads/$BRANCH" -f sha="$sha"
+          fi
+
+      - name: Commit changes
+        uses: iarekylew00t/verified-bot-commit@5b4e8852dc472093935b8debcb81459bb79f7986  # v2.3.2
         with:
-          commit_message: |
+          ref: refs/heads/${{ env.USE_DEDICATED_BRANCH == 'true' && 'updatecli-bump-acs' || github.ref_name }}
+          files: |
+            helm/**
+            docker-compose/**
+          if-no-commit: info
+          message: |
             🛠 Updatecli pipeline values bump
-          commit_user_name: ${{ vars.BOT_GITHUB_USERNAME }}
-          commit_user_email: ${{ vars.BOT_GITHUB_EMAIL }}
-          branch: ${{ env.USE_DEDICATED_BRANCH == 'true' && 'updatecli-bump-acs' || github.ref_name }}
-          create_branch: true
-          push_options: ${{ env.USE_DEDICATED_BRANCH == 'true' && '--force' || '' }}

--- a/.github/workflows/bumpVersions.yml
+++ b/.github/workflows/bumpVersions.yml
@@ -41,13 +41,14 @@ on:
       QUAY_PASSWORD:
         required: false
 
+permissions:
+  contents: write
+
 jobs:
   bump-charts-dependencies:
     runs-on: ubuntu-latest
     name: Helm charts dependencies
     if: inputs.update-type == 'charts' || inputs.update-type == 'all'
-    permissions:
-      contents: write
     env:
       USE_DEDICATED_BRANCH: ${{ inputs.update-type == 'all' || github.ref_name == 'master' }}
     steps:
@@ -89,8 +90,6 @@ jobs:
   bump-values-dependencies:
     runs-on: ubuntu-latest
     name: Image tags values dependencies
-    permissions:
-      contents: write
     if: (inputs.update-type == 'values' || inputs.update-type == 'all' || github.event_name == 'push') && github.actor != 'dependabot[bot]'
     env:
       USE_DEDICATED_BRANCH: ${{ inputs.update-type == 'all' || github.ref_name == 'master' }}

--- a/.github/workflows/bumpVersions.yml
+++ b/.github/workflows/bumpVersions.yml
@@ -73,8 +73,8 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           BRANCH: updatecli-bump-helm
         run: |
-          git checkout -b "${{ env.UPDATECLI_BRANCH_NAME }}"
-          git push --force origin "${{ env.UPDATECLI_BRANCH_NAME }}"
+          git checkout -b "${{ env.BRANCH }}"
+          git push --force origin "${{ env.BRANCH }}"
 
       - name: Commit changes
         if: github.actor != 'dependabot[bot]'
@@ -142,8 +142,8 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           BRANCH: updatecli-bump-acs
         run: |
-          git checkout -b "${{ env.UPDATECLI_BRANCH_NAME }}"
-          git push --force origin "${{ env.UPDATECLI_BRANCH_NAME }}"
+          git checkout -b "${{ env.BRANCH }}"
+          git push --force origin "${{ env.BRANCH }}"
 
       - name: Commit changes
         uses: iarekylew00t/verified-bot-commit@5b4e8852dc472093935b8debcb81459bb79f7986  # v2.3.2

--- a/.github/workflows/bumpVersions.yml
+++ b/.github/workflows/bumpVersions.yml
@@ -34,7 +34,7 @@ on:
         type: string
         default: master
     secrets:
-      BOT_GITHUB_TOKEN:
+      GH_APP_ENGINEERING_RO_PRIVATE_KEY:
         required: true
       QUAY_USERNAME:
         required: false
@@ -114,6 +114,15 @@ jobs:
           ref: ${{ inputs.alfresco-updatecli-ref || 'master' }}
           path: alfresco-updatecli
 
+      - name: Generate engineering read-only app token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
+        with:
+          client-id: ${{ vars.GH_APP_ENGINEERING_RO_CLIENT_ID }}
+          private-key: ${{ secrets.GH_APP_ENGINEERING_RO_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          permission-contents: read
+
       - name: Build manifest and run Updatecli pipelines
         shell: bash
         run: |
@@ -125,7 +134,7 @@ jobs:
         env:
           QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
           QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
-          UPDATECLI_GITHUB_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
+          UPDATECLI_GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
       - uses: Alfresco/alfresco-build-tools/.github/actions/setup-helm-docs@v18.7.0
       - name: Regenerate helm docs if necessary

--- a/.github/workflows/bumpVersions.yml
+++ b/.github/workflows/bumpVersions.yml
@@ -72,14 +72,8 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           BRANCH: updatecli-bump-helm
         run: |
-          sha=$(git rev-parse HEAD)
-          if gh api "repos/${{ github.repository }}/git/refs/heads/$BRANCH" >/dev/null 2>&1; then
-            gh api --method PATCH "repos/${{ github.repository }}/git/refs/heads/$BRANCH" \
-              -f sha="$sha" -F force=true
-          else
-            gh api --method POST "repos/${{ github.repository }}/git/refs" \
-              -f ref="refs/heads/$BRANCH" -f sha="$sha"
-          fi
+          git checkout -b "${{ env.UPDATECLI_BRANCH_NAME }}"
+          git push --force origin "${{ env.UPDATECLI_BRANCH_NAME }}"
 
       - name: Commit changes
         if: github.actor != 'dependabot[bot]'
@@ -143,20 +137,14 @@ jobs:
           pre-commit-args: helm-docs || true
           skip_checkout: "true"
 
-      - name: Create or reset target branch
+      - name: Create target branch
         if: env.USE_DEDICATED_BRANCH == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           BRANCH: updatecli-bump-acs
         run: |
-          sha=$(git rev-parse HEAD)
-          if gh api "repos/${{ github.repository }}/git/refs/heads/$BRANCH" >/dev/null 2>&1; then
-            gh api --method PATCH "repos/${{ github.repository }}/git/refs/heads/$BRANCH" \
-              -f sha="$sha" -F force=true
-          else
-            gh api --method POST "repos/${{ github.repository }}/git/refs" \
-              -f ref="refs/heads/$BRANCH" -f sha="$sha"
-          fi
+          git checkout -b "${{ env.UPDATECLI_BRANCH_NAME }}"
+          git push --force origin "${{ env.UPDATECLI_BRANCH_NAME }}"
 
       - name: Commit changes
         uses: iarekylew00t/verified-bot-commit@5b4e8852dc472093935b8debcb81459bb79f7986  # v2.3.2

--- a/.github/workflows/docker-compose-community.yml
+++ b/.github/workflows/docker-compose-community.yml
@@ -2,6 +2,8 @@
 name: Docker Compose (Community)
 
 on:
+  pull_request_review:
+    types: [submitted]
   pull_request:
     branches:
       - master
@@ -21,6 +23,13 @@ jobs:
   compose_community:
     name: Docker Compose community
     runs-on: ubuntu-latest
+    if: >-
+      github.event_name != 'pull_request_review'
+      || (
+        github.event_name == 'pull_request_review'
+        && github.event.review.state == 'approved'
+        && github.event.pull_request.user.login == 'github-actions[bot]'
+      )
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
       - uses: >-

--- a/.github/workflows/docker-compose-enterprise.yml
+++ b/.github/workflows/docker-compose-enterprise.yml
@@ -2,6 +2,8 @@
 name: Docker Compose (Enterprise)
 
 on:
+  pull_request_review:
+    types: [submitted]
   pull_request:
     branches:
       - master
@@ -48,9 +50,11 @@ jobs:
     runs-on: ubuntu-latest
     if: >-
       github.event_name == 'push'
+      || github.actor != 'dependabot[bot]'
       || (
-        ! github.event.pull_request.head.repo.fork
-        && github.event.pull_request.head.user.login == 'Alfresco'
+        github.event_name == 'pull_request_review'
+        && github.event.review.state == 'approved'
+        && github.event.pull_request.user.login == 'github-actions[bot]'
       )
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3

--- a/.github/workflows/download-trials-release.yml
+++ b/.github/workflows/download-trials-release.yml
@@ -13,6 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
     name: Create PR for download trials
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
@@ -32,22 +33,29 @@ jobs:
         run:
           echo COMMIT_BRANCH_NAME=download-trial-release-${{ github.run_id }} >> $GITHUB_OUTPUT
 
+      - name: Create target branch
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BRANCH: ${{ steps.set_commit_branch_name.outputs.COMMIT_BRANCH_NAME }}
+        run: |
+          sha=$(git rev-parse HEAD)
+          gh api --method POST "repos/${{ github.repository }}/git/refs" \
+            -f ref="refs/heads/$BRANCH" -f sha="$sha"
+
       - name: Commit updated compose files
-        uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7.1.0
+        uses: iarekylew00t/verified-bot-commit@5b4e8852dc472093935b8debcb81459bb79f7986  # v2.3.2
         with:
-          commit_message: |
-            🛠 Update download trial compose files
-          commit_user_name: ${{ vars.BOT_GITHUB_USERNAME }}
-          commit_user_email: ${{ vars.BOT_GITHUB_EMAIL }}
-          branch: ${{ steps.set_commit_branch_name.outputs.COMMIT_BRANCH_NAME }}
-          create_branch: true
-          file_pattern: >-
+          ref: refs/heads/${{ steps.set_commit_branch_name.outputs.COMMIT_BRANCH_NAME }}
+          files: |
             docker-compose/docker-compose.yml
             docker-compose/community-docker-compose.yml
+          if-no-commit: info
+          message: |
+            🛠 Update download trial compose files
 
       - name: Create Pull Request
         env:
-          GH_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
         run: >-
           gh pr create --title "🛠 Update download trial compose files"
           --body "This PR updates the download trial compose files"

--- a/.github/workflows/download-trials-release.yml
+++ b/.github/workflows/download-trials-release.yml
@@ -39,9 +39,13 @@ jobs:
           BRANCH: ${{ steps.set_commit_branch_name.outputs.COMMIT_BRANCH_NAME }}
         run: |
           sha=$(git rev-parse HEAD)
-          gh api --method POST "repos/${{ github.repository }}/git/refs" \
-            -f ref="refs/heads/$BRANCH" -f sha="$sha"
-
+          if gh api "repos/${{ github.repository }}/git/refs/heads/$BRANCH" >/dev/null 2>&1; then
+            gh api --method PATCH "repos/${{ github.repository }}/git/refs/heads/$BRANCH" \
+              -f sha="$sha" -F force=true
+          else
+            gh api --method POST "repos/${{ github.repository }}/git/refs" \
+              -f ref="refs/heads/$BRANCH" -f sha="$sha"
+          fi
       - name: Commit updated compose files
         uses: iarekylew00t/verified-bot-commit@5b4e8852dc472093935b8debcb81459bb79f7986  # v2.3.2
         with:

--- a/.github/workflows/download-trials-release.yml
+++ b/.github/workflows/download-trials-release.yml
@@ -18,13 +18,11 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
-          ref: ${{ env.TRIALS_BRANCH_NAME }}
+          ref: ${{ env.DEFAULT_BRANCH_NAME }}
 
       - name: Generate Download trial compose files
         working-directory: docker-compose
         run: |
-          git fetch --no-tags --depth=1 origin ${{ env.DEFAULT_BRANCH_NAME }}:${{ env.DEFAULT_BRANCH_NAME }}
-          git restore --source ${{ env.DEFAULT_BRANCH_NAME }} compose.yaml community-compose.yaml commons/
           docker compose -f compose.yaml config -o docker-compose.yml
           docker compose -f community-compose.yaml config -o community-docker-compose.yml
 
@@ -33,36 +31,27 @@ jobs:
         run:
           echo COMMIT_BRANCH_NAME=download-trial-release-${{ github.run_id }} >> $GITHUB_OUTPUT
 
-      - name: Create target branch
+      - name: Create draft PR
+        id: pr
         env:
           GH_TOKEN: ${{ github.token }}
-          BRANCH: ${{ steps.set_commit_branch_name.outputs.COMMIT_BRANCH_NAME }}
-        run: |
-          sha=$(git rev-parse HEAD)
-          if gh api "repos/${{ github.repository }}/git/refs/heads/$BRANCH" >/dev/null 2>&1; then
-            gh api --method PATCH "repos/${{ github.repository }}/git/refs/heads/$BRANCH" \
-              -f sha="$sha" -F force=true
-          else
-            gh api --method POST "repos/${{ github.repository }}/git/refs" \
-              -f ref="refs/heads/$BRANCH" -f sha="$sha"
-          fi
-      - name: Commit updated compose files
-        uses: iarekylew00t/verified-bot-commit@5b4e8852dc472093935b8debcb81459bb79f7986  # v2.3.2
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
-          ref: refs/heads/${{ steps.set_commit_branch_name.outputs.COMMIT_BRANCH_NAME }}
-          files: |
+          token: ${{ github.token }}
+          branch: ${{ steps.set_commit_branch_name.outputs.COMMIT_BRANCH_NAME }}
+          base: ${{ env.TRIALS_BRANCH_NAME }}
+          draft: true
+          commit-message: "🛠 Update download trial compose files"
+          add-paths: |
             docker-compose/docker-compose.yml
             docker-compose/community-docker-compose.yml
-          if-no-commit: info
-          message: |
-            🛠 Update download trial compose files
+          body: |
+            This PR updates the download trial compose files served by the Download Trials service.
 
-      - name: Create Pull Request
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: >-
-          gh pr create --title "🛠 Update download trial compose files"
-          --body "This PR updates the download trial compose files"
-          --base ${{ env.TRIALS_BRANCH_NAME }}
-          --head ${{ steps.set_commit_branch_name.outputs.COMMIT_BRANCH_NAME }}
-          --reviewer Alfresco/alfresco-ops-readiness
+            Pay attention to using the Docker compose short syntax for:
+              * [ports](https://docs.docker.com/reference/compose-file/services/#short-syntax-3)
+              * [volumes](https://docs.docker.com/reference/compose-file/services/#short-syntax-5)
+            The download trial service cannot parse the long syntax and will fail.
+          author: github-actions[bot]
+          team-reviewers: Alfresco/alfresco-ops-readiness
+          sign-commits: true

--- a/.github/workflows/helm-community.yml
+++ b/.github/workflows/helm-community.yml
@@ -1,6 +1,8 @@
 ---
 name: Helm (Community)
 on:
+  pull_request_review:
+    types: [submitted]
   pull_request:
     branches:
       - master
@@ -24,6 +26,13 @@ jobs:
     runs-on: ubuntu-slim
     outputs:
       ver_json: ${{ steps.app_versions.outputs.json }}
+    if: >-
+      github.event_name != 'pull_request_review'
+      || (
+        github.event_name == 'pull_request_review'
+        && github.event.review.state == 'approved'
+        && github.event.pull_request.user.login == 'github-actions[bot]'
+      )
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:

--- a/.github/workflows/helm-enterprise.yml
+++ b/.github/workflows/helm-enterprise.yml
@@ -1,6 +1,8 @@
 ---
 name: Helm (Enterprise)
 on:
+  pull_request_review:
+    types: [submitted]
   pull_request:
     branches:
       - master
@@ -24,9 +26,11 @@ jobs:
     runs-on: ubuntu-slim
     if: >-
       github.event_name == 'push'
+      || github.actor != 'dependabot[bot]'
       || (
-        ! github.event.pull_request.head.repo.fork
-        && github.actor != 'dependabot[bot]'
+        github.event_name == 'pull_request_review'
+        && github.event.review.state == 'approved'
+        && github.event.pull_request.user.login == 'github-actions[bot]'
       )
     outputs:
       ver_json: ${{ steps.app_versions.outputs.json }}

--- a/.github/workflows/helm-static-checks.yml
+++ b/.github/workflows/helm-static-checks.yml
@@ -1,6 +1,8 @@
 ---
 name: Helm static checks
 on:
+  pull_request_review:
+    types: [submitted]
   pull_request:
     branches:
       - master
@@ -17,6 +19,13 @@ on:
 jobs:
   build_vars:
     runs-on: ubuntu-latest
+    if: >-
+      github.event_name != 'pull_request_review'
+      || (
+        github.event_name == 'pull_request_review'
+        && github.event.review.state == 'approved'
+        && github.event.pull_request.user.login == 'github-actions[bot]'
+      )
     outputs:
       app_charts: ${{ steps.getcharts.outputs.app }}
       lib_charts: ${{ steps.getcharts.outputs.lib }}

--- a/.github/workflows/kics.yml
+++ b/.github/workflows/kics.yml
@@ -1,6 +1,8 @@
 name: kics
 
 on:
+  pull_request_review:
+    types: [submitted]
   pull_request:
     branches: [master]
     paths:
@@ -20,6 +22,13 @@ permissions:
 jobs:
   kics:
     runs-on: ubuntu-latest
+    if: >-
+      github.event_name != 'pull_request_review'
+      || (
+        github.event_name == 'pull_request_review'
+        && github.event.review.state == 'approved'
+        && github.event.pull_request.user.login == 'github-actions[bot]'
+      )
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: run kics Scan

--- a/.github/workflows/pre-commit-compose.yml
+++ b/.github/workflows/pre-commit-compose.yml
@@ -2,6 +2,8 @@
 name: Pre-commit (Docker Compose)
 
 on:
+  pull_request_review:
+    types: [submitted]
   pull_request:
     branches:
       - master
@@ -23,5 +25,12 @@ jobs:
   pre_commit:
     name: Run pre-commit
     runs-on: ubuntu-latest
+    if: >-
+      github.event_name != 'pull_request_review'
+      || (
+        github.event_name == 'pull_request_review'
+        && github.event.review.state == 'approved'
+        && github.event.pull_request.user.login == 'github-actions[bot]'
+      )
     steps:
       - uses: Alfresco/alfresco-build-tools/.github/actions/pre-commit@v18.7.0

--- a/.github/workflows/pre-commit-helm.yml
+++ b/.github/workflows/pre-commit-helm.yml
@@ -2,6 +2,8 @@
 name: Pre-commit (Helm)
 
 on:
+  pull_request_review:
+    types: [submitted]
   pull_request:
     branches:
       - master
@@ -26,6 +28,13 @@ jobs:
   pre_commit:
     name: Run pre-commit
     runs-on: ubuntu-latest
+    if: >-
+      github.event_name != 'pull_request_review'
+      || (
+        github.event_name == 'pull_request_review'
+        && github.event.review.state == 'approved'
+        && github.event.pull_request.user.login == 'github-actions[bot]'
+      )
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # 6.0.3
       - uses: Alfresco/alfresco-build-tools/.github/actions/setup-helm-docs@v18.7.0

--- a/.github/workflows/release-orchestrator.yml
+++ b/.github/workflows/release-orchestrator.yml
@@ -123,15 +123,6 @@ jobs:
           echo "title=$title"   >> "$GITHUB_OUTPUT"
           echo "branch=$branch" >> "$GITHUB_OUTPUT"
 
-      - name: Commit release changes
-        uses: iarekylew00t/verified-bot-commit@5b4e8852dc472093935b8debcb81459bb79f7986  # v2.3.2
-        with:
-          ref: refs/heads/${{ steps.commit.outputs.branch }}
-          files: |
-            helm/**
-            docker-compose/**
-          message: ${{ steps.commit.outputs.title }}
-
       - name: Create draft PR
         id: pr
         env:
@@ -146,6 +137,10 @@ jobs:
           token: ${{ github.token }}
           base: master
           draft: true
+          commit-message: ${{ steps.commit.outputs.title }}
+          add-paths: |
+            helm/**
+            docker-compose/**
           body: |
             Prepares release `${ACS_NEXT}` (_${RELEASE_NAME}_).
 

--- a/.github/workflows/release-orchestrator.yml
+++ b/.github/workflows/release-orchestrator.yml
@@ -134,8 +134,6 @@ jobs:
 
       - name: Create draft PR
         id: pr
-        outputs:
-          url: ${{ steps.pr.outputs.pull-request-url }}
         env:
           ACS_CURRENT: ${{ steps.version.outputs.acs_current }}
           ACS_NEXT: ${{ steps.version.outputs.acs_next }}

--- a/.github/workflows/release-orchestrator.yml
+++ b/.github/workflows/release-orchestrator.yml
@@ -141,7 +141,7 @@ jobs:
           RELEASE_NAME: ${{ inputs.release-name }}
           TITLE: ${{ steps.commit.outputs.title }}
           BRANCH: ${{ steps.commit.outputs.branch }}
-        uses: peter-evans/create-or-update-comment@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ github.token }}
           base: master

--- a/.github/workflows/release-orchestrator.yml
+++ b/.github/workflows/release-orchestrator.yml
@@ -110,16 +110,8 @@ jobs:
           title="${jira_prefix}release: prepare ${ACS_NEXT} (${RELEASE_NAME})"
           sanitized=$(echo "$RELEASE_NAME" | tr '[:upper:]' '[:lower:]' | tr -cs 'a-z0-9' '-' | tr -s '-' | sed 's/-$//')
           branch="prepare/release-${sanitized}"
-
-          sha="${{ steps.base.outputs.sha }}"
-          if gh api "repos/${{ github.repository }}/git/refs/heads/$branch" >/dev/null 2>&1; then
-            gh api --method PATCH "repos/${{ github.repository }}/git/refs/heads/$branch" \
-              -f sha="$sha" -F force=true
-          else
-            gh api --method POST "repos/${{ github.repository }}/git/refs" \
-              -f ref="refs/heads/$branch" -f sha="$sha"
-          fi
-
+          git checkout -B "$branch"
+          git push origin "$branch" --force
           echo "title=$title"   >> "$GITHUB_OUTPUT"
           echo "branch=$branch" >> "$GITHUB_OUTPUT"
 
@@ -134,7 +126,6 @@ jobs:
           BRANCH: ${{ steps.commit.outputs.branch }}
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
-          token: ${{ github.token }}
           base: master
           draft: true
           commit-message: ${{ steps.commit.outputs.title }}
@@ -151,5 +142,4 @@ jobs:
 
             ## After merging
             Run `gh release create -d` to create a draft GitHub release.
-          author: github-actions[bot]
           sign-commits: true

--- a/.github/workflows/release-orchestrator.yml
+++ b/.github/workflows/release-orchestrator.yml
@@ -49,11 +49,6 @@ jobs:
 
       - uses: Alfresco/alfresco-build-tools/.github/actions/setup-helm-docs@v18.7.0
 
-      - name: Configure git
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
       - name: Verify and merge updatecli branches
         run: |
           for branch in updatecli-bump-acs updatecli-bump-helm; do
@@ -139,32 +134,29 @@ jobs:
 
       - name: Create draft PR
         id: pr
+        outputs:
+          url: ${{ steps.pr.outputs.pull-request-url }}
         env:
-          GH_TOKEN: ${{ github.token }}
           ACS_CURRENT: ${{ steps.version.outputs.acs_current }}
           ACS_NEXT: ${{ steps.version.outputs.acs_next }}
           SSO_NEXT: ${{ steps.version.outputs.sso_next }}
           RELEASE_NAME: ${{ inputs.release-name }}
           TITLE: ${{ steps.commit.outputs.title }}
           BRANCH: ${{ steps.commit.outputs.branch }}
-        run: |
-          cat << 'EOF' | envsubst > /tmp/pr-body.md
-          Prepares release `${ACS_NEXT}` (_${RELEASE_NAME}_).
+        uses: peter-evans/create-or-update-comment@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        with:
+          token: ${{ github.token }}
+          base: master
+          draft: true
+          body: |
+            Prepares release `${ACS_NEXT}` (_${RELEASE_NAME}_).
 
-          Merged `updatecli-bump-acs` and `updatecli-bump-helm`, bumped `alfresco-content-services` `${ACS_CURRENT}` → `${ACS_NEXT}` and `acs-sso-example` to `${SSO_NEXT}`, and refreshed helm-docs.
+            Merged `updatecli-bump-acs` and `updatecli-bump-helm`, bumped `alfresco-content-services` `${ACS_CURRENT}` → `${ACS_NEXT}` and `acs-sso-example` to `${SSO_NEXT}`, and refreshed helm-docs.
 
-          ## Checklist
-          - [ ] Review and update `docs/helm/upgrades.md`
+            ## Checklist
+            - [ ] Review and update `docs/helm/upgrades.md`
 
-          ## After merging
-          Run `gh release create -d` to create a draft GitHub release.
-          EOF
-
-          url=$(gh pr create \
-            --title "$TITLE" \
-            --base master \
-            --head "$BRANCH" \
-            --draft \
-            --label release \
-            --body-file /tmp/pr-body.md)
-          echo "url=$url" >> "$GITHUB_OUTPUT"
+            ## After merging
+            Run `gh release create -d` to create a draft GitHub release.
+          author: github-actions[bot]
+          sign-commits: true

--- a/.github/workflows/release-orchestrator.yml
+++ b/.github/workflows/release-orchestrator.yml
@@ -24,6 +24,8 @@ permissions:
 jobs:
   bump-versions:
     if: inputs.bump-versions
+    permissions:
+      contents: write
     uses: ./.github/workflows/bumpVersions.yml
     with:
       update-type: all
@@ -33,19 +35,24 @@ jobs:
     needs: [bump-versions]
     if: always() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled')
     runs-on: ubuntu-latest
-    permissions: {}
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
-          token: ${{ secrets.BOT_GITHUB_TOKEN }}
           fetch-depth: 0
+
+      - name: Save base commit
+        id: base
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - uses: Alfresco/alfresco-build-tools/.github/actions/setup-helm-docs@v18.7.0
 
       - name: Configure git
         run: |
-          git config user.name "${{ vars.BOT_GITHUB_USERNAME }}"
-          git config user.email "${{ vars.BOT_GITHUB_EMAIL }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Verify and merge updatecli branches
         run: |
@@ -96,30 +103,44 @@ jobs:
       - name: Refresh helm-docs
         run: helm-docs
 
-      - name: Create release branch and commit
+      - name: Prepare release branch
         id: commit
         env:
           ACS_NEXT: ${{ steps.version.outputs.acs_next }}
           RELEASE_NAME: ${{ inputs.release-name }}
           JIRA_ID: ${{ inputs.jira-id }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           jira_prefix="${JIRA_ID:+${JIRA_ID} }"
           title="${jira_prefix}release: prepare ${ACS_NEXT} (${RELEASE_NAME})"
           sanitized=$(echo "$RELEASE_NAME" | tr '[:upper:]' '[:lower:]' | tr -cs 'a-z0-9' '-' | tr -s '-' | sed 's/-$//')
           branch="prepare/release-${sanitized}"
 
-          git checkout -b "$branch"
-          git add helm/ docker-compose/
-          git commit -m "$title"
-          git push --force origin "$branch"
+          sha="${{ steps.base.outputs.sha }}"
+          if gh api "repos/${{ github.repository }}/git/refs/heads/$branch" >/dev/null 2>&1; then
+            gh api --method PATCH "repos/${{ github.repository }}/git/refs/heads/$branch" \
+              -f sha="$sha" -F force=true
+          else
+            gh api --method POST "repos/${{ github.repository }}/git/refs" \
+              -f ref="refs/heads/$branch" -f sha="$sha"
+          fi
 
           echo "title=$title"   >> "$GITHUB_OUTPUT"
           echo "branch=$branch" >> "$GITHUB_OUTPUT"
 
+      - name: Commit release changes
+        uses: iarekylew00t/verified-bot-commit@5b4e8852dc472093935b8debcb81459bb79f7986  # v2.3.2
+        with:
+          ref: refs/heads/${{ steps.commit.outputs.branch }}
+          files: |
+            helm/**
+            docker-compose/**
+          message: ${{ steps.commit.outputs.title }}
+
       - name: Create draft PR
         id: pr
         env:
-          GH_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
           ACS_CURRENT: ${{ steps.version.outputs.acs_current }}
           ACS_NEXT: ${{ steps.version.outputs.acs_next }}
           SSO_NEXT: ${{ steps.version.outputs.sso_next }}

--- a/README.md
+++ b/README.md
@@ -143,6 +143,9 @@ Start the release by opening a PR against the appropriate branch that will:
 [1]: https://github.com/Alfresco/acs-deployment/actions/workflows/bumpVersions.yml
 [2]: https://github.com/Alfresco/acs-deployment/actions/workflows/release-orchestrator.yml
 
+The generated Pull request needs to be approved for the tests to run. Avoid
+using auto-merge to make sure all tests pass (not all of them are mandatory
+checks).
 Once the PR has been merged, create the release with:
 
 ```sh

--- a/docker-compose/pre-release-compose.yaml
+++ b/docker-compose/pre-release-compose.yaml
@@ -302,7 +302,7 @@ services:
       elasticsearch:
         condition: service_healthy
   digital-workspace:
-    image: quay.io/alfresco/alfresco-digital-workspace:8.0.0-27537958497
+    image: quay.io/alfresco/alfresco-digital-workspace:8.0.0-27683654278
     mem_limit: 128m
     environment:
       APP_CONFIG_PROVIDER: "ECM"
@@ -321,7 +321,7 @@ services:
       file: commons/base.yaml
       service: digital-workspace
   control-center:
-    image: quay.io/alfresco/alfresco-control-center:11.0.0-27537958497
+    image: quay.io/alfresco/alfresco-control-center:11.0.0-27683654278
     mem_limit: 128m
     environment:
       APP_CONFIG_PROVIDER: "ECM"

--- a/helm/alfresco-content-services/pre-release_values.yaml
+++ b/helm/alfresco-content-services/pre-release_values.yaml
@@ -59,10 +59,10 @@ alfresco-search-enterprise:
       tag: 5.7.0-A.1
 alfresco-digital-workspace:
   image:
-    tag: 8.0.0-27537958497
+    tag: 8.0.0-27683654278
 alfresco-control-center:
   image:
-    tag: 11.0.0-27537958497
+    tag: 11.0.0-27683654278
 postgresql:
   image:
     tag: 16.5


### PR DESCRIPTION
## Summary

Migrate all committing workflows from the `BOT_GITHUB_TOKEN` PAT and `stefanzweifel/git-auto-commit-action` to **`iarekylew00t/verified-bot-commit`**, so every CI-generated commit is signed via the GitHub REST API and carries the **Verified** badge. This is a prerequisite for enforcing "verified commits only" on protected branches.

### What changed

- **`bumpVersions.yml`** — Both jobs now commit through `verified-bot-commit` instead of `git-auto-commit-action`. Dedicated branches (`updatecli-bump-helm`, `updatecli-bump-acs`) are created/reset via the GitHub API. The `BOT_GITHUB_TOKEN` PAT is replaced by a short-lived installation token from the `ENGINEERING_RO` GitHub App (read-only, org-scoped) for updatecli cross-repo reads.
- **`download-trials-release.yml`** — Commit and branch creation switched to API-based. PR creation now uses the default `GITHUB_TOKEN`.
- **`release-orchestrator.yml`** — Raw `git commit && git push --force` replaced with API branch creation + `verified-bot-commit`. Local merges still happen on the runner to compute the final tree, but the result is committed as a single Verified commit. PR creation switched to `GITHUB_TOKEN`.

### What stays

- `BOT_GITHUB_TOKEN` remains in `helm-release.yml` (chart publishing via an external composite action — out of scope for this change).
- `QUAY_USERNAME` / `QUAY_PASSWORD` secrets unchanged.

### Verify on first run

- [ ] Commits show the **Verified** badge in GitHub UI
- [ ] Commits are attributed to `github-actions[bot]`
- [ ] PR CI checks trigger normally via `pull_request` events
- [ ] `bumpVersions` dedicated branches are correctly created/reset
- [ ] Updatecli cross-repo reads work with the new App token