### PR TITLE
Simplify pull_request_review CI trigger trick

### DIFF
--- a/.github/workflows/docker-compose-community.yml
+++ b/.github/workflows/docker-compose-community.yml
@@ -2,8 +2,6 @@
 name: Docker Compose (Community)
 
 on:
-  pull_request_review:
-    types: [submitted]
   pull_request:
     branches:
       - master
@@ -23,13 +21,6 @@ jobs:
   compose_community:
     name: Docker Compose community
     runs-on: ubuntu-latest
-    if: >-
-      github.event_name != 'pull_request_review'
-      || (
-        github.event_name == 'pull_request_review'
-        && github.event.review.state == 'approved'
-        && github.event.pull_request.user.login == 'github-actions[bot]'
-      )
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       - uses: >-

--- a/.github/workflows/docker-compose-enterprise.yml
+++ b/.github/workflows/docker-compose-enterprise.yml
@@ -32,7 +32,7 @@ jobs:
       || (
         github.event_name == 'pull_request_review'
         && github.event.review.state == 'approved'
-        && github.event.pull_request.user.login == 'github-actions[bot]'
+        && github.event.pull_request.user.login == 'dependabot[bot]'
       )
     outputs:
       matrix_json: ${{ steps.eval.outputs.matrix_json }}

--- a/.github/workflows/docker-compose-enterprise.yml
+++ b/.github/workflows/docker-compose-enterprise.yml
@@ -27,13 +27,8 @@ jobs:
   build_vars:
     runs-on: ubuntu-latest
     if: >-
-      github.event_name == 'push'
-      || (github.event_name == 'pull_request' && github.actor != 'dependabot[bot]')
-      || (
-        github.event_name == 'pull_request_review'
-        && github.event.review.state == 'approved'
-        && github.event.pull_request.user.login == 'dependabot[bot]'
-      )
+      (github.event.review.state == 'approved' && github.event.pull_request.user.login == 'dependabot[bot]') ||
+      (github.actor != 'dependabot[bot]' && github.event_name != 'pull_request_review')
     outputs:
       matrix_json: ${{ steps.eval.outputs.matrix_json }}
     steps:

--- a/.github/workflows/helm-community.yml
+++ b/.github/workflows/helm-community.yml
@@ -2,8 +2,6 @@
 name: Helm (Community)
 
 on:
-  pull_request_review:
-    types: [submitted]
   pull_request:
     branches:
       - master
@@ -33,13 +31,6 @@ jobs:
     runs-on: ubuntu-slim
     outputs:
       ver_json: ${{ steps.app_versions.outputs.json }}
-    if: >-
-      github.event_name != 'pull_request_review'
-      || (
-        github.event_name == 'pull_request_review'
-        && github.event.review.state == 'approved'
-        && github.event.pull_request.user.login == 'dependabot[bot]'
-      )
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
@@ -72,7 +63,7 @@ jobs:
     needs:
       - build_vars
     env:
-      REGISTRY_SECRET_NAME: ${{ github.event.pull_request.head.repo.fork && '' || 'regcred' }}
+      REGISTRY_SECRET_NAME: ${{ (github.event.pull_request.head.repo.fork || github.actor == 'dependabot[bot]') && '' || 'regcred' }}
       POD_METRICS_LOG: /tmp/pod-metrics.log
       NODE_METRICS_LOG: /tmp/node-metrics.log
       HELM_INSTALL_TIMEOUT: 10m0s
@@ -90,7 +81,7 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@06fb636fac595d6fb4b28a5dfcb21a6f5091859c  # v4.5.0
         if: >-
-          ! github.event.pull_request.head.repo.fork
+          ! github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]'
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/helm-community.yml
+++ b/.github/workflows/helm-community.yml
@@ -38,7 +38,7 @@ jobs:
       || (
         github.event_name == 'pull_request_review'
         && github.event.review.state == 'approved'
-        && github.event.pull_request.user.login == 'github-actions[bot]'
+        && github.event.pull_request.user.login == 'dependabot[bot]'
       )
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1

--- a/.github/workflows/helm-enterprise.yml
+++ b/.github/workflows/helm-enterprise.yml
@@ -30,7 +30,7 @@ jobs:
       || (
         github.event_name == 'pull_request_review'
         && github.event.review.state == 'approved'
-        && github.event.pull_request.user.login == 'github-actions[bot]'
+        && github.event.pull_request.user.login == 'dependabot[bot]'
       )
     outputs:
       ver_json: ${{ steps.app_versions.outputs.json }}

--- a/.github/workflows/helm-enterprise.yml
+++ b/.github/workflows/helm-enterprise.yml
@@ -25,13 +25,8 @@ jobs:
   build_vars:
     runs-on: ubuntu-slim
     if: >-
-      github.event_name == 'push'
-      || (github.event_name == 'pull_request' && github.actor != 'dependabot[bot]')
-      || (
-        github.event_name == 'pull_request_review'
-        && github.event.review.state == 'approved'
-        && github.event.pull_request.user.login == 'dependabot[bot]'
-      )
+      (github.event.review.state == 'approved' && github.event.pull_request.user.login == 'dependabot[bot]') ||
+      (github.actor != 'dependabot[bot]' && github.event_name != 'pull_request_review')
     outputs:
       ver_json: ${{ steps.app_versions.outputs.json }}
     steps:

--- a/.github/workflows/helm-static-checks.yml
+++ b/.github/workflows/helm-static-checks.yml
@@ -1,8 +1,6 @@
 ---
 name: Helm static checks
 on:
-  pull_request_review:
-    types: [submitted]
   pull_request:
     branches:
       - master
@@ -19,13 +17,6 @@ on:
 jobs:
   build_vars:
     runs-on: ubuntu-latest
-    if: >-
-      github.event_name != 'pull_request_review'
-      || (
-        github.event_name == 'pull_request_review'
-        && github.event.review.state == 'approved'
-        && github.event.pull_request.user.login == 'github-actions[bot]'
-      )
     outputs:
       app_charts: ${{ steps.getcharts.outputs.app }}
       lib_charts: ${{ steps.getcharts.outputs.lib }}

--- a/.github/workflows/kics.yml
+++ b/.github/workflows/kics.yml
@@ -1,8 +1,6 @@
 name: kics
 
 on:
-  pull_request_review:
-    types: [submitted]
   pull_request:
     branches: [master]
     paths:
@@ -22,13 +20,6 @@ permissions:
 jobs:
   kics:
     runs-on: ubuntu-latest
-    if: >-
-      github.event_name != 'pull_request_review'
-      || (
-        github.event_name == 'pull_request_review'
-        && github.event.review.state == 'approved'
-        && github.event.pull_request.user.login == 'dependabot[bot]'
-      )
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: run kics Scan

--- a/.github/workflows/kics.yml
+++ b/.github/workflows/kics.yml
@@ -27,7 +27,7 @@ jobs:
       || (
         github.event_name == 'pull_request_review'
         && github.event.review.state == 'approved'
-        && github.event.pull_request.user.login == 'github-actions[bot]'
+        && github.event.pull_request.user.login == 'dependabot[bot]'
       )
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/pre-commit-compose.yml
+++ b/.github/workflows/pre-commit-compose.yml
@@ -2,8 +2,6 @@
 name: Pre-commit (Docker Compose)
 
 on:
-  pull_request_review:
-    types: [submitted]
   pull_request:
     branches:
       - master
@@ -25,12 +23,5 @@ jobs:
   pre_commit:
     name: Run pre-commit
     runs-on: ubuntu-latest
-    if: >-
-      github.event_name != 'pull_request_review'
-      || (
-        github.event_name == 'pull_request_review'
-        && github.event.review.state == 'approved'
-        && github.event.pull_request.user.login == 'github-actions[bot]'
-      )
     steps:
       - uses: Alfresco/alfresco-build-tools/.github/actions/pre-commit@v18.21.0

--- a/.github/workflows/pre-commit-helm.yml
+++ b/.github/workflows/pre-commit-helm.yml
@@ -2,8 +2,6 @@
 name: Pre-commit (Helm)
 
 on:
-  pull_request_review:
-    types: [submitted]
   pull_request:
     branches:
       - master
@@ -28,13 +26,6 @@ jobs:
   pre_commit:
     name: Run pre-commit
     runs-on: ubuntu-latest
-    if: >-
-      github.event_name != 'pull_request_review'
-      || (
-        github.event_name == 'pull_request_review'
-        && github.event.review.state == 'approved'
-        && github.event.pull_request.user.login == 'github-actions[bot]'
-      )
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # 7.0.1
       - uses: Alfresco/alfresco-build-tools/.github/actions/setup-helm-docs@v18.21.0


### PR DESCRIPTION
## Summary

GitHub now queues `pull_request` events created via `GITHUB_TOKEN` for manual approval instead of not firing them at all, so the `pull_request_review` fallback trigger added in #1521 is no longer needed for `github-actions[bot]`-authored PRs. Dependabot PRs are a separate case: GitHub still denies secrets/elevated permissions to their `pull_request` runs, so workflows that actually need secrets keep the `pull_request_review` fallback, retargeted at `dependabot[bot]`.

- Dropped the trick entirely from `pre-commit-helm.yml`, `helm-static-checks.yml`, `pre-commit-compose.yml`, `docker-compose-community.yml`, `kics.yml` (KICS scan needs no secrets; the SARIF upload was already gated per-step) and `helm-community.yml` (Docker Hub login there is just to dodge rate limits, so it's now skipped for dependabot instead of gating the whole job)
- Kept and simplified it in `helm-enterprise.yml` and `docker-compose-enterprise.yml`, the two workflows whose integration test jobs need Docker Hub/Quay secrets

## Test plan

- [ ] Human-authored PRs still trigger all workflows normally
- [ ] A `github-actions[bot]`-authored PR (bump workflows) triggers checks via GitHub's native approval queue
- [ ] A dependabot PR touching `helm/**`/`docker-compose/**` is skipped on the initial run and runs (with secrets) after a maintainer approves the review, on the two enterprise workflows only