### PR TITLE
OPSEXP-4167 Fix overly permissive review guard on enterprise CI jobs

### DIFF
--- a/.github/workflows/docker-compose-enterprise.yml
+++ b/.github/workflows/docker-compose-enterprise.yml
@@ -26,6 +26,14 @@ concurrency:
 jobs:
   build_vars:
     runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'push'
+      || (github.event_name == 'pull_request' && github.actor != 'dependabot[bot]')
+      || (
+        github.event_name == 'pull_request_review'
+        && github.event.review.state == 'approved'
+        && github.event.pull_request.user.login == 'github-actions[bot]'
+      )
     outputs:
       matrix_json: ${{ steps.eval.outputs.matrix_json }}
     steps:
@@ -48,14 +56,6 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJSON(needs.build_vars.outputs.matrix_json) }}
     runs-on: ubuntu-latest
-    if: >-
-      github.event_name == 'push'
-      || github.actor != 'dependabot[bot]'
-      || (
-        github.event_name == 'pull_request_review'
-        && github.event.review.state == 'approved'
-        && github.event.pull_request.user.login == 'github-actions[bot]'
-      )
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
       - name: Verify docker-compose

--- a/.github/workflows/helm-enterprise.yml
+++ b/.github/workflows/helm-enterprise.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-slim
     if: >-
       github.event_name == 'push'
-      || github.actor != 'dependabot[bot]'
+      || (github.event_name == 'pull_request' && github.actor != 'dependabot[bot]')
       || (
         github.event_name == 'pull_request_review'
         && github.event.review.state == 'approved'


### PR DESCRIPTION
The enterprise workflows gated their first job with a bare `github.actor != 'dependabot[bot]'` OR clause. On pull_request_review events github.actor is the reviewer (a human), so that clause was almost always true, causing the secret-using enterprise suites to re-run on every review of any PR (including plain comments and change requests) and making the approval clause dead code.

Bind the dependabot exclusion to pull_request events so the guard matches the intended design: run on push, on non-dependabot pull_request, or on an approved review of a github-actions[bot] PR.

Also add the guard to docker-compose-enterprise's build_vars job (which had none) and drop the now-redundant copy on compose_enterprise, which inherits the skip via its needs dependency.

OPSEXP-4167