### PR TITLE
OPSEXP-4340 upgrade guidance for 10.8.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Start the release by opening a PR against the appropriate branch that will:
   to the version you want to release.
 * Run `pre-commit run --all-files helm-docs` to update helm docs
 * Edit [upgrades docs](docs/helm/upgrades.md) renaming the `Unreleased` section
-  to the current version and create a new `Unreleased` section for the future.
+  to the current version and creating a new `Unreleased` section for the future.
 * Run [Bump versions][1] workflow against the same newly created branch, the
   first time with `charts` option. Inspect the changes pushed on the branch,
   revert unwanted changes if necessary - all charts dependencies should not be

--- a/README.md
+++ b/README.md
@@ -61,9 +61,8 @@ Start the release by opening a PR against the appropriate branch that will:
   [acs-sso-example](helm/acs-sso-example/Chart.yaml) charts:bump chart version
   to the version you want to release.
 * Run `pre-commit run --all-files helm-docs` to update helm docs
-* Edit [upgrades docs](docs/helm/upgrades.md) renaming the `To be released`
-  section to the current version and create a new `To be released` section for
-  the future.
+* Edit [upgrades docs](docs/helm/upgrades.md) renaming the `Unreleased` section
+  to the current version and create a new `Unreleased` section for the future.
 * Run [Bump versions][1] workflow against the same newly created branch, the
   first time with `charts` option. Inspect the changes pushed on the branch,
   revert unwanted changes if necessary - all charts dependencies should not be

--- a/docs/helm/upgrades.md
+++ b/docs/helm/upgrades.md
@@ -22,7 +22,7 @@ version in which they have been released.
 
 * The `alfresco-connector-cic` subchart has been added to the
   `alfresco-content-services` umbrella chart (disabled by default). It replaces
-  the deprecated `alfresco-knowledge-retrieval` (HXI) connector and brings up
+  the deprecated `alfresco-knowledge-retrieval` (HXI) connector. It brings up
   three services — `live-ingester`, `bulk-ingester` and `nucleus-sync` — when
   `alfresco-connector-cic.enabled: true`. See
   `docs/helm/values/with-cic_values.yaml` for a

--- a/docs/helm/upgrades.md
+++ b/docs/helm/upgrades.md
@@ -18,6 +18,8 @@ version in which they have been released.
 
 ## Unreleased
 
+## 10.8.0
+
 * The `alfresco-connector-cic` subchart has been added to the
   `alfresco-content-services` umbrella chart (disabled by default). It replaces
   the deprecated `alfresco-knowledge-retrieval` (HXI) connector and brings up
@@ -46,11 +48,6 @@ version in which they have been released.
   unaffected. Enterprise deployments using legacy Search Services (`solr6`)
   must now set this key explicitly, in addition to providing
   `global.search.sharedSecret`.
-* The `alfresco-knowledge-retrieval` (HXI) dependency, its values and related
-  docs have been removed from the `alfresco-content-services` chart. If you were
-  using Knowledge Retrieval / HXI features, deploy that chart independently. The
-  replacement is the new `alfresco-connector-cic` subchart, available from chart
-  version 10.8.0.
 
 ## 10.3.1
 

--- a/docs/helm/upgrades.md
+++ b/docs/helm/upgrades.md
@@ -48,6 +48,11 @@ version in which they have been released.
   unaffected. Enterprise deployments using legacy Search Services (`solr6`)
   must now set this key explicitly, in addition to providing
   `global.search.sharedSecret`.
+* The `alfresco-knowledge-retrieval` (HXI) dependency, its values and related
+  docs have been removed from the `alfresco-content-services` chart. If you were
+  using Knowledge Retrieval / HXI features, deploy that chart independently. The
+  replacement is the new `alfresco-connector-cic` subchart, available from chart
+  version 10.8.0.
 
 ## 10.3.1
 


### PR DESCRIPTION
OPSEXP-4340 
## Summary

- Document the Helm chart changes introduced in 10.8.0.