### PR TITLE
OPSEXP-4167 Skip version checks for pre-release values

### DIFF
--- a/helm/alfresco-content-services/README.md
+++ b/helm/alfresco-content-services/README.md
@@ -249,7 +249,7 @@ Please refer to the [documentation](https://github.com/Alfresco/acs-deployment/b
 | dtas.enabled | bool | `false` | Enables the deployment test suite which can run via `helm test` (currently available for Enterprise only) |
 | dtas.image.pullPolicy | string | `"IfNotPresent"` |  |
 | dtas.image.repository | string | `"quay.io/alfresco/alfresco-deployment-test-automation-scripts"` |  |
-| dtas.image.tag | string | `"v1.7.4"` |  |
+| dtas.image.tag | string | `"v1.7.5"` |  |
 | elasticsearch.elasticsearch.image.repository | string | `"elasticsearch"` |  |
 | elasticsearch.elasticsearch.image.tag | string | `"8.17.10"` |  |
 | elasticsearch.elasticsearch.ingress.enabled | bool | `false` | toggle deploying elasticsearch-audit ingress |

--- a/helm/alfresco-content-services/pre-release_values.yaml
+++ b/helm/alfresco-content-services/pre-release_values.yaml
@@ -95,11 +95,8 @@ dtas:
         version: 26.2.0
         modules:
         - id: org_alfresco_device_sync_repo
-          version: 5.3.3-A.4
           installed: true
         - id: org.alfresco.integrations.google.docs
-          version: 4.1.0
           installed: true
         - id: alfresco-aos-module
-          version: 3.4.1
           installed: true

--- a/helm/alfresco-content-services/values.yaml
+++ b/helm/alfresco-content-services/values.yaml
@@ -628,7 +628,7 @@ dtas:
   enabled: false
   image:
     repository: quay.io/alfresco/alfresco-deployment-test-automation-scripts
-    tag: v1.7.4
+    tag: v1.7.5
     pullPolicy: IfNotPresent
   additionalArgs:
     - --tb=short


### PR DESCRIPTION
Fix https://github.com/Alfresco/acs-deployment/actions/runs/28775299528/job/85321467309#step:20:46

Pre-release module versions change often and are not worth automating, so this drops the per-module version pins from `pre-release_values.yaml` for the device-sync, google-docs, and aos modules. The dtas scripts image is bumped to `v1.7.5`, which supports the relaxed version checking, and the chart README is regenerated to match.

OPSEXP-4167