### PR TITLE
OPSEXP-3962 Use traefik GA helm chart

### DIFF
--- a/.github/workflows/helm-community.yml
+++ b/.github/workflows/helm-community.yml
@@ -84,7 +84,7 @@ jobs:
 
       - name: Setup cluster
         id: setup-kind
-        uses: Alfresco/alfresco-build-tools/.github/actions/setup-kind@v18.15.1
+        uses: Alfresco/alfresco-build-tools/.github/actions/setup-kind@bump-setup-kind-traefik-41
         with:
           traefik-enabled: true
           cloud-provider-kind-enabled: true

--- a/.github/workflows/helm-community.yml
+++ b/.github/workflows/helm-community.yml
@@ -196,11 +196,3 @@ jobs:
           namespace: default
           log_retention: 7
           log_name_identifier: "logs-pods-helm-com-${{ matrix.name }}"
-
-      - name: Upload traefik logs
-        if: always() && steps.helm_install.outcome != 'skipped'
-        uses: Alfresco/alfresco-build-tools/.github/actions/kubectl-keep-nslogs@v18.15.1
-        with:
-          namespace: traefik
-          log_retention: 7
-          log_name_identifier: "logs-traefik-helm-com-${{ matrix.name }}"

--- a/.github/workflows/helm-community.yml
+++ b/.github/workflows/helm-community.yml
@@ -172,6 +172,7 @@ jobs:
           helm ls --all-namespaces
           kubectl get all --all-namespaces
           kubectl describe pod
+          kubectl logs -n traefik -l app.kubernetes.io/name=traefik --tail=-1
 
           OOM_PODS=$(kubectl get pods -o jsonpath='{.items[?(@.status.containerStatuses[*].lastState.terminated.reason=="OOMKilled")].metadata.name}')
           if [ -n "$OOM_PODS" ]; then
@@ -195,3 +196,11 @@ jobs:
           namespace: default
           log_retention: 7
           log_name_identifier: "logs-pods-helm-com-${{ matrix.name }}"
+
+      - name: Upload traefik logs
+        if: always() && steps.helm_install.outcome != 'skipped'
+        uses: Alfresco/alfresco-build-tools/.github/actions/kubectl-keep-nslogs@v18.15.1
+        with:
+          namespace: traefik
+          log_retention: 7
+          log_name_identifier: "logs-traefik-helm-com-${{ matrix.name }}"

--- a/.github/workflows/helm-community.yml
+++ b/.github/workflows/helm-community.yml
@@ -84,7 +84,7 @@ jobs:
 
       - name: Setup cluster
         id: setup-kind
-        uses: Alfresco/alfresco-build-tools/.github/actions/setup-kind@bump-setup-kind-traefik-41
+        uses: Alfresco/alfresco-build-tools/.github/actions/setup-kind@v18.16.0
         with:
           traefik-enabled: true
           cloud-provider-kind-enabled: true

--- a/.github/workflows/helm-enterprise.yml
+++ b/.github/workflows/helm-enterprise.yml
@@ -227,11 +227,3 @@ jobs:
           namespace: default
           log_retention: 7
           log_name_identifier: "logs-pods-helm-ent-${{ matrix.name }}-${{ matrix.values }}"
-
-      - name: Upload traefik logs
-        if: always() && steps.helm_install.outcome != 'skipped'
-        uses: Alfresco/alfresco-build-tools/.github/actions/kubectl-keep-nslogs@v18.15.1
-        with:
-          namespace: traefik
-          log_retention: 7
-          log_name_identifier: "logs-traefik-helm-ent-${{ matrix.name }}-${{ matrix.values }}"

--- a/.github/workflows/helm-enterprise.yml
+++ b/.github/workflows/helm-enterprise.yml
@@ -192,6 +192,7 @@ jobs:
           kubectl get all --all-namespaces
           kubectl describe pod
           kubectl events --for deployment/acs-alfresco-repository
+          kubectl logs -n traefik -l app.kubernetes.io/name=traefik --tail=-1
 
       - name: Run helm test
         id: helm_test
@@ -226,3 +227,11 @@ jobs:
           namespace: default
           log_retention: 7
           log_name_identifier: "logs-pods-helm-ent-${{ matrix.name }}-${{ matrix.values }}"
+
+      - name: Upload traefik logs
+        if: always() && steps.helm_install.outcome != 'skipped'
+        uses: Alfresco/alfresco-build-tools/.github/actions/kubectl-keep-nslogs@v18.15.1
+        with:
+          namespace: traefik
+          log_retention: 7
+          log_name_identifier: "logs-traefik-helm-ent-${{ matrix.name }}-${{ matrix.values }}"

--- a/.github/workflows/helm-enterprise.yml
+++ b/.github/workflows/helm-enterprise.yml
@@ -94,7 +94,7 @@ jobs:
 
       - name: Setup cluster
         id: setup-kind
-        uses: Alfresco/alfresco-build-tools/.github/actions/setup-kind@bump-setup-kind-traefik-41
+        uses: Alfresco/alfresco-build-tools/.github/actions/setup-kind@v18.16.0
         with:
           traefik-enabled: true
           cloud-provider-kind-enabled: true

--- a/.github/workflows/helm-enterprise.yml
+++ b/.github/workflows/helm-enterprise.yml
@@ -94,10 +94,9 @@ jobs:
 
       - name: Setup cluster
         id: setup-kind
-        uses: Alfresco/alfresco-build-tools/.github/actions/setup-kind@v18.15.1
+        uses: Alfresco/alfresco-build-tools/.github/actions/setup-kind@bump-setup-kind-traefik-41
         with:
           traefik-enabled: true
-          traefik-chart-version: v40.0.0-ea.1
           cloud-provider-kind-enabled: true
           metrics: true
           import-docker-credentials-secret-name: ${{ env.REGISTRY_SECRET_NAME }}

--- a/docs/helm/traefik.md
+++ b/docs/helm/traefik.md
@@ -30,12 +30,12 @@ namespace:
 helm repo add traefik https://traefik.github.io/charts
 helm repo update
 helm upgrade --install traefik traefik/traefik \
-  --set providers.kubernetesIngressNginx.enabled=true \
+  --set providers.kubernetesIngressNGINX.enabled=true \
   --set logs.access.enabled=true \
   --namespace traefik --create-namespace
 ```
 
-The `providers.kubernetesIngressNginx.enabled=true` option is required to tell
+The `providers.kubernetesIngressNGINX.enabled=true` option is required to tell
 Traefik to watch for `Ingress` resources with `ingressClassName` set to `nginx`,
 which is still the default in our charts for backwards compatibility reasons.
 

--- a/test/postman/helm/acs-test-helm-collection.json
+++ b/test/postman/helm/acs-test-helm-collection.json
@@ -1241,7 +1241,7 @@
 									"pm.globals.get(\"url\");",
 									"",
 									"pm.test(\"prometheusAlfrescoStatusCodeTest\", function () {",
-									"    pm.response.to.have.status(404);",
+									"    pm.expect(pm.response.code).to.be.oneOf([404, 503]);",
 									"});"
 								]
 							}


### PR DESCRIPTION
Adopt the GA Traefik v40+ helm chart in acs-deployment:

- Point the `setup-kind` steps in the community and enterprise helm workflows at alfresco-build-tools `v18.16.0`, which ships the GA traefik chart default (`41.0.2`), so CI exercises the GA chart end-to-end.
- Drop the pinned pre-release `traefik-chart-version: v40.0.0-ea.1` from the enterprise workflow so it uses the GA default (community already relied on the default).
- Update `docs/helm/traefik.md` to the GA `providers.kubernetesIngressNGINX` casing.
- Capture Traefik pod logs (`kubectl logs -n traefik`) in the post-test debug steps, since the existing debug/upload steps only covered the `default` namespace and Traefik runs in its own namespace, making ingress-side failures impossible to diagnose.
- Relax the `prometheusAlfrescoStatusCodeTest` newman assertion to accept 404 or 503. The repository ingress blocks `/alfresco/s/prometheus` by routing it to a non-existent backend service; ingress-nginx renders that as 404 while Traefik returns 503. The endpoint is blocked either way, so the test should accept both codes.

OPSEXP-3962